### PR TITLE
Fix paginating in link_to dialog

### DIFF
--- a/pages/app/views/admin/pages_dialogs/link_to.html.erb
+++ b/pages/app/views/admin/pages_dialogs/link_to.html.erb
@@ -109,7 +109,7 @@
           <%= will_paginate @resources,
                             :param_name => :resource_page,
                             :renderer => Refinery::LinkRenderer,
-                            :url => {:paginating => "resource_file"},
+                            :params => {:paginating => "resource_file"},
                             :id => 'resouces_paginate' %>
         </div>
       </div>


### PR DESCRIPTION
When you change page in link_to dialog, your resource option is unselected, and your page is selected again.
