### PR TITLE
I18n de

### DIFF
--- a/vendor/refinerycms/authentication/config/locales/de.yml
+++ b/vendor/refinerycms/authentication/config/locales/de.yml
@@ -1,77 +1,74 @@
 de:
+  plugins:
+    refinery_users:
+      title: Benutzer
+      description: Verwaltet Benutzer
   admin:
     users:
+      delete: Diesen Benutzer für immer löschen
+      edit: Diesen Benutzer bearbeiten
       update:
-        cannot_remove_user_plugin_from_current_user: "Sie können das 'Users' Plugin nicht vom Konto des aktuell eingeloggten Benutzers löschen."
+        cannot_remove_user_plugin_from_current_user: Sie können die Erweiterung 'Benutzer' nicht vom aktuellen Konto entfernen.
       form:
-        blank_password_keeps_current: "Das aktuelle Passwort wird beibehalten, wenn das Feld leer gelassen wird"
+        blank_password_keeps_current: Wird das Passwort leer gelassen, wird das aktuelle Passwort beibehalten
+        enable_all: Alles aktivieren
       index:
-        create_new_user: Neuen Benutzer erstellen
-        no_users_yet:  Es wurden noch keine Benutzer erstellt. Klicken Sie auf "Neuen Benutzer erstellen" um Ihren ersten Benutzer zu erstellen.
+        create_new_user: Neuen Benutzer anlegen
+        no_users_yet:  Es sind noch keine Benutzer vorhanden. Klicken Sie auf  "Neuen Benutzer anlegen", um Ihren ersten Benutzer hinzuzufügen.
       user:
-        confirm_delete_message: "Sind Sie sicher, dass Sie '%{who}' löschen möchten?"
-        confirm_delete_title: Diesen Benutzer für immer löschen.
-        edit_user: Diesen Benutzer bearbeiten
-        email_user: Diesem Benutzer eine E-Mail schicken
-        preview: "(%{who}) wurde erstellt am %{created_at}"
+        email_user: Diesem Benutzer emailen
+        preview: (%{who}) angelegt am %{created_at}
   sessions:
-    login_successful: Erfolgreich eingeloggt
-    login_failed: "Entschuldigung, Ihr Benutzername oder Passwort war nicht korrekt."
-    logged_out: Sie wurden ausgeloggt.
+    login_successful: Erfolgreich angemeldet
+    login_failed: Tut mir leid, Ihr Passwort oder Benutzername war nicht korrekt.
     new:
-      login: Login Name
-      log_in: Login
-      cancel: Abbrechen
-      password: Passwort
-      remember_me: Anmeldung merken
-      or: oder
-      forgot_password: Ich habe mein Passwort vergessen
-      hello_please_sign_in: Hallo! Bitte melden Sie sich
+      hello_please_sign_in: Hallo! Bitte melden Sie sich an.
       sign_in: Anmelden
+      forgot_password: Ich habe mein Passwort vergessen
   users:
-    forgot:
-      blank_email: Sie haben nicht eine E-Mail-Adresse.
-      email_not_associated_with_account: "Leider, '%{email}' ist nicht im Zusammenhang mit allen anderen Konten. <br/> Sind Sie sicher, die richtige E-Mail-Adresse eingegeben?"
-      email_reset_sent: "Eine E-Mail wurde Ihnen mit einem Link geschickt, um Ihr Passwort zurücksetzen."
-    reset:
-      code_invalid: "Es tut uns leid, aber diese Reset-Code ist abgelaufen oder ungültig. Wenn Sie Probleme versuchen Kopieren und Einfügen der URL aus Ihrem E-Mail in Ihrem Browser oder ein Neustart des Passwort-Reset-Prozess."
-      successful: "Passwort zurücksetzen erfolgreich %{email}"
-    setup_website_name: "Lassen Sie uns der Website als Erstes einen Namen geben. <a href='%{link}' name='%{title}'>Hier</a> können Sie den Namen Ihrer Website bearbeiten."
-    signup_disabled: Benutzerregistrierung ist deaktiviert
+    setup_website_name: Als ersten können wir der Seite einen Namen geben. <a href='%{link}' name='%{title}'>Hier klicken</a>, um den Namen der Webseite zu bearbeiten
     new:
-      fill_form: "Füllen Sie das Formular unten mit Ihren Angaben aus, damit wir loslegen können."
-      sign_up: Registrieren
+      fill_form: Füllen Sie die Details unten aus, damit wir anfangen können.
+      sign_up: Anmelden
     create:
