### PR TITLE
Fix plugin translation

### DIFF
--- a/core/lib/refinery/plugin.rb
+++ b/core/lib/refinery/plugin.rb
@@ -36,12 +36,12 @@ module Refinery
 
     # Returns the internationalized version of the title
     def title
-      ::I18n.translate(['plugins', name, 'title'].join('.'))
+      ::I18n.translate(['refinery', 'plugins', name, 'title'].join('.'))
     end
 
     # Returns the internationalized version of the description
     def description
-      ::I18n.translate(['plugins', name, 'description'].join('.'))
+      ::I18n.translate(['refinery', 'plugins', name, 'description'].join('.'))
     end
 
     # Retrieve information about how to access the latest activities of this plugin.


### PR DESCRIPTION
My admin dashboard tabs all had undefined translations.  Plugins weren't using the refinery translation namespace.
