### PR TITLE
Fix respond_to? in presenters

### DIFF
--- a/core/lib/refinery/base_presenter.rb
+++ b/core/lib/refinery/base_presenter.rb
@@ -24,4 +24,8 @@ class Refinery::BasePresenter
     end
   end
 
+  def respond_to?(method)
+    super || @model.respond_to?(method) || DEFAULT_FIELDS.has_key?(method)
+  end
+
 end


### PR DESCRIPTION
Presenters responds to more methods with method_missing but respond_to? method don't return true for those methods.

For example, chain_page_title option in page_title helper wasn't working because it uses respond_to? :ancestors and PagePresenter has no ancestors so method so respond_to? return false, although ancestors works due to method_missing.

With this patch you can use chain_page_title to build a breadcrumb
