### PR TITLE
Patch to fix extraneous characters prepended to uploaded filenames

### DIFF
--- a/images/lib/images.rb
+++ b/images/lib/images.rb
@@ -28,7 +28,7 @@ module Refinery
         # /system/images/BAhbB1sHOgZmIiMyMDEwLzA5LzAxL1NTQ19DbGllbnRfQ29uZi5qcGdbCDoGcDoKdGh1bWIiDjk0MngzNjAjYw/refinery_is_awesome.jpg
         # Officially the way to do it, from: http://markevans.github.com/dragonfly/file.URLs.html
         app_images.url_suffix = proc{|job|
-          "/#{job.uid_basename}#{job.encoded_extname || job.uid_extname}"
+          "/#{job.name}"
         }
 
         ### Extend active record ###

--- a/resources/lib/resources.rb
+++ b/resources/lib/resources.rb
@@ -26,7 +26,7 @@ module Refinery
         # /system/images/BAhbB1sHOgZmIiMyMDEwLzA5LzAxL1NTQ19DbGllbnRfQ29uZi5qcGdbCDoGcDoKdGh1bWIiDjk0MngzNjAjYw/refinery_is_awesome.pdf
         # Officially the way to do it, from: http://markevans.github.com/dragonfly/file.URLs.html
         app_resources.url_suffix = proc{|job|
-          "/#{job.uid_basename}#{job.encoded_extname || job.uid_extname}"
+          "/#{job.name}"
         }
 
         ### Extend active record ###


### PR DESCRIPTION
Here are some method invocations on a file I uploaded.  In 'rails console' you can get ahold of the dragonfly job with:

j = Resource.find(:first).file.instance_variable_get('@job')

> > j.name

=> "foo-0.1.jar"

> > j.encoded_extname

=> nil

> > j.uid_extname

=> ".jar"

> > j.uid_basename

=> "16_43_43_144_foo_0.1"

Note that I'm submitting this for master, but it should probably be cherry-picked to the 0.9.8 stable branch as well.
