### PR TITLE
Make catch-all routes for marketable urls controlled by configuration switch.

### DIFF
--- a/pages/lib/pages/marketable_routes.rb
+++ b/pages/lib/pages/marketable_routes.rb
@@ -1,9 +1,10 @@
-::Refinery::Application.routes.draw do
-  match '*path' => 'pages#show'
-end
 
-# Add any parts of routes as reserved words.
 if Page.use_marketable_urls?
+  ::Refinery::Application.routes.draw do
+    match '*path' => 'pages#show'
+  end
+
+  # Add any parts of routes as reserved words.
   route_paths = ::Refinery::Application.routes.named_routes.routes.map{|name, route| route.path}
   Page.friendly_id_config.reserved_words |= route_paths.map { |path|
     path.to_s.gsub(/^\//, '').to_s.split('(').first.to_s.split(':').first.to_s.split('/')


### PR DESCRIPTION
I discussed this change with parndt on an email thread.  Making this change helps with integrating Refinery into existing apps that have the /:controller/:action/:id catch-all route already defined.  
