### PR TITLE
Japanese translations for wymeditor

### DIFF
--- a/core/public/javascripts/wymeditor/lang/jp.js
+++ b/core/public/javascripts/wymeditor/lang/jp.js
@@ -1,7 +1,7 @@
 WYMeditor.STRINGS['jp'] = {
   Strong:           '強調',
   Bold:             '太字',
-  Emphasis:         'やや強調',
+  Emphasis:         '斜体字',
   Superscript:      '上つき',
   Subscript:        '下つき',
   Ordered_List:     '番号つきリスト',


### PR DESCRIPTION
First pass. Some texts remain English; I suspect those can't be overridden. https://skitch.com/banzaiman/rikwy/company-name-refinery
