### PR TITLE
Typo in admin/pages/_sortable_list partial

### DIFF
--- a/pages/app/views/admin/pages/_sortable_list.html.erb
+++ b/pages/app/views/admin/pages/_sortable_list.html.erb
@@ -3,7 +3,7 @@
              :collection => @pages.select{|p| p.parent_id.nil?},
              :locals => {
                :collection => @pages
-             },  %>
+             }  %>
 </ul>
 <%= render :partial => "/shared/admin/sortable_list",
            :locals => {:continue_reordering => !!local_assigns[:continue_reordering]} %>


### PR DESCRIPTION
There is a trailing comma in _sortable_list partial
