### PR TITLE
Menu rendering speed-up

### DIFF
--- a/core/app/views/shared/_menu_branch.html.erb
+++ b/core/app/views/shared/_menu_branch.html.erb
@@ -5,7 +5,7 @@
   dom_id = ("id='item_#{menu_branch_counter}'" if menu_branch.parent_id.nil? and menu_branch.title.present?)
 
   hide_children = (defined?(hide_children) && hide_children)
-  children = (hide_children || !menu_branch.has_descendants?) ? [] : collection.select { |p| p.parent_id == menu_branch.id && p.in_menu? }
+  children = (hide_children || !menu_branch.has_descendants?) ? [] : collection.select { |p| p.parent_id == menu_branch.id }
 -%>
 <li<%= ['', css, dom_id].compact.join(' ').gsub(/\ *$/, '') %>>
   <%= link_to menu_branch.title, menu_branch.url -%>


### PR DESCRIPTION
The first commit is the money one  -- it checks to see if a page has descendents before manually going through the entire collection of pages.

On our site, with 137 pages, this cuts the rendering time in half, from ~2.5 to 1.2 seconds.

Second commit is just minor cleanup.
