### PR TITLE
Suggestion to fix TODO # bin/refinerycms:301

### DIFF
--- a/bin/refinerycms
+++ b/bin/refinerycms
@@ -347,6 +347,12 @@ module Refinery
 
       # Install!
       run_command("bundle install")
+      if $? != 0
+        puts "Unable to install necessary gems!"
+        puts "Removing #{@app_path}!"
+        FileUtils.rm_rf @app_path
+        exit 1
+      end
     end
 
     def output!


### PR DESCRIPTION
I attempted to install refinerycms on an ubuntu server.  I was missing several packages, so gem installations [from refinerycms] kept bombing, and I kept having to remove my installation and try again (after installing O/S packages).  I wanted to change it and noticed in bin/refinerycms @ line 301 the "TODO" to add return value checking after gem installs.

The pull request here includes a simple check after the "bundle install" command, which I found to work very well when a [necessary] gem can't be installed (because, for example, an O/S package is missing).  I was NOT able to cause the "bundle update" to fail, so I could not test that.  Possibly this same snippet of code (lines 310-315) could be applied at line 306 as well?

This is my 1st ever open source patch contribution/suggestion, so please take it easy on me!
