### PR TITLE
dutch translation fix

### DIFF
--- a/images/config/locales/nl.yml
+++ b/images/config/locales/nl.yml
@@ -27,8 +27,8 @@ nl:
         resize_image: Schaal de afbeelding
         size: Grootte
       insert:
-        existing_image: Bestaand
-        new_image: Nieuw
+        existing_image: Bibliotheek
+        new_image: Uploaden
   activerecord:
     models:
       image: afbeelding


### PR DESCRIPTION
Hi

I've fixed a small translation issue. The translation of the two lines in the commit was wrapped upon each other making the add-image-popup look weird.
