### PR TITLE
Untitled

### DIFF
--- a/pages/lib/refinery/pages/instance_methods.rb
+++ b/pages/lib/refinery/pages/instance_methods.rb
@@ -26,7 +26,7 @@ module Refinery
     private
       def store_current_location!
         unless admin?
-          session[:website_return_to] = @page.url if @page.try(:present?)
+          session[:website_return_to] = url_for(@page.url) if @page.try(:present?)
         else
           super
         end


### PR DESCRIPTION
fix for https://github.com/resolve/refinerycms-blog/issues/#issue/58 and others who use nested scopes in routes.rb

Somehow if you have nested routes in an engine like blog you get the error described in the issue above. this error occurs always if you come from a page different than the root page and want to switch to the engine with the nested scopes:

```
  scope(:path => 'refinery', :as => 'admin', :module => 'admin') do
    scope(:path => 'blog', :as => 'blog', :module => 'blog') do
```

The bug is caused by @page.url which is a hash and stored in the session. Somehow, link_to, which uses url_for can't resolve this hash when routes define nested scopes like above. As far as I see it, there are two ways to fix this: first, make url_for work correctly. Second, only store already resolved url in session[:website_return_to] so it must no be evaluated in the engine. This is what the commit appended does. Hope that helps.
