### PR TITLE
Minor fix for the menu helper

### DIFF
--- a/core/lib/refinery/helpers/menu_helper.rb
+++ b/core/lib/refinery/helpers/menu_helper.rb
@@ -84,7 +84,7 @@ module Refinery
 
         # Ensure we match the path without the locale, if present.
         if defined?(::Refinery::I18n) and ::Refinery::I18n.enabled? and path =~ %r{^/#{::I18n.locale}/}
-          path = path.split(%r{^/#{::I18n.locale}/}).last
+          path = path.split(%r{^/#{::I18n.locale}}).last
           path = "/" if path.blank?
         end
 


### PR DESCRIPTION
I noticed a funny bug related to localization today: When a page slug incidentally includes the default locale string as the first two characters, the css class "selected" is not properly assigned (and consequently the menu shows weird behaviour).

For example:
- default locale is "en"
- page title is "engine"
- visit ...refinerycms.com/engine

Obviously it's a simple Regex issue I fixed with this commit.

Thanks for your consideration and the excellent job you guys are doing!

Best,
Boris