-      welcome: "Willkommen bei Refinery, %{who}"
-      signup_complete: Registrierung abgeschlossen!
+      welcome: Willkommen bei Refinery, %{who}
+    forgot:
+      email_address: E-Mail-Adresse
+      enter_email_address: Bitte geben Sie die E-Mail-Adresse für Ihre Konto an.
+      reset_password: Passwort zurücksetzen
+      blank_email: Sie haben keine E-Mail-Adresse angegeben.
+      email_not_associated_with_account: Tut mir leid, '%{email}' ist mit keinem Konto verbunden.<br />Sind Sie sicher, dass Sie die richtige E-Mail-Adresse eingegeben haben?
+      email_reset_sent: Es wurde Ihnen eine E-Mail mit einem Link geschickt, durch den Sie ihr Passwort zurücksetzen können.
+    reset:
+      code_invalid: Tut mir leid, aber dieser Zurücksetzungscode ist abgelaufen oder ungültig. Wenn Sie Probleme haben, versuchen Sie den Link aus der E-Mail zu kopieren und in Ihren Browser einzufügen, oder wiederholen Sie den Vorgang mit dem Passwort zurücksetzen.
+      successful: Passwort für '%{email}' erfolgreich zurückgesetzt
+      pick_new_password_for: Wählen Sie ein neues Passwort für %{email}
+      reset_password: Passwort zurücksetzen
+      password_blank: Füllen Sie die Felder mit übereinstimmenden Passwörtern aus.
   user_mailer:
-    please_activate: Bitte aktivieren Sie Ihr neues Benutzerkonto
-    activated: Ihr Benutzerkonto wurde aktiviert!
-    activated_email: "%{who}, Ihr Benutzerkonto wurde aktiviert. Sie können jetzt Ihre Plugins wählen:"
-    account_created: Ihr Benutzerkonto wurde erstellt.
-    user_name: "Benutzername %{name}"
-    password: "Passwort %{password}"
-    visit_url: "Besuchen Sie folgende URL um Ihr Benutzerkonto zu aktivieren:"
-    link_to_reset_your_password: Link um Ihr Passwort zurückzusetzen
+    link_to_reset_your_password: Link zum Zurücksetzen Ihres Passworts
   authlogic:
     error_messages:
-      login_blank: darf nicht leer sein
-      login_not_found: ist nicht gültig
-      login_invalid: "darf nur Buchstaben, Zahlen, Leerzeichen und .-_@ enthalten."
-      consecutive_failed_logins_limit_exceeded: "Zu viele fehlerhafte Logins, das Benutzerkonto wurde deaktiviert."
-      email_invalid: sollte wie eine E-Mail-Adresse aussehen.
-      password_blank: darf nicht leer sein
-      password_invalid: ist nicht gültig
-      not_active: Ihr Benutzerkonto ist nicht aktiv
-      not_confirmed: Ihr Benutzerkonto ist nicht bestätigt
-      not_approved: Ihr Benutzerkonto ist nicht freigeschaltet
-      no_authentication_details: Sie haben keine Angaben zur Authentifizierung gemacht.
+      login_blank: Kann nicht leer gelassen werden
+      login_invalid: Sollte bitte nur Buchstaben, Zahlen, Leerzeichen und .-_@ enthalten.
+      email_invalid: Sollte nach einer gültigen E-Mail-Adresse aussehen.
+      no_authentication_details: Sie haben keine Details zur Authentifizierung angeben.
     models:
-      user_session: UserSession
+      user_session: Benutzersitzung
     attributes:
       user_session:
         login: Login
-        email: E-Mail-Adresse
+        email: E-Mail
         password: Passwort
-        remember_me: Anmeldung merken
-        incorrect: "Entschuldigung, %{login_field} oder Passwort waren nicht korrekt."
+        remember_me: Login merken
+        incorrect: Tut mir leid, Ihr %{login_field} oder Passwort war nicht korrekt.
+  activerecord:
+    attributes:
+      user:
+        login: Login
+        email: E-Mail
+        password: Passwort
+        password_confirmation: Passwort Bestätigung
+        plugin_access: Zugriff auf Erweiterungen
+    models:
+      user: user

--- a/vendor/refinerycms/core/config/locales/de.yml
+++ b/vendor/refinerycms/core/config/locales/de.yml
@@ -1,68 +1,67 @@
 de:
