### PR TITLE
Fixes IE7 bug with flash message.

### DIFF
--- a/vendor/refinerycms/core/public/javascripts/refinery/core.js
+++ b/vendor/refinerycms/core/public/javascripts/refinery/core.js
@@ -6,7 +6,7 @@ $(document).ready(function(){
 });
 
 init_flash_messages = function(){
-  $('#flash').hide().css('visibility', null).fadeIn(550);
+  $('#flash').hide().css('visibility', '').fadeIn(550);
   $('#flash_close').click(function(e) {
      $('#flash').fadeOut({duration: 330});
      e.preventDefault();


### PR DESCRIPTION
Passing null as the value to css is deprecated and incorrect in IE.

http://bugs.jquery.com/ticket/7233

"Calling css( key, null ) in jQuery < 1.4.3 just seemed to work but actually did the wrong thing by setting the value to nullpx which throws errors in IE."
