### PR TITLE
Ability to define a custom js file to customize wym editor on a section by section basis in the admin

### DIFF
--- a/core/app/views/admin/_javascripts.html.erb
+++ b/core/app/views/admin/_javascripts.html.erb
@@ -19,9 +19,9 @@
 
 <%= yield :after_javascript_libraries -%>
 
-<%= javascript_include_tag 'wymeditor/jquery.refinery.wymeditor.js',
-                           'admin',
-                           'refinery/boot_wym',
+<%= javascript_include_tag 'wymeditor/jquery.refinery.wymeditor.js', 'admin' %>
+<%= yield :customize_wym -%>
+<%= javascript_include_tag 'refinery/boot_wym',
                            'refinery/core',
                            'refinery/site_bar',
                            'refinery/admin',


### PR DESCRIPTION
We ran into an issue where we wanted the editor to have different options in "Pages" than when used in other areas of the admin. The boot_wym file is helpful, but it updates the options for all engines.
