### PR TITLE
Fix overriding cache_men

### DIFF
--- a/core/app/views/shared/_menu.html.erb
+++ b/core/app/views/shared/_menu.html.erb
@@ -4,8 +4,8 @@
   hide_children = RefinerySetting.find_or_set(:menu_hide_children, false) if hide_children.nil?
   # Select top menu items unless 'roots' is supplied.
   collection ||= @menu_pages
-  caching = ((defined?(cache_menu) && cache_menu) || RefinerySetting.find_or_set(:cache_menu, false)) && File.writable?(Rails.cache.cache_path)
-  cache_if(caching && !user_signed_in?, [Refinery.base_cache_key, "pages_menus", dom_id, Globalize.locale, request.path].join('_')) do
+  caching = (cache_menu ||= RefinerySetting.find_or_set(:cache_menu, false)) && File.writable?(Rails.cache.cache_path)
+  cache_if(caching && !user_signed_in?, [Refinery.base_cache_key, "pages_menus", dom_id, Globalize.locale, cache_path ||= request.path].join('_')) do
     if (roots ||= collection.select{|p| p.parent_id.nil?}).present?
       # In order to match items that aren't shown in menu and highlight their associations.
       # This can be supplied if the logic is different in your case.


### PR DESCRIPTION
If cache_menu was enabled globally you couldn't disable it in a render :partial call

Also I have added option to enable overriding request.path in cache name, so cache can be shared for all requests. I use a top menu with hidden children and selected item is not relevant, so that menu can be shared for all requests.
