### PR TITLE
Fixes wymeditor display bug in IE7

### DIFF
--- a/vendor/refinerycms/core/public/stylesheets/refinery/ui.css
+++ b/vendor/refinerycms/core/public/stylesheets/refinery/ui.css
@@ -68,6 +68,12 @@
   left: -10000px;
   top: -10000px;
 }
+.ie7 .ui-tabs-hide {
+  display: none !important !important;
+  height: auto !important !important;
+  width: auto !important !important;
+  position: static;
+}
 /** Makes sure your embed does not have leftover height when hidden **/
 .ui-tabs-hide object,
 .ui-tabs-hide embed {


### PR DESCRIPTION
This fix applies a style for IE7 only which uses display: none to hide tabs instead of off-left positioning.

Before fix:
http://i53.tinypic.com/18ixbl.png

After fix:
http://i56.tinypic.com/aewnxe.png
