### PR TITLE
Seperate each error message

### DIFF
--- a/vendor/refinerycms/core/app/views/shared/admin/_error_messages.html.erb
+++ b/vendor/refinerycms/core/app/views/shared/admin/_error_messages.html.erb
@@ -3,12 +3,12 @@
   <p><%= t('.problems_in_following_fields') %>:</p>
   <ul>
   <% unless defined?(include_object_name) and include_object_name %>
-    <% object.errors.each_value do |msg| %>
-      <li><%= msg %></li>
+    <% object.errors.each do |key, value| %>
+      <li><%= value %></li>
     <% end %>
   <% else %>
-    <% object.errors.full_messages.each do |msg| %>
-      <li><%= msg %></li>
+    <% object.errors.full_messages.each do |value| %>
+      <li><%= value %></li>
     <% end %>
   <% end %>
   </ul>


### PR DESCRIPTION
Current situation was that if for example we have two failed validations when uploading image then both messages was displayed in one <li></li> tag. This commit separates those messages each in it's own <li></li> tags.
