### PR TITLE
HTML5 Reset

### DIFF
--- a/core/app/assets/stylesheets/refinery/application.css.scss
+++ b/core/app/assets/stylesheets/refinery/application.css.scss
@@ -1,6 +1,108 @@
-body {
-  margin: 0px;
-}
+/* HTML 5 Reset from http://html5reset.org */
+
+html, body, div, span, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, abbr, address, cite, code, del, dfn, em, img, ins, kbd, q, samp, small, strong, sub, sup, var, b, i, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, figure, footer, header, hgroup, menu, nav, section, menu, time, mark, audio, video{margin:0; padding:0; border:0; outline:0; font-size:100%; vertical-align:baseline; background:transparent}
+
+article, aside, figure, footer, header, hgroup, nav, section{display:block}
+
+img, 
+object, 
+embed{max-width:100%}
+
+html{overflow-y:scroll}
+
+ul{list-style:none}
+
+blockquote, q{quotes:none}
+
+blockquote:before, 
+blockquote:after, 
+q:before, 
+q:after{content:''; content:none}
+
+a{margin:0; padding:0; font-size:100%; vertical-align:baseline; background:transparent}
+
+del{text-decoration:line-through}
+
+abbr[title], dfn[title]{border-bottom:1px dotted #000; cursor:help}
+
+table{border-collapse:collapse; border-spacing:0}
+th{font-weight:bold; vertical-align:bottom}
+td{font-weight:normal; vertical-align:top}
+
+hr{display:block; height:1px; border:0; border-top:1px solid #ccc; margin:1em 0; padding:0}
+
+input, select{vertical-align:middle}
+
+pre{white-space:pre; white-space:pre-wrap; white-space:pre-line; word-wrap:break-word; /* IE */}
+
+input[type="radio"]{vertical-align:text-bottom}
+input[type="checkbox"]{vertical-align:bottom; *vertical-align:baseline}
+.ie6 input{vertical-align:text-bottom}
+
+select, input, textarea{font:99% sans-serif}
+
+table{font-size:inherit; font:100%}
+ 
+a:hover, a:active{outline:none}
+
+small{font-size:85%}
+
+strong, th{font-weight:bold}
+
+td, td img{vertical-align:top}
+
+sub, sup{font-size:75%; line-height:0; position:relative}
+sup{top:-0.5em}
+sub{bottom:-0.25em}
+
+pre, code, kbd, samp{font-family:monospace,sans-serif}
+
+.clickable, 
+label, 
+input[type=button], 
+input[type=submit], 
+button{cursor:pointer}
+
+button, input, select, textarea{margin:0}
+
+button{width:auto; overflow:visible}
+ 
+.ie7 img{-ms-interpolation-mode:bicubic}
+
+.ie6 html{filter:expression(document.execCommand("BackgroundImageCache",false,true))}
+
+.clearfix:before, .clearfix:after{content:"\0020"; display:block; height:0; overflow:hidden}
+ 
+.clearfix:after{clear:both}
+ 
+.clearfix{zoom:1}
+ 
+body{font:13px Helmet,Freesans,sans-serif}
+
+body, select, input, textarea{color:#333}
+
+a{color:#03f}
+a:hover{color:#69f}
+
+
+::-moz-selection{background:#fcd700; color:#fff; text-shadow:none}
+::selection{background:#fcd700; color:#fff; text-shadow:none}
+
+a:link{-webkit-tap-highlight-color:#fcd700}
+
+ins{background-color:#fcd700; color:#000; text-decoration:none}
+mark{background-color:#fcd700; color:#000; font-style:italic; font-weight:bold}
+
+@media print{}
+
+@media screen and (max-device-width:480px){}
+
+@media all and (orientation:portrait){}
+
+@media all and (orientation:landscape){}
+
+/* Begin other application styles */
+
 #page, #site_bar_content, footer, header {
   width: 1000px;
   margin: 0px auto;


### PR DESCRIPTION
Refinery really should have a CSS reset to make styling a little more sane for developers. I think we should include in application.css because you should reset all the styles before doing anything else. I put in the stylesheet from (http://html5reset.org) because it doesn't go changing a lot of accessibility things.

Webkit
[screenshot](http://skit.ch/bxcp)

Firefox
[screenshot](http://skit.ch/bxcq)

Check out the headers on these screenshots and you can see they are not the same. This is Refinery out of the box.

Yes it means you have to style more stuff, but you should be doing that anyway and not trusting browser defaults which are unpredictable.