+  plugins:
+    refinery_core:
+      title: Refinery
+      description: Core Refinery Erweiterung
+    refinery_dialogs:
+      title: Dialoge
+      description: Refinery Dialog Erweiterung
   welcome:
-    there_are_no_users: "Es gibt noch keine Benutzer, also richten wir erstmal einen ein."
-    remember_admin_location: "Den Refinery Admin Bereich finden Sie unter:"
-    lets_start: "Alles klar, lassen Sie uns Ihre Daten erfassen, damit Sie sich einloggen können..."
-    continue: "Weiter..."
+    there_are_no_users: Es sind noch keine Benutzer vorhanden, darum lassen wir uns Ihren zuerst anlegen.
+    remember_admin_location: "Merken Sie sich Ihren Refinery Administrationsbereich:"
+    lets_start: Alles klar, lassen wir uns Ihren Benutzer anlegen, damit Sie sich anmelden können...
+    continue: Weiter...
   admin:
     menu:
-      reorder_menu: Menü neu anordnen
-      reorder_menu_done: "Menü Anordnung speichern"
-    search: Suche
-    search_submit: Los
-    search_results_for: "Suchergebnisse für '%{query}'"
-    search_no_results: "Leider gibt es keine Ergebnisse."
+      reorder_menu: Menü umsortieren
+      reorder_menu_done: Ich bin mit dem Umsortieren fertig
+    dialogs:
+      show:
+        save: Speichern
+        cancel: Abbrechen
   refinery:
-    other: "Weitere %{what}"
-    reorder: "Umordnen %{what}"
-    reorder_done: "Geschehen umordnen %{what}"
     crudify:
-      created: "%{what} wurde erfolgreich erstellt."
-      updated: "%{what} wurde erfolgreich aktualisiert."
-      destroyed: "%{what} wurde erfolgreich gelöscht."
-  layouts:
-    admin:
-      view_public_site: Profil öffentlichen Website
-      welcome_to_refinery: Willkommen bei Refinery
+      created: %{what} wurde erfolgreich angelegt.
+      updated: %{what} wurde erfolgreich aktualisiert.
+      destroyed: %{what} wurde erfolgreich gelöscht.
   shared:
     site_bar:
-      log_out: Ausloggen
+      log_out: Abmelden
+      switch_to_your_website: Zu Ihrer Webseite wechseln
+      switch_to_your_website_editor: Zum Editor Ihrer Webseite wechseln
     admin:
-      message:
-        close: Schließen
       continue_editing:
-        save_and_continue_editing: "Speichern & Bearbeitung fortsetzen"
+        save_and_continue_editing: Speichern & Bearbeiten fortsetzen
       form_actions:
-        or: oder
         save: Speichern
-        or_cancel: oder
         cancel: Abbrechen
-        or_continue: oder
-        cancel_lose_changes: "Abbrechen verlieren alle Änderungen, die Sie auf diese %{object_name} gemacht haben"
-        delete: 'Löschen'
+        cancel_lose_changes: Durch Abbrechen gehen all ihre gemachten Änderungen verloren
+        delete: Löschen
+        previous: Vorherige
+        next: Nächste
+        close: Schließen
       image_picker:
-        none_selected: "Es ist derzeit kein %{what} ausgewählt ist, klicken Sie bitte hier eine Annonce aufgeben"
-        remove_current: "Entfernen aktuel %{what}"
-        change: "Klicken Sie hier, um ein Bild auszuwählen"
-        image: bild
+        none_selected: Es ist momentan kein %{what} ausgewählt, bitte klicken Sie hier, um eins hinzuzufügen.
+        remove_current: Entferne aktuelles %{what}
+        change: Klicken Sie hier, um ein Bild auszuwählen
+        show: anzeigen
       resource_picker:
-        none_selected: "Derzeit gibt es keine %{what} ausgewählt, klicken Sie bitte hier eine Annonce aufgeben"
-        current: "Aktuelle %{what}"
-        download_current: "Download der aktuellen %{what}"
-        opens_in_new_window: Öffnet in einem neuen Browserfenster
-        remove_current: "Entfernen Sie aktuelle %{what}"
-        resource: Datei
+        download_current: Aktuelles %{what} herunterladen
+        opens_in_new_window: Öffnet in einem neuen Fenster
+        remove_current: "Entferne aktuelles %{what}"
+      search:
+        button_text: Suchen
+        results_for: Suchergebnisse für '%{query}'
+        no_results: Tut mir leid, Suche brachte keine Ergebnisse
+      delete:
+        message: Sind Sie sicher, dass Sie '%{title}' löschen möchten?
+      error_messages:
+        problems_in_following_fields: Es gab Probleme mit den folgenden Feldern
+      help: Hilfe
     message:
       close: Schließen
