### PR TITLE
added id to header element in templates

### DIFF
--- a/core/app/views/layouts/application.html.erb
+++ b/core/app/views/layouts/application.html.erb
@@ -1,21 +1,21 @@
 <!DOCTYPE html>
-<%= render :partial => "/refinery/html_tag" %>
-  <% site_bar = render(:partial => "/refinery/site_bar", :locals => {:head => true}) -%>
-  <%= render :partial => "/refinery/head" %>
+<%= render :partial => '/refinery/html_tag' %>
+  <% site_bar = render(:partial => '/refinery/site_bar', :locals => {:head => true}) -%>
+  <%= render :partial => '/refinery/head' %>
   <body>
     <%= site_bar -%>
-    <%= render :partial => "/refinery/ie6check" if request.env['HTTP_USER_AGENT'] =~ /MSIE/ -%>
+    <%= render :partial => '/refinery/ie6check' if request.env['HTTP_USER_AGENT'] =~ /MSIE/ -%>
     <div id="page_container">
-      <header>
-        <%= render :partial => "/refinery/header" -%>
+      <header id="header">
+        <%= render :partial => '/refinery/header' -%>
       </header>
-      <section id='page'>
+      <section id="page">
         <%= yield %>
       </section>
       <footer>
-        <%= render :partial => "/refinery/footer" -%>
+        <%= render :partial => '/refinery/footer' -%>
       </footer>
     </div>
-    <%= render :partial => "/refinery/javascripts" %>
+    <%= render :partial => '/refinery/javascripts' %>
   </body>
 </html>

--- a/core/app/views/layouts/refinery/admin.html.erb
+++ b/core/app/views/layouts/refinery/admin.html.erb
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<%= render :partial => "/refinery/html_tag" %>
+<%= render :partial => '/refinery/html_tag' %>
   <% content_for :meta, "<meta refinerycms='#{Refinery.version}' />".html_safe %>
   <%= render :partial => "refinery/admin/head" %>
-  <body class='<%= action_name %> <%= I18n.locale %>'>
+  <body class="<%= action_name %> <%= I18n.locale %>">
     <%= render :partial => '/refinery/site_bar' %>
     <div id='tooltip_container'></div>
-    <header>
+    <header id="header">
       <%= render :partial => "refinery/admin/menu" %>
     </header>
     <div id="page_container">
@@ -13,7 +13,7 @@
         <div id="content" class="clearfix">
           <div id="flash_container">
             <%= render :partial => '/refinery/no_script' %>
-            <%= render :partial => "/refinery/message" %>
+            <%= render :partial => '/refinery/message' %>
           </div>
           <%= yield %>
         </div>


### PR DESCRIPTION
Hello boys,

I added id to header element, because they not must be one per page and ID simplify manipulation and styling.

Second i change quotes in these templates to simple convention:
In html "always" use double quotes " (example: <div id="page">)
in programming language always use ' ( example: <%= render :partial => '/refinery/footer' -%>),
break these rules when neccessary (example: <% content_for :meta, "<meta refinerycms='#{Refinery.version}' />".html_safe %> ).

If you agree, i wish stay this convention in others templates and code.

This will help us have a cleaner and more beautiful code. ;-)
