### PR TITLE
Fixing issue #662; the to_run string should not be altered through a '|'

### DIFF
--- a/bin/refinerycms
+++ b/bin/refinerycms
@@ -374,7 +374,7 @@ module Refinery
 
       if Refinery::WINDOWS
         to_run = ['"'] + to_run + ['"']
-        to_run = %w(cmd /c) | to_run.map{|c| c.gsub(/\//m, '\\')}
+        to_run = %w(cmd /c) + to_run.map{|c| c.gsub(/\//m, '\\')}
       end
 
       to_run = to_run.join(' ')


### PR DESCRIPTION
Fixing issue #662 by making the to_run string not be altered through a "|", which removed the last character.
