### PR TITLE
Prevent new page parts dialog being removed on save

### DIFF
--- a/core/public/javascripts/refinery/admin.js
+++ b/core/public/javascripts/refinery/admin.js
@@ -725,7 +725,6 @@ var page_options = {
               page_options.tabs.find('> ul li a').corner('top 5px');
 
               $('#new_page_part_dialog').dialog('close');
-              $('#new_page_part_dialog').remove();
             }
           );
         }else{


### PR DESCRIPTION
Add new page parts dialog should remain in the dom to allow multiple new parts per save.
Re: https://github.com/resolve/refinerycms/issues/615#issuecomment-1003480
