### PR TITLE
Added customizable image titles and descriptions

### DIFF
--- a/core/public/javascripts/refinery/admin.js
+++ b/core/public/javascripts/refinery/admin.js
@@ -136,12 +136,6 @@ init_interface = function() {
     e.preventDefault();
   });
 
-  $('#existing_image img').load(function(){
-    $('form.edit_image .form-actions').css({
-      'margin-top': ($('#existing_image').height() - $('form.edit_image').height() + 8)
-    });
-  });
-
   $('.form-actions .form-actions-left input:submit#submit_button').click(function(e) {
     $("<img src='/images/refinery/icons/ajax-loader.gif' width='16' height='16' class='save-loader' />").appendTo($(this).parent());
   });

--- a/db/migrate/20110212224402_add_title_and_description_to_images.rb
+++ b/db/migrate/20110212224402_add_title_and_description_to_images.rb
@@ -1,0 +1,11 @@
+class AddTitleAndDescriptionToImages < ActiveRecord::Migration
+  def self.up
+    add_column ::Image.table_name, :title, :string
+    add_column ::Image.table_name, :description, :text
+  end
+
+  def self.down
+    remove_column ::Image.table_name, :title
+    remove_column ::Image.table_name, :description
+  end
+end

--- a/images/app/models/image.rb
+++ b/images/app/models/image.rb
@@ -15,6 +15,8 @@ class Image < ActiveRecord::Base
   # Docs for acts_as_indexed http://github.com/dougal/acts_as_indexed
   acts_as_indexed :fields => [:title]
 
+  before_save :default_values
+
   # when a dialog pops up with images, how many images per page should there be
   PAGES_PER_DIALOG = 18
 
@@ -63,10 +65,12 @@ class Image < ActiveRecord::Base
     end
   end
 
-  # Returns a titleized version of the filename
-  # my_file.jpg returns My File
-  def title
-    CGI::unescape(image_name.to_s).gsub(/\.\w+$/, '').titleize
+  def default_values
+    # Returns a titleized version of the filename
+    # my_file.jpg returns My File
+    if self.title.blank? || self.image_name_changed?
+      self.title = CGI::unescape(image_name.to_s).gsub(/\.\w+$/, '').titleize
+    end
   end
 
 end

--- a/images/app/views/admin/images/_form.html.erb
+++ b/images/app/views/admin/images/_form.html.erb
@@ -6,8 +6,16 @@
                :include_object_name => false
              } %>
 
-  <div class='field'>
-    <% if action_name =~ /(edit)|(update)/ %>
+  <% if action_name =~ /(edit)|(update)/ %>
+    <div class='field'>
+      <%= f.label :title %>
+      <%= f.text_field :title %>
+    </div>
+    <div class='field'>
+      <%= f.label :description %>
+      <%= f.text_area :description, :rows => 3 %>
+    </div>
+    <div class='field'>
       <p>
         <%= t('.use_current_image') %>
         <em><%= t('.or') %></em><%= t('.replace_image') %>
@@ -15,11 +23,13 @@
       <p>
         <%= f.file_field :image %>
       </p>
-    <% else %>
+    </div>
+  <% else %>
+    <div class='field'>
       <% # we must only hint at multiple when it's a new record otherwise update fails. %>
       <%= f.file_field :image, :multiple => true %>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 
   <div class='field'>
     <label><%= t('.maximum_image_size', :megabytes => Image::MAX_SIZE_IN_MB) %></label>

--- a/images/db/migrate/20110212224402_add_title_and_description_to_images.rb
+++ b/images/db/migrate/20110212224402_add_title_and_description_to_images.rb
@@ -1,0 +1,11 @@
+class AddTitleAndDescriptionToImages < ActiveRecord::Migration
+  def self.up
+    add_column ::Image.table_name, :title, :string
+    add_column ::Image.table_name, :description, :text
+  end
+
+  def self.down
+    remove_column ::Image.table_name, :title
+    remove_column ::Image.table_name, :description
+  end
+end


### PR DESCRIPTION
Sorry, I moved this commit into a different branch and it killed my previous pull request.

Image titles will still be automatically set by the file name, but now users can edit it. There's also a new description field.

I also removed the ugly Javascript CSS hack for the .form-actions on that page, since it's no longer necessary (and in fact was breaking the new form layout).

> _parndt commented_:
> This is a new feature and so we will have to wait until after 1.0
> What does everyone else think about this change? We used to have this but we removed it.
