### PR TITLE
Fixes IE7 display bug of pages tree

### DIFF
--- a/vendor/refinerycms/core/public/stylesheets/refinery/refinery.css
+++ b/vendor/refinerycms/core/public/stylesheets/refinery/refinery.css
@@ -489,6 +489,9 @@ header p {
   padding: 4px 0 0 40px;
   background: url('/images/refinery/branch.gif') no-repeat 15px 0px;
 }
+#records.tree li.record ul {
+  margin-left: 0;
+}
 #records.tree .on-hover, #pagination ul.tree a:hover, #pagination .tree .on {
   background: url('/images/refinery/branch.gif') no-repeat 15px 0px;
 }


### PR DESCRIPTION
IE7 was giving the nested nodes a default margin-left of 30pt. This fix forces the margin-left to 0px

Before fix:
http://tinypic.com/r/15qf1va/7

After fix:
http://tinypic.com/r/2f0ahea/7

Tested 3 nodes deep in IE7/8, FF, Chrome.
