### PR TITLE
Misc fixes in Refinery::Activity

### DIFF
--- a/core/lib/refinery/activity.rb
+++ b/core/lib/refinery/activity.rb
@@ -30,11 +30,11 @@ module Refinery
     end
 
     def base_class_name
-      self.class.name.split("::").last
+      self.class.name.demodulize
     end
 
     def url
-      "#{self.url_prefix}#{@url ||= "refinery_admin_#{self.base_class_name.underscore.downcase}_path"}"
+      "#{self.url_prefix}#{@url ||= "refinery_admin_#{self.base_class_name.underscore}_path"}"
     end
 
     def class

--- a/core/spec/lib/refinery/activity_spec.rb
+++ b/core/spec/lib/refinery/activity_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+describe Refinery::Activity do
+  before do
+    module Y
+      module Y
+        class Z
+        end
+      end
+    end
+    @activity = Refinery::Activity.new(:class => Y::Y::Z, :url_prefix => "rush")
+  end
+
+  describe "#base_class_name" do
+    it "should return the base class name, less module nesting" do
+      @activity.base_class_name.should == "Z"
+    end
+  end
+
+  describe "#url" do
+    it "should return the url" do
+      @activity.url.should == "rush_refinery_admin_z_path"
+    end
+  end
+end


### PR DESCRIPTION
Use built-in ActiveSupport method for retrieving class name. Remove underscore.downcase because underscore already downcases the string.