-    site_bar:
-      switch_to_your_website: Wechseln Sie zu Ihrer Website
-      switch_to_your_website_editor: Wechseln Sie zu Ihrem Website-Editor
-  activerecord:
-    models:
-      page: seite
-      user: benutzer
-      image: bild
-      inquiry: anfrage
-      resource: datei
-      refinery_setting: refinery einstellung
-      inquiry_setting: anfrage einstellung
+      close_this_message: Diese Meldung schließen
+    draft_page_message:
+      not_live: Diese Seite ist NICHT öffentlich sichtbar.
+    footer:
+      copyright: Copyright &copy;

--- a/vendor/refinerycms/dashboard/config/locales/de.yml
+++ b/vendor/refinerycms/dashboard/config/locales/de.yml
@@ -2,6 +2,7 @@ de:
   plugins:
     refinery_dashboard:
       title: Armaturenbrett
+      description: Gibt eine Übersicht über Aktivitäten in Refinery
   admin:
     dashboard:
       index:
@@ -9,16 +10,15 @@ de:
         add_a_new_page: Neue Seite erstellen
         update_a_page: Eine Seite aktualisieren
         upload_a_image: Ein Bild hochladen
+        upload_a_file: Eine Datei hochladen
         change_language: Sprache wechseln
         see_home_page: Homepage ansehen
       recent_activity:
         latest_activity: Letzte Aktivität
-        see: "'%{what}' ansehen"
+        latest_activity_message: %{what} %{kind} wurde %{action}
       recent_inquiries:
-        latest_inquiries: Latest inquiries
+        latest_inquiries: Letzte Anfragen
   updated:
-    'with_article "the"':  aktualisiert
+    'with_article "the"': aktualisiert
   created:
-    'with_article "the"':  erstellt
-  ago: "vor %{time}"
-  see: Ansehen
+    'with_article "the"': erstellt

--- a/vendor/refinerycms/images/config/locales/de.yml
+++ b/vendor/refinerycms/images/config/locales/de.yml
@@ -2,41 +2,37 @@ de:
   plugins:
     refinery_images:
       title: Bilder
-  no_file_chosen: Sie müssen ein Bild zum Hochladen wählen.
-  image_should_be_smaller_than_max_image_size: Dateien sollten kleiner als %{max_image_size} sein
-  image_must_be_these_formats: Ihr Bild muss im Format JPG, PNG oder GIF vorliegen
+      description: Verwaltet Bilder
+  image_specify_for_upload: Sie müssen ein Bild zum Hochladen angeben
+  image_should_be_smaller_than_max_image_size: Bild sollte kleiner als %{max_image_size} sein
+  image_must_be_these_formats: 'Ihr Bild sollte ein JPG, PNG oder GIF sein'
   admin:
     images:
-      image:
-        delete:
-          message: Sind Sie sicher, dass Sie '%{title}' löschen möchten?
-          title: Dieses Bild für immer löschen
+      delete: Dieses Bild für immer löschen
+      edit: Dieses Bild bearbeiten
       form:
         image: Bild
         use_current_image: Aktuelles Bild verwenden
         or: oder
-        replace_image: Oder durch dieses ersetzen ...
+        replace_image: " mit diesem ersetzen..."
         current_image: Aktuelles Bild
-        maximum_image_size: "Die maximale Bildgröße beträgt %{megabytes} Megabyte."
+        maximum_image_size: Die maximale Größe eines Bildes beträgt %{megabytes} Megabytes.
       index:
-        create_new_image: Neues Bild erstellen
-        no_images_yet: Es wurden noch keine Bilder erstellt. Klicken Sie auf "Neues Bild erstellen" um Ihr erstes Bild zu erstellen.
+        create_new_image: Neues Bild anlegen
+        no_images_yet: Es sind noch keine Bilder vorhanden. Klicken Sie auf "Neues Bild anlegen", um Ihr estes Bild hinzuzufügen.
         view:
