### PR TITLE
Removed duplicate call of link_dialog.init()

### DIFF
--- a/resources/app/views/refinery/admin/resources/insert.html.erb
+++ b/resources/app/views/refinery/admin/resources/insert.html.erb
@@ -47,6 +47,9 @@
 <% content_for :javascripts do %>
   <script>
     $(document).ready(function(){
+	  <% unless user_can_modify_resources %>
+	    link_dialog.init();
+	  <% end %>
       resource_picker.init(<%= @callback.present? ? "self.parent.#{@callback}" : "null" %>);
     });
   </script>


### PR DESCRIPTION
In resources#insert view, which is shown in iframe within dialog, link_dialog.init() is being called twice.

Once from around line 47 of resources/app/views/refinery/admin/resources/insert.html.erb,

```
<script>
  $(document).ready(function(){
    link_dialog.init();
    resource_picker.init(<%= @callback.present? ? "self.parent.#{@callback}" : "null" %>);
  });
</script>
```

.. and twice from around line 51 of resources/app/views/refinery/admin/resources/_form.html.erb.

```
<script>
  $(document).ready(function(){
    link_dialog.init();
  });
</script>
```

Currently, behavior of link_dialog.init() (or Resources#insert dialog) is not changed by calling it twice, but this could be problematic when users customize behavior of the Resources#insert dialog (which is in my case).

BTW, thanks for your great work! :D
