### PR TITLE
engine generator not creating image fields properly in _form

### DIFF
--- a/vendor/refinerycms/core/lib/generators/refinery_engine/refinery_engine_generator.rb
+++ b/vendor/refinerycms/core/lib/generators/refinery_engine/refinery_engine_generator.rb
@@ -9,7 +9,7 @@ class RefineryEngineGenerator < Rails::Generators::NamedBase
 
   def generate
     unless attributes.empty?
-      Dir.glob(File.expand_path('../templates/**/**', __FILE__), File::FNM_DOTMATCH).each do |path|
+      Dir.glob(File.expand_path('../templates/**/**', __FILE__), File::FNM_DOTMATCH).sort.each do |path|
         # ignore directories which are created automatically by template()
         unless File.directory?(path)
           template path, plugin_path_for(path)


### PR DESCRIPTION
Today I ran into an issue w/ the engine generator creating the proper files in _form.html.erb.  I tracked it down.  The attributes were getting modified by "generators/refinery_engine/templates/db/migrate/create_plural_name.rb" before the _form file was generated.  This was making the image fields show up as text fields w/ the name_id instead of the code for the partial.

I simply sorted the array which gets looped over, which put the _form file generation before creat_plural_name.rb is generated.  This is kind of a hack.  It seems strange to me that "attributes" is floating around like a global variable that is referenced and updated throughout the generation of the engine files.  I personally don't know enough about generators at this point to try to rewrite it without a global attributes variable.

Here is the change I made on the "/gems/refinerycms-0.9.8.6/vendor/refinerycms/core/lib/generators/refinery_engine/refinery_engine_generator.rb" file.

<pre>
12c12
&lt;       Dir.glob(File.expand_path('../templates/**/**', __FILE__), File::FNM_DOTMATCH).each do |path|

---
&gt;       Dir.glob(File.expand_path('../templates/**/**', __FILE__), File::FNM_DOTMATCH).sort.each do |path|
</pre>
