### PR TITLE
Removed titleize from dashboard page titles

### DIFF
--- a/dashboard/app/views/admin/dashboard/_recent_activity.html.erb
+++ b/dashboard/app/views/admin/dashboard/_recent_activity.html.erb
@@ -1,5 +1,5 @@
 <div id='recent_activity'>
-  <h2><%= t('.latest_activity').titleize %></h2>
+  <h2><%= t('.latest_activity') %></h2>
   <% if (activity = @recent_activity.collect{|a| activity_message_for(a) rescue ''}.reject(&:blank?)).present? %>
     <ul class='clickable'>
     <% activity.each do |message| %>

--- a/dashboard/app/views/admin/dashboard/index.html.erb
+++ b/dashboard/app/views/admin/dashboard/index.html.erb
@@ -3,7 +3,7 @@
     <%= render :partial => 'records' %>
   </section>
   <aside id='actions'>
-    <h2><%= t('.quick_tasks').titleize %></h2>
+    <h2><%= t('.quick_tasks') %></h2>
     <%= render :partial => 'actions' %>
   </aside>
 </div>

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -6,7 +6,7 @@ en:
   admin:
     dashboard:
       index:
-        quick_tasks: Quick tasks
+        quick_tasks: Quick Tasks
       actions:
         add_a_new_page: Add a new page
         update_a_page: Update a page
@@ -16,7 +16,7 @@ en:
         see_home_page: See home page
       recent_activity:
         empty: There has not been any activity recently.
-        latest_activity: Latest activity
+        latest_activity: Latest Activity
         latest_activity_message: '%{what} %{kind} was %{action}'
       recent_inquiries:
         latest_inquiries: Latest inquiries


### PR DESCRIPTION
The reason for this change is localization: in many languages, the output of titleize is grammatically incorrect.

(In addition, edited the English locale so that the titles appear the same as before.)
