### PR TITLE
Remove unused code that sets Rails::Engine.called_from

### DIFF
--- a/core/lib/refinery/plugin.rb
+++ b/core/lib/refinery/plugin.rb
@@ -14,20 +14,6 @@ module Refinery
 
       raise "A plugin MUST have a name!: #{plugin.inspect}" if plugin.name.blank?
 
-      # Set the root as Rails::Engine.called_from will always be
-      #                 vendor/engines/refinery/lib/refinery
-      new_called_from = begin
-        # Remove the line number from backtraces making sure we don't leave anything behind
-        call_stack = caller.map { |p| p.split(':')[0..-2].join(':') }
-        File.dirname(call_stack.detect { |p| p !~ %r[railties[\w\-\.]*/lib/rails|rack[\w\-\.]*/lib/rack] })
-      end
-
-      klass = Class.new(Rails::Engine)
-      klass.class_eval <<-RUBY
-        def self.called_from; "#{new_called_from}"; end
-      RUBY
-      Object.const_set(plugin.class_name.to_sym, klass)
-
       # provide a default pathname to where this plugin is using its lib directory.
       depth = RUBY_VERSION >= "1.9.2" ? 4 : 3
       plugin.pathname ||= Pathname.new(caller(depth).first.match("(.*)#{File::SEPARATOR}lib")[1])


### PR DESCRIPTION
I can't find any code that the Rails::Engine function "called_from"  that's set inside Refinery::Plugin.register

https://github.com/resolve/refinerycms/blob/master/core/lib/refinery/plugin.rb#L17-29

Tests pass with that chunk commented out. If it is used, it seems like it should only be evaluated once, not each time a plugin is registered. I can provide a patch either way.. but here's a commit that removes it.
