### PR TITLE
Dependant user plugins

### DIFF
--- a/vendor/refinerycms/authentication/app/models/user.rb
+++ b/vendor/refinerycms/authentication/app/models/user.rb
@@ -34,7 +34,7 @@ class User < ActiveRecord::Base
   #-------------------------------------------------------------------------------------------------
 
   has_and_belongs_to_many :roles
-  has_many :plugins, :class_name => "UserPlugin", :order => "position ASC"
+  has_many :plugins, :class_name => "UserPlugin", :order => "position ASC", :dependent => :destroy
   has_friendly_id :login, :use_slug => true
 
   def plugins=(plugin_names)


### PR DESCRIPTION
We're polluting the database, by not removing UserPlugins when we remove a user.
