### PR TITLE
Quick fix for comma typo

### DIFF
--- a/pages/app/views/admin/pages/_sortable_list.html.erb
+++ b/pages/app/views/admin/pages/_sortable_list.html.erb
@@ -3,7 +3,7 @@
              :collection => @pages.select{|p| p.parent_id.nil?},
              :locals => {
                :collection => @pages
-             },  %>
+             } %>
 </ul>
 <%= render :partial => "/shared/admin/sortable_list",
            :locals => {:continue_reordering => !!local_assigns[:continue_reordering]} %>


### PR DESCRIPTION
Hey all,

It looks like this bug was introduced yesterday.  The existing cucumber features were failing, I removed the comma, and the features pass so I didn't add any additional testing.
- Jeff 
