### PR TITLE
Devise 1.2 message about config.encryptor

### DIFF
--- a/authentication/db/migrate/20110325213325_remove_password_salt_from_users.rb
+++ b/authentication/db/migrate/20110325213325_remove_password_salt_from_users.rb
@@ -1,0 +1,9 @@
+class RemovePasswordSaltFromUsers < ActiveRecord::Migration
+  def self.up
+    remove_column :users, :password_salt
+  end
+
+  def self.down
+    add_column :users, :password_salt, :string
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -45,7 +45,7 @@ Devise.setup do |config|
   # from others authentication tools as :clearance_sha1, :authlogic_sha512 (then
   # you should set stretches above to 20 for default behavior) and :restful_authentication_sha1
   # (then you should set stretches to 10, and copy REST_AUTH_SITE_KEY to pepper)
-  config.encryptor = :bcrypt
+  # config.encryptor = :bcrypt
 
   # Setup a pepper to generate the encrypted password.
   config.pepper = "2e20a8abdd34d729ba6d05f679e513cfea9fbb1e83c81f84b29e9e4fdbd4ee59b56a32200064082a15a72b05a4d4a6a2c3784a09c0554b3a47a67cc8333ccbc7"

--- a/db/migrate/20110325213325_remove_password_salt_from_users.rb
+++ b/db/migrate/20110325213325_remove_password_salt_from_users.rb
@@ -1,0 +1,9 @@
+class RemovePasswordSaltFromUsers < ActiveRecord::Migration
+  def self.up
+    remove_column :users, :password_salt
+  end
+
+  def self.down
+    add_column :users, :password_salt, :string
+  end
+end


### PR DESCRIPTION
This removes devises message:
"[DEVISE] From version 1.2, there is no need to set your encryptor to bcrypt since encryptors are only enabled if you include :encryptable in your models. With this change, we can integrate better with bcrypt and get rid of the password_salt column (since bcrypt stores the salt with password). Please comment config.encryptor in your initializer to get rid of this warning."

Although I didn't include :null => false in the down migration step because it's too much of a hassle to get that down step to work knowing refinerycms uses devise which doesn't require password_salt field anymore.
