### PR TITLE
Raw html strings in shared partials should use #html_save.

### DIFF
--- a/core/app/views/shared/_content_page.html.erb
+++ b/core/app/views/shared/_content_page.html.erb
@@ -48,9 +48,9 @@
     dom_id = section[:id] || section[:yield]
     if section[:html].present?
       if section[:title]
-        section[:html] = "<h1 id='#{dom_id}'>#{section[:html]}</h1>"
+        section[:html] = "<h1 id='#{dom_id}'>#{section[:html]}</h1>".html_safe
       else
-        section[:html] = "<section id='#{dom_id}'><div class='inner'>#{section[:html]}</div></section>"
+        section[:html] = "<section id='#{dom_id}'><div class='inner'>#{section[:html]}</div></section>".html_safe
       end
     else
       css << "no_#{dom_id}"

--- a/core/app/views/shared/_menu_branch.html.erb
+++ b/core/app/views/shared/_menu_branch.html.erb
@@ -1,12 +1,12 @@
 <%
   if !!local_assigns[:apply_css] and (classes = menu_branch_css(local_assigns)).any?
-    css = "class='#{classes.join(' ')}'"
+    css = "class='#{classes.join(' ')}'".html_safe
   end
-  dom_id = "id='item_#{menu_branch_counter}'"
+  dom_id = "id='item_#{menu_branch_counter}'".html_safe
 
   children = menu_branch.children.live.in_menu unless hide_children
 -%>
-<li<%= ['', css, dom_id].compact.join(' ').gsub(/\ *$/, '') %>>
+<li<%= ['', css, dom_id].compact.join(' ').gsub(/\ *$/, '').html_safe %>>
   <%= link_to menu_branch.title, menu_branch.url -%>
   <% if children.present? -%>
     <ul class='clearfix'>


### PR DESCRIPTION
Hi, I added `html_save` to the _raw_ html strings on the shared/ partials. I realize it's not such a big deal on ERB, but with other template engines such as haml that's not being rendered properly...

Check it out, and merge it if you guys think it's okay...

Cheers,
