### PR TITLE
Manually set use_filesystem to prevent calling IO.popen errors in file ty

### DIFF
--- a/images/lib/refinery/images/dragonfly.rb
+++ b/images/lib/refinery/images/dragonfly.rb
@@ -28,7 +28,9 @@ module Refinery
 
           app_images.define_macro(::ActiveRecord::Base, :image_accessor)
           app_images.analyser.register(::Dragonfly::ImageMagick::Analyser)
-          app_images.analyser.register(::Dragonfly::Analysis::FileCommandAnalyser)
+          app_images.analyser.register(::Dragonfly::Analysis::FileCommandAnalyser) do |a|
+            a.use_filesystem = true #prevents IO::Pipe errors in analysis
+          end
         end
 
         def attach!(app)


### PR DESCRIPTION
Manually set use_filesystem to prevent calling IO.popen errors in file type analysis e.g. https://github.com/resolve/refinerycms/issues/282