-          switch_to: Zur Ansicht "%{view_name}" wechseln
-          list: Liste
+          switch_to: Zur %{view_name}-Ansicht wechseln
+          list: Listen
           grid: Gitter
-        search:
-          results_for: Suchergebnisse für %{query}
       grid_view:
-        edit: Dieses Bild bearbeiten
-        view_live: Dieses Bild anzeigen <br/><em>Öffnet ein neues Fenster</em>
-      list_view_image:
-        edit_this_image: Dieses Bild bearbeiten
+        view_live: Dieses Bild betrachten <br/><em>Öffnet sich in einem neuen Fenster</em>
+      existing_image:
+        button_text: Einfügen
+        resize_image: Bild in der Größe ändern?
+        size: Größe
       insert:
-        existing_image: Existierendes Bild
+        existing_image: Vorhandenes Bild
         new_image: Neues Bild
-        previous: vorheriges
-        next: nächstes
-        submit_insert: Einfügen
-        or: oder
-        cancel: Abbrechen
+  activerecord:
+    models:
+      image: Bild

--- a/vendor/refinerycms/pages/config/locales/de.yml
+++ b/vendor/refinerycms/pages/config/locales/de.yml
@@ -2,52 +2,82 @@ de:
   plugins:
     refinery_pages:
       title: Seiten
+      description: Verwaltet Inhaltsseiten
   admin:
+    pages_dialogs:
+      page_link:
+        link_to_this_page: Link zu dieser Seite
+      link_to:
+        insert: Einfügen
+        your_page:
+          tab_name: Ihre Seite
+        web_address:
+          tab_name: Webseite
+          location: Zieladresse
+          new_window: Neues Fenster
+          new_window_label: Link in einem neuen Fenster öffnen
+          not_sure: Nicht sicher, was in das Feld oben rein soll?
+          step1: Finden Sie die Seite im Web, die Sie verlinken möchten.
+          step2: Kopieren Sie die Adresse aus der Adressleiste ihres Browsers und fügen Sie diese in das Feld oben ein.
+        email_address:
+          tab_name: E-Mail-Adresse
+          subject_line_optional: Optionaler Betreff
+          body_optional: Optionaler Inhaltstext
+          not_sure: Nicht sicher, was in Felder oben rein soll?
+          step1: Schreiben oder kopieren Sie die E-Mail-Adresse (z.B. aus Ihrem Adressbuch) die verlinkt werden soll in das Feld "E-Mail-Adresse".
+          step2: Verwenden Sie das Feld '<strong>Optionaler Betreff</strong>', wenn der Betreff schon <strong>vorher mit einer Zeile verfasst</strong> werden soll.
+          step3: Verwenden Sie das Feld '<strong>Optionaler Inhaltstext</strong>', wenn die E-Mail bereits <strong>mit einem Text verfasst</strong> werden soll.
+        your_resource:
+          tab_name: Ihre Datei
+          link_to_this_resource: Link zu dieser Datei
     pages:
-      form_advanced_options:
+      delete: Diese Seite für immer löschen
+      edit: Diese Seite bearbeiten
+      page:
+        view_live: Diese Seite live betrachten <br/><em>(öffnet sich in einem neuen Fenster)</em>
+        hidden: Versteckt
+        draft: Entwurf
+      form_new_page_parts:
         title: Titel
-        create_content_section: Inhaltsbereich erstellen
-        delete_content_section: Inhaltsbereich löschen
+      form_page_parts:
+        create_content_section: Inhaltsabschnitt anlegen
+        delete_content_section: Inhaltsabschnitt löschen
+      form_advanced_options:
+        toggle_advanced_options: Klicken Sie hier, um die erweiterten Optionen anzuzeigen
+        page_options: Seitenoptionen
+        parent_page: Übergeordnete Seite
         advanced_options: Erweiterte Optionen
-        explain_page_different_title: "Geben Sie hier einen Seitentitel ein, wenn Sie nicht möchten, dass der Menü- und Browsertitel als Seitentitel verwendet wird."
-        redirect_to_first_child: "Checken Sie diese Box, wenn der Besucher zur ersten Unterseite dieser Seite weitergeleitet werden soll, wenn diese SEite aufgerufen wird."
-        parent_id_title: Übergeordnet
-        custom_title: Eigener Titel
-        title_type: "Typ:"
+        custom_title: Angepasster Titel
         title_types:
-          none: Keiner
+          none: Keinen
           text: Text
