### PR TITLE
Turn off verbose unless we're in development environment

### DIFF
--- a/vendor/refinerycms/images/lib/images.rb
+++ b/vendor/refinerycms/images/lib/images.rb
@@ -66,7 +66,7 @@ module Refinery
         app.config.middleware.insert_after 'Rack::Lock', 'Dragonfly::Middleware', :images, '/system/images'
 
         app.config.middleware.insert_before 'Dragonfly::Middleware', 'Rack::Cache', {
-          :verbose     => true,
+          :verbose     => Rails.env == "development"
           :metastore   => "file:#{Rails.root.join('tmp', 'dragonfly', 'cache', 'meta')}",
           :entitystore => "file:#{Rails.root.join('tmp', 'dragonfly', 'cache', 'body')}"
         }

--- a/vendor/refinerycms/resources/lib/resources.rb
+++ b/vendor/refinerycms/resources/lib/resources.rb
@@ -65,7 +65,7 @@ module Refinery
         app.config.middleware.insert_after 'Rack::Lock', 'Dragonfly::Middleware', :resources, '/system/resources'
 
         app.config.middleware.insert_before 'Dragonfly::Middleware', 'Rack::Cache', {
-          :verbose     => true,
+          :verbose     => Rails.env == "development"
           :metastore   => "file:#{Rails.root.join('tmp', 'dragonfly', 'cache', 'meta')}",
           :entitystore => "file:#{Rails.root.join('tmp', 'dragonfly', 'cache', 'body')}"
         }


### PR DESCRIPTION
At the moment the Rack::Cache middleware specified has verbose set to `true` and there's no way to turn it off without some source hackery. This commit fixes that, disabling it ("verbose mode") in any environment that isn't development.
