### PR TITLE
Fixed already initialized constant WINDOWS warning.

### DIFF
--- a/lib/refinery.rb
+++ b/lib/refinery.rb
@@ -2,7 +2,7 @@ require 'rbconfig'
 
 module Refinery
 
-  WINDOWS = !!(RbConfig::CONFIG["host_os"] =~ %r!(msdos|mswin|djgpp|mingw)!)
+  WINDOWS = !!(RbConfig::CONFIG["host_os"] =~ %r!(msdos|mswin|djgpp|mingw)!) unless defined? WINDOWS
 
   class << self
     attr_accessor :root, :s3_backend, :base_cache_key, :rescue_not_found


### PR DESCRIPTION
Ruby 1.8.7 loads lib/refinery.rb twice, so we only define WINDOWS if it's not already defined. Fixes #341