-          image: Bild
-        custom_url: Eigene URL
-        custom_url_explanation: "Geben Sie eine URL ein, wenn diese Seite zu einer externen Seite oder einer bereits existierenden Ressource (z.B. eine Kontaktseite) verlinken soll.<br />Hinweis: Diese URL muss zu einem bereits existierenden Ort verlinken, eine neue Seite wird nicht angelegt."
-        draft: Entwurf
         show_in_menu_title: Im Menü anzeigen
-        show_in_menu_description: "Checken Sie diese Box, wenn diese Seite im Seitenmenü angezeigt werden soll."
-        draft: Entwurf
+        show_in_menu_description: Zeigt diese Seite im Seitenmenü an
+        show_in_menu_help: Entfernen Sie diesen Haken, wenn die Seite nicht im Menü erscheinen soll. Dies kann praktisch sein, wenn Sie eine Seite direkt verlinken möchten aber nicht im Menü anzeigen lassen wollen.
         save_as_draft: Als Entwurf speichern
-        save: Speichern
-        cancel: Abbrechen
+        skip_to_first_child: Überspringen der obersten Ebene
+        skip_to_first_child_label: Auf erste untergeordnete Seite weiterleiten
+        skip_to_first_child_help: Diese Option verlinkt die Seite zu der ersten untergeordneten Seite. Dies kann nützlich sein, wenn Seiten gruppiert werden.
+        link_url: Diese Seite auf eine andere Seite weiterleiten
+        link_url_help: Wenn diese Seite zu einer anderen Seite weitergeleitet werden soll, geben Sie hier eine Adresse an, sonst lassen Sie dieses Feld leer.
+        parent_page_help: Sie können eine Seite einer anderen unterordnen, indem Sie diese aus der Liste wählen. Soll die Seite auf die oberste Ebene, lassen Sie dieses Feld leer.
+        custom_title_help: Wenn die Seite einen anderen Titel haben soll als der im Menü angezeigte, wählen Sie "Text" und geben Sie ihn hier ein.
       form_advanced_options_seo:
-        seo: Suchmaschinen-Optimierung
-        seo_override_title: Browser Titel
-        seo_override_title_help: Hier können Sie den Standard-Browser-Titel überschreiben.
-        meta_keywords_title: Meta keywords
-        meta_description_help: Geben Sie 5-10 Schlüsselbegriffe mit Bezug zu dieser Seite ein. Trennen Sie Schlüsselbegriffe mit Kommas.
-        meta_description_title: Meta description
-        meta_description_help: Geben Sie zwei bis drei kurze Sätze über den Inhalt dieser Seite ein.
-        js:
-          content_section:
-            create: Inhaltsbereich erstellen.
-            already_exists: Ein Inhaltsbereich mit diesem Titel existiert bereits. Bitte wählen Sie einen anderen Titel.
-            title_empty: Sie haben keinen Titel für den Inhaltsbereich eingegeben. Bitte geben Sie einen Titel ein.
-            confirm_delete: "Der Inhaltsbereich %{section_name} und alle darin enthaltenen Inhalte werden gelöscht, wenn diese Seite gespeichert wird. Sind Sie sicher?"
+        seo: Suchmaschinenoptimierung
+        seo_override_title: Browsertitel
+        seo_override_title_help: Geben Sie einen 5-10 Wörter langen Titel an, den der Inhalt der Seite beschreibt.
+        meta_keywords_title: Meta-Schlüsselwörter
+        meta_keywords_help: Geben Sie 5-10 Schlüsselwörter für diese Seite an. Trennen Sie Schlüsselwörter mit einem Komma.
+        meta_description_title: Meta-Beschreibung
+        meta_description_help: Beschreiben Sie in knappen zwei oder drei Sätzen, um was es sich bei dieser Seite handelt.
       index:
-        create_new_page: Neue Seite erstellen
-        reorder_pages: Seiten neu anordnen
-        reorder_pages_done: Seitenanordnung speichern
-        sorry_no_results: Entschuldigung! Es wurden keine Suchergebnisse gefunden.
-        no_pages_yet: Es wurden noch keine Seiten erstellt. Klicken Sie auf "Neue Seite erstellen" um Ihre erste Seite zu erstellen..
+        create_new_page: Neue Seite anlegen
+        reorder_pages: Seiten umsortieren
+        reorder_pages_done: Umsortieren erledigt
+        no_pages_yet: Es sind noch keine Seiten vorhanden. Klicken Sie auf "Neue Seite anlegen", um Ihre erste Seite zu erzeugen.
   activerecord:
