### PR TITLE
Strip Non ASCII preference for slugs

### DIFF
--- a/pages/app/models/page.rb
+++ b/pages/app/models/page.rb
@@ -48,7 +48,8 @@ class Page < ActiveRecord::Base
   has_friendly_id :title, :use_slug => true,
                   :default_locale => (::Refinery::I18n.default_frontend_locale rescue :en),
                   :reserved_words => %w(index new session login logout users refinery admin images wymiframe),
-                  :approximate_ascii => RefinerySetting.find_or_set(:approximate_ascii, false, :scoping => "pages")
+                  :approximate_ascii => RefinerySetting.find_or_set(:approximate_ascii, false, :scoping => "pages"),
+                  :strip_non_ascii => RefinerySetting.find_or_set(:strip_non_ascii, false, :scoping => "pages")
 
   has_many :parts,
            :class_name => "PagePart",


### PR DESCRIPTION
Hi,

I can create page titles containing non-ASCII characters, but would like the resulting slugs to contain only ASCII.
