### PR TITLE
Fix for NameError thrown by rake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ rmagick_options = {:require => false}
 rmagick_options.update({
   :git => 'git://github.com/refinerycms/rmagick.git',
   :branch => 'windows'
-}) if Bundler::WINDOWS
+}) if defined? Bundler::WINDOWS
 
 # Specify a version of RMagick that works in your environment:
 gem 'rmagick',                  '~> 2.12.0', rmagick_options
@@ -70,7 +70,7 @@ group :test do
   gem 'database_cleaner'
   gem 'cucumber-rails'
   gem 'cucumber'
-  gem 'spork' unless Bundler::WINDOWS
+  gem 'spork' unless defined? Bundler::WINDOWS
   gem 'launchy'
   gem 'gherkin'
   gem 'rack-test',              '~> 0.5.5'


### PR DESCRIPTION
running 1.9.2 on OS X here. Was getting a uninitialized constant Bundler::WINDOWS complaint when trying to do any rake task. Looks like this was introduced in
http://github.com/resolve/refinerycms/commit/21f97c555abc4538174a39ba1837be7ff7427404