+    models:
+      page: Seite
     attributes:
       page:
-        skip_to_first_child: "Direkt zum ersten Kindes?"
+        title: Titel

--- a/vendor/refinerycms/resources/config/locales/de.yml
+++ b/vendor/refinerycms/resources/config/locales/de.yml
@@ -2,31 +2,30 @@ de:
   plugins:
     refinery_files:
       title: Dateien
-  must_choose_file: "Sie müssen eine Datei zum Hochladen auswählen"
-  file_should_be_smaller_than_max_file_size: "Die Dateien sollten kleiner als %{max_file_size} werden"
+      description: Dateien hochladen und verlinken
+  file_specify_for_upload: Sie müssen eine Datei zum Hochladen angeben
+  file_should_be_smaller_than_max_file_size: Die Dateien sollten kleiner als %{max_file_size} sein
   admin:
     resources:
+      delete: Diese Datei für immer löschen
+      edit: Diese Datei bearbeiten    
       form:
-        file_to_upload: Datei zum Hochladen
         download_current: Download der aktuellen Datei
         or: oder
-        replace: ", ersetzen Sie es mit diesem einen..."
+        replace: ", mit dieser ersetzen..."
         maximum_file_size: "Die maximale Dateigröße beträgt %{megabytes} Megabyte."
       resource:
-        download: "Diese Datei herunterladen (%{size})"
-        edit: Bearbeiten Sie diese Datei
-        delete:
-          message: "Sind Sie sicher, die Sie löschen möchten '%{title}'?"
-          title: Löschen Sie diese Datei immer
+        download: Diese Datei herunterladen (%{size})
       index:
         upload_new: Neue Datei Hochladen
-        no_files_yet: Es gibt keine Dateien. Klicken Sie auf "Neue Datei Hochladen" um Ihre erste Datei hinzufügen.
+        no_files_yet: Keine Dateien vorhanden. Klicken Sie auf "Neue Datei Hochladen" um Ihre erste Datei hinzuzufügen.
       insert:
-        existing_file: Bestehende Datei
+        existing: Vorhandene Datei
         new: Neue Datei
-        link_to_resource: 'Link zu dieser Datei'
-        previous: Zurück
-        next: Nächste
-        submit_insert: Einfügen
-        or: oder
-        cancel: Abbrechen
+        no_files: Keine Dateien vorhanden.
+      existing_resource:
+        link_to_file: Link zu dieser Datei
+        button_text: Einfügen
+  activerecord:
+    models:
+      resource: Datei

--- a/vendor/refinerycms/settings/config/locales/de.yml
+++ b/vendor/refinerycms/settings/config/locales/de.yml
@@ -1,23 +1,43 @@
 de:
