### PR TITLE
Fixed: error when recreating db from scratch using rake db:drop db:create db:migrate

### DIFF
--- a/db/migrate/20100926142529_add_value_type_to_refinery_settings.rb
+++ b/db/migrate/20100926142529_add_value_type_to_refinery_settings.rb
@@ -1,6 +1,8 @@
 class AddValueTypeToRefinerySettings < ActiveRecord::Migration
   def self.up
     add_column ::RefinerySetting.table_name, :form_value_type, :string
+
+    ::RefinerySetting.reset_column_information
   end
 
   def self.down

--- a/db/migrate/20101206013505_change_to_devise_users_table.rb
+++ b/db/migrate/20101206013505_change_to_devise_users_table.rb
@@ -10,6 +10,8 @@ class ChangeToDeviseUsersTable < ActiveRecord::Migration
 
     rename_column ::User.table_name, :crypted_password, :encrypted_password
     rename_column ::User.table_name, :login, :username
+
+    ::User.reset_column_information
   end
 
   def self.down

--- a/db/migrate/20101216194133_remove_cached_slug_from_pages.rb
+++ b/db/migrate/20101216194133_remove_cached_slug_from_pages.rb
@@ -3,6 +3,8 @@ class RemoveCachedSlugFromPages < ActiveRecord::Migration
     if ::Page.column_names.map(&:to_s).include?('cached_slug')
       remove_column ::Page.table_name, :cached_slug
     end
+
+    ::Page.reset_column_information
   end
 
   def self.down

--- a/db/migrate/20101217113424_add_locale_to_slugs.rb
+++ b/db/migrate/20101217113424_add_locale_to_slugs.rb
@@ -3,6 +3,8 @@ class AddLocaleToSlugs < ActiveRecord::Migration
     add_column :slugs, :locale, :string, :limit => 5
 
     add_index :slugs, :locale
+
+    ::Slug.reset_column_information
   end
 
   def self.down

--- a/db/migrate/20110106184757_add_remember_created_at_to_users.rb
+++ b/db/migrate/20110106184757_add_remember_created_at_to_users.rb
@@ -1,6 +1,8 @@
 class AddRememberCreatedAtToUsers < ActiveRecord::Migration
   def self.up
     add_column :users, :remember_created_at, :datetime
+
+    ::User.reset_column_information
   end
 
   def self.down

--- a/db/migrate/20110307025652_translate_custom_title_on_pages.rb
+++ b/db/migrate/20110307025652_translate_custom_title_on_pages.rb
@@ -9,6 +9,8 @@ class TranslateCustomTitleOnPages < ActiveRecord::Migration
       end
 
     end
+
+    ::Page.reset_column_information
   end
 
   def self.down

--- a/db/migrate/20110314213540_remove_translated_fields_from_pages.rb
+++ b/db/migrate/20110314213540_remove_translated_fields_from_pages.rb
@@ -3,6 +3,8 @@ class RemoveTranslatedFieldsFromPages < ActiveRecord::Migration
     ::Page.translated_attribute_names.map(&:to_sym).each do |column_name|
       remove_column ::Page.table_name, column_name if ::Page.column_names.map(&:to_sym).include?(column_name)
     end
+
+    ::Page.reset_column_information
   end
 
   def self.down

--- a/db/migrate/20110325213325_remove_password_salt_from_users.rb
+++ b/db/migrate/20110325213325_remove_password_salt_from_users.rb
@@ -5,6 +5,8 @@ class RemovePasswordSaltFromUsers < ActiveRecord::Migration
     User.all.each do |u|
       u.update_attribute(:encrypted_password, u.encrypted_password[29..-1])
     end
+
+    ::User.reset_column_information
   end
 
   def self.down


### PR DESCRIPTION
Added the proper calls to reset_column_information in the various migrations that needed it
