### PR TITLE
Edited doc/guides/8 - Tips and Tricks/3 - How to test Refinery.textile vi

### DIFF
--- a/doc/guides/8 - Tips and Tricks/3 - How to test Refinery.textile
+++ b/doc/guides/8 - Tips and Tricks/3 - How to test Refinery.textile
@@ -9,6 +9,10 @@ endprologue.
 
 h3. Running the Tests
 
+Edit your Gemfile to un-comment the line with the refinerycms_testing gem (around line 42) 
+Then type @bundle install@
+then, @rails generate refinerycms_testing@
+
 At your application root run:
 
 <shell>
@@ -31,7 +35,7 @@ $ rake spec
 
 h3. What do I do if tests fail?
 
-Check the error message to see if it is a problem on your end.
+Check the error message to see if it is a problem on your end. Check local versions of gems and consider creating a fresh gemset if using RVM. You may need to use @bundle exec rake@
 
 If not, then "file an issue on GitHub":https://github.com/resolve/refinerycms/issues, with your version of Ruby and OS included. Bonus points if you fix it yourself!
 


### PR DESCRIPTION
Edited doc/guides/8 - Tips and Tricks/3 - How to test Refinery.textile via GitHub

The guide at https://github.com/resolve/refinerycms/blob/master/doc/guides/8%20-%20Tips%20and%20Tricks/3%20-%20How%20to%20test%20Refinery.textile

seems out of date. There are no rake tasks for cucumber and spec out of the box.

If I un-comment the refinerycms_testing gem in Gemfile, and run rails generate refinerycms_testing it works
