### PR TITLE
Links to the 8 orphan docs at https://github.com/resolve/refinerycms/tree/master/doc

### DIFF
--- a/doc/guides/1 - Getting Started/1 - Getting Started with Refinery.textile
+++ b/doc/guides/1 - Getting Started/1 - Getting Started with Refinery.textile
@@ -439,6 +439,6 @@ Now that you've made your first Refinery application with a custom events engine
 
 If you need assistance getting up and running with Refinery follow the "How to get help with Refinery Guide":/guides/how-to-get-help-with-refinery and for professional support & consulting contact "Resolve Digital":http://resolvedigital.com/ (the creators of Refinery).
 
-p(#fn1). If you want to know more about the Engine's file structure, check out the "separate documentation on Engines":https://github.com/resolve/refinerycms/blob/master/doc/engines.md.
+fn1. If you want to know more about the Engine's file structure, check out the "separate documentation on Engines":https://github.com/resolve/refinerycms/blob/master/doc/engines.md.
 
-p(#fn2). There's a "separate doc on configuring and overriding Crudify":https://github.com/resolve/refinerycms/blob/master/doc/crud.md.
+fn2. There's a "separate doc on configuring and overriding Crudify":https://github.com/resolve/refinerycms/blob/master/doc/crud.md.


### PR DESCRIPTION
There are 8 orphan docs at https://github.com/resolve/refinerycms/tree/master/doc: 

file     authentication.md       February 17, 2011       Reduce line sizes for fixed width editors. [parndt]
file    crud.md     March 09, 2011  Added xhr_paging as an option in crudify which han... [parndt]
file    dashboard.md    February 16, 2011   Added some sample guides to help test things out. [stevenheidel]
file    engines.md  March 28, 2011  fix links to crudify docs [Tony Collen]
file    images.md   February 17, 2011   Reduce line sizes for fixed width editors. [parndt]
file    pages.md    February 17, 2011   Reduce line sizes for fixed width editors. [parndt]
file    resources.md    February 17, 2011   Reduce line sizes for fixed width editors. [parndt]
file    settings.md     February 17, 2011   Reduce line sizes for fixed width editors. [parndt] 

I discovered them by Googling and thought it was a pity they were not on the main site with the guides.
So I inserted links to them in the "Getting Started Guide": linked to the 6 "engines Refinery comes with" and put links to the technical documentation on Engines and Crudify in the footnotes.

(BTW rendering footnotes from Textile doesn't seem to be fully implemented in Github yet - I guess that's just a matter of time).
