### PR TITLE
fix setting GA code in development mode

### DIFF
--- a/core/app/views/shared/_google_analytics.html.erb
+++ b/core/app/views/shared/_google_analytics.html.erb
@@ -1,8 +1,10 @@
-<% unless refinery_user? or
+<% unless local_request? or refinery_user? or
   (page_code = ::Refinery::Setting.find_or_set(:analytics_page_code, 'UA-xxxxxx-x').to_s.strip) =~ /^(UA-xxxxxx-x)?$/ -%>
 <!-- asynchronous google analytics: mathiasbynens.be/notes/async-analytics-snippet -->
 <script>var _gaq=[['_setAccount','<%= page_code %>'],['_trackPageview'],['_trackPageLoadTime']];(function(d,t){
 var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
 g.async=1;g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)
 }(document,'script'))</script>
+<% else %>
+<%= raw  "<!-- Google Analytics tracking code (#{RefinerySetting.find_or_set(:analytics_page_code, 'UA-xxxxxx-x')}) is included to page only in production mode and only for unsigned users. -->" %>
 <% end -%>

--- a/core/app/views/shared/_head.html.erb
+++ b/core/app/views/shared/_head.html.erb
@@ -14,7 +14,7 @@
   <%= stylesheet_link_tag "home", :theme => theme if home_page? %>
 
   <%= yield :stylesheets %>
-  <%= render :partial => '/shared/google_analytics' unless local_request? %>
+  <%= render :partial => '/shared/google_analytics' %>
 
   <%= javascript_include_tag 'modernizr-min' %>
 </head>


### PR DESCRIPTION
Via https://github.com/resolve/refinerycms/issues/721 .
Now is GA code added to administration settings always, and for coders and testers is in html inserted explanatory comment why (or when) is GA activated.
