### PR TITLE
Suggest in the gemfile that you should use Fog if you want Heroku and AWS.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,9 @@ gem 'mysql2', '~> 0.2.7'
 # For Heroku/s3:
 # gem 'aws-s3', :require => 'aws/s3'
 
+# Use Fog to play nice with cloud services (recommended for Heroku/s3)
+# gem 'fog'
+
 # REFINERY CMS ================================================================
 # Anything you put in here will be overridden when the app gets updated.
 


### PR DESCRIPTION
without fog, if you're using heroku you could not upgrade to the latest version of refinery without fog. Suggesting it in the gemfile.
