### PR TITLE
Adding a few helpers for cleaning up the _content_page.html.erb partial.

### DIFF
--- a/core/app/views/shared/_content_page.html.erb
+++ b/core/app/views/shared/_content_page.html.erb
@@ -1,41 +1,18 @@
-<%
-  # provide a default array for collecting CSS for sections
+<%- sections = page_sections(@page, local_assigns) -%>
+
+<%#= page_body_content do -%>
+  <%#- sections.collect{|section| section[:html] = yield(section[:yield])} -%>
+  <%#- sections.collect do |section| -%>
+    <%#= page_html(section, local_assigns) -%>
+  <%#- end -%>
+<%#- end -%>
+
+<%#- Backwards compatibility block:
+     Remove the following section and uncomment
+     the above page helpers on new applications.
+-%>
+<%-
   css = []
-
-  # if 'sections' is passed in as a local_assigns, all of this is ignored.
-  if local_assigns[:sections].blank?
-    # always have a title
-    sections = [{:yield => :body_content_title, :fallback => page_title, :title => true}]
-
-    # append sections from this page.
-    @page.parts.inject(sections) do |s, part|
-      # we have some default yields, body_content_left and body_content_right
-      # these map to 'body' and 'side_body' fields in default Refinery.
-      section = {:fallback => part.body}
-      section[:yield] = case (title_symbol = part.title.to_s.gsub(/\ /, '').underscore.to_sym)
-        when :body then :body_content_left
-        when :side_body then :body_content_right
-        else title_symbol
-        end
-
-      # add section to the list unless we were specifically requested not to.
-      # otherwise, add css saying it's been removed.
-      unless (local_assigns[:hide_sections]||=[]).include?(section[:yield])
-        s << section
-      else
-        css << "no_#{section[:yield]}"
-      end
-    end unless @page.nil? or @page.parts.blank?
-
-    # Ensure that even without @page.parts we still have body_content_left and body_content_right
-    all_yields = sections.collect{|s| s[:yield]}
-    sections << {:yield => :body_content_left} unless all_yields.include?(:body_content_left)
-    sections << {:yield => :body_content_right} unless all_yields.include?(:body_content_right)
-  end
-
-  # you can add more sections to the list using something like this:
-  # sections |= [{:yield => :something_else, :fallback => another_method, :id => 'something'}]
-
   sections.each do |section|
     section[:html] = yield(section[:yield]) if section[:yield].present?
 
@@ -57,7 +34,10 @@
     end
   end
 -%>
+
 <section id='body_content'<%= " class='#{css.join(' ')}'" if css.present? %>>
   <%= raw sections.map{|section| section[:html]}.join("\n") -%>
 </section>
+<%#- End BC -%>
+
 <%= render :partial => '/shared/draft_page_message' unless @page.nil? or @page.live? -%>

--- a/core/lib/refinery/application_helper.rb
+++ b/core/lib/refinery/application_helper.rb
@@ -14,6 +14,7 @@ module Refinery
       base.send :include, Refinery::Helpers::SiteBarHelper
       base.send :include, Refinery::Helpers::TagHelper
       base.send :include, Refinery::Helpers::TranslationHelper
+      base.send :include, Refinery::Helpers::PageHelper
     end
   end
 end

--- a/core/lib/refinery/helpers/page_helper.rb
+++ b/core/lib/refinery/helpers/page_helper.rb
@@ -1,0 +1,72 @@
+module Refinery
+  module Helpers
+    module PageHelper
+
+      def page_sections(page, local_assigns={})
+        if local_assigns[:sections].blank?
+          # always have a title
+          sections = [{:yield => :body_content_title,
+              :fallback => page_title,
+              :title => true}]
+          # append sections from this page.
+          page.parts.inject(sections) do |s, part|
+            # we have some default yields,
+            # body_content_left and body_content_right these
+            # map to 'body' and 'side_body' fields in default Refinery.
+            section = {:fallback => part.body}
+            title_symbol = part.title.to_s.gsub(/\ /, '').underscore.to_sym
+            section[:yield] = case (title_symbol)
+                              when :body then :body_content_left
+                              when :side_body then :body_content_right
+                              else title_symbol
+                              end
+
+            # add section to the list unless
+            # we were specifically requested not to.
+            if !(local_assigns[:hide_sections]||=[]).include?(section[:yield])
+              s << section
+            end
+          end unless page.nil? or page.parts.blank?
+
+          # Ensure that even without @page.parts we
+          # still have body_content_left and body_content_right.
+          all_yields = sections.collect{|s| s[:yield]}
+            sections << {:yield => :body_content_left} unless \
+          all_yields.include?(:body_content_left)
+            sections << {:yield => :body_content_right} unless \
+          all_yields.include?(:body_content_right)
+        end
+        sections
+      end
+
+      def page_html(section=[], local_assigns={})
+        if section[:html].blank? \
+          and !local_assigns[:show_empty_sections] \
+          and !local_assigns[:remove_automatic_sections] \
+          and section.keys.include?(:fallback) \
+          and section[:fallback].present?
+            section[:html] = raw(section[:fallback])
+        end
+
+        raw_html = section[:html]
+        dom_id = section[:id] || section[:yield]
+
+        if section[:title]
+          content_tag(:h1, raw_html.html_safe, :id => dom_id)
+        else
+          content_tag :div, :id => dom_id, do
+            content_tag(:section, raw_html.html_safe, :class => 'inner')
+          end
+        end
+      end
+
+      def page_body_content(&block)
+        if block_given?
+          content = capture(&block)
+          content_tag :section, content, :id => 'body_content'
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Hi, in this commit I'm adding a page_helper with a few methods meant to
clean up the `_content_page.html.erb`. I think that moving the block of
Ruby code on top of this partial, would help in order to add flexibility
and maybe in the long run to refactor or extend Refinery.

Another important thing (IMHO) is that other template engines such as
Haml would benefit, since they would not have to do it any way.

I also left part of the Ruby "block of code" in the
`_content_page.html.erb` for backwards compatibility.

Check it out, and merge it if you guys think is okay.

Cheers,