+  plugins:
+    refinery_settings:
+      title: Einstellungen
+      description: Refinery-Einstellungen verwalten
+  admin:
+    refinery_settings:
+      delete: Diese Einstellung für immer löschen
+      edit: Diese Einstellung bearbeiten
+      index:
+        new: Neue Einstellung erstellen
+        empty_set: Es gibt noch keine Einstellungen.
+        create_first: Klicken Sie auf '%{link}', um Ihre erste Einstellung anzulegen.
+      form:
+        restart_may_be_in_order: "<strong>Bitte beachten Sie</strong>, dass Sie Ihre Website eventuell neu starten müssen, damit die Einstellungen angewendet werden."
+        yes_make_this_setting_restricted: Ja, diese Einstellung auf Administratoren einschränken.
+        help:
+          restricted: Macht diese Einstellung nur für Administratoren sichtbar und veränderbar.
+          activity_show_limit: Dies schränkt die Anzahl der Einträge im Amaturenbrett ein.
+          analytics_page_code: Dieser Code aktiviert Google Analytics innerhalb Ihrer Webseite. Wenn diese Einstellung leer gelassen wird oder auf UA-xxxxxx-x gesetzt wird, ist diese Funktion deaktiviert und es werden keine Verbindungsaufrufe zu Google Analytics gemacht.
+          image_dialogue_sizes: Diese Einstellung wirkt sich auf den "Bild einfügen" Dialog aus. Sie müssen für die verschiedenen Miniaturansichten sorgen, sowie diesen Wert hier ändern.
+          image_thumbnails: Wenn Sie diese Einstellung verändern, müssen Sie Ihre Bilder neu erzeugen lassen, indem Sie "rake images:regenerate" (oder "rake images:update" wenn Sie nur neue Miniaturansichten hinzugefügt haben), sonst wird diese Einstellung nicht für bereits vorhandene Bilder angewendet.
+          menu_hide_children: Versteckt alle Unterseiten auf dem Menü, auch wenn diese vorhanden sind.
+          new_page_parts: Erlaubt das Hinzufügen neuer Teilbereiche (Inhalts-Abschnitte) im Seiten-Editor.
+          page_title: Sehr umfangreiche Möglichkeit zum Setzen des Seitentitels. Hier können Sie eine angepasste CSS-Klasse oder ein HTML-Tag angeben, oder auch eine Brotkrumen-Navigation erzeugen.
+          pages_advanced_options_include_seo: Dies legt fest, ob die Suchmaschinenoptimierung unter den erweiterten Einstellungen einer Seite angezeigt werden soll.
+          preferred_image_view: Dies legt fest, welche Ansicht des Bilder-Erweiterung für vorhandene Bilder verwendet werden soll - "grid" für eine Gitter-Ansicht und "list" für eine Listen-Ansicht. Es gibt einen Knopf in der Erweiterung selbst, um diesen Vorgang zu automatisieren.
+          refinery_enable_backend_reordering: Hiermit können Sie die Möglichkeit, Erweiterungen umzusortieren, entfernen.
+          refinery_menu_cache_action_suffix: Die steuert den Schlüssel der benutzt wird, um das Menü der Seite zwischenzuspeichern. Wenn Sie ein Thema verwenden, lassen Sie diesen Wert so - das Thema wird sich darum kümmern.
+          show_contact_privacy_link: Sie können den Link zu den Datenschutzbestimmungen beim Kontaktformular verstecken oder beim Absenden-Knopf anzeigen lassen.
+          site_name: Dies ist der Name Ihrer Webseite, der im Kopfbereich, im Administrationsbereich und bei manchen Themen im Fußbereich beim Copyright angezeigt wird.
+          theme: Geben Sie den Namen des Themas an, das die verwenden möchten. Dies wirkt sich sofort aus und muss auf ein vorhandenes Thema verweisen.
+          use_google_ajax_libraries: Wenn Sie Googles AJAX CDN verwenden wollen, setzen diesen Wert auf "true".
+          use_marketable_urls: Ändert Urls von /pages/about auf /about und behebt automatisch Konflikte mit anderen Erweiterungen.
+          use_resource_caching: Es wird empfohlen, dies in der Produktionsumgebung zu verwenden, da es Javascript- und Stylesheet Dateien zusammenfasst, um die Anzahl an Web-Anfragen zu verringern und die Geschwindigkeit zu erhöhen.
   activerecord:
     models:
-      refinery_setting: Refinery Einstellungen
+      refinery_setting: Einstellungen
     attributes:
       refinery_setting:
         name: Name
         value: Wert
-  admin:
-    refinery_settings:
-      refinery_setting:
-        edit: 'Diese Einstellung bearbeiten'
-        confirm: 'Sind Sie sicher, dass Sie diese Einstellung für immer löschen möchten?'
-        remove: 'Diese Einstellung für immer löschen'
-      index:
-        new: Neue Einstellung erstellen
-        empty_set: Es gibt noch keine Einstellungen.
-        create_first: "Klicken Sie auf '%{link}' um Ihre erste Einstellung anzulegen."
-      form:
-        restart_may_be_in_order: "<strong>Bitte beachten Sie</strong>, dass Sie Ihre Website eventuell neu starten müssen, damit die Einstellungen angwendet werden."
-  plugins:
-    refinery_settings:
-      title: Einstellungen
+        restricted: Eingeschränkt


### PR DESCRIPTION
Hello! There been lot of missing translations for i18n_de which i fixed or added. Also rewrote existing ones to match symbol order in i18n_en. However few translations are missing for the inquiry plugin which i guess is in a separate gem.

I also had to add few lines for ActiveRecord which not been in the i18n_en file.

vendor/refinerycms/authentication/config/locales/de.yml:

  activerecord:
    attributes:
      user:
        login: Login
        email: Email
        password: Password
        password_confirmation: Password confirmation
        plugin_access: Plugin access

You can add those lines to i18n_en in case someone starts with a fresh translation and uses _en as blueprint.
