### PR TITLE
remove unnecessary group() in Page translations arel chain

### DIFF
--- a/pages/app/models/page.rb
+++ b/pages/app/models/page.rb
@@ -94,7 +94,7 @@ class Page < ActiveRecord::Base
         end
       end
       # A join implies readonly which we don't really want.
-      joins(:translations).where(globalized_conditions).where(conditions).group(self.arel_table[:id]).readonly(false)
+      joins(:translations).where(globalized_conditions).where(conditions).readonly(false)
     end
   else
     def self.with_globalize(conditions = {})


### PR DESCRIPTION
remove unnecessary group() in Page translations arel chain, which was disturbing PostrgreSQL. see #709

Simplifies the query, and wasn't needed because the WHERE condition already restricts to the selected locale. Solves #709
