### PR TITLE
Fixed syntax error

### DIFF
--- a/images/app/controllers/refinery/admin/images_controller.rb
+++ b/images/app/controllers/refinery/admin/images_controller.rb
@@ -97,8 +97,7 @@ module ::Refinery
       end
 
       def paginate_images
-        @images = @images.page(params[:page])
-                         .per(Image.per_page(from_dialog?, !@app_dialog))
+        @images = @images.page(params[:page]).per(Image.per_page(from_dialog?, !@app_dialog))
       end
 
       def restrict_controller


### PR DESCRIPTION
ImagesController contained a Ruby syntax error where a dot was placed on the wrong line
