### PR TITLE
Use asset_host for url returned from image picker dialog

### DIFF
--- a/images/app/views/admin/images/_existing_image.html.erb
+++ b/images/app/views/admin/images/_existing_image.html.erb
@@ -8,11 +8,11 @@
 <%
       @images.each do |image|
         thumbnail_urls = {
-          :"data-original" => image.url,
-          :"data-grid" => image.thumbnail('135x135#c').url
+          :"data-original" => compute_public_path(image.url, ''),
+          :"data-grid" => compute_public_path(image.thumbnail('135x135#c').url, '')
         }
         ::Image.user_image_sizes.sort_by{|key,geometry| geometry}.each do |size, pixels|
-          thumbnail_urls[:"data-#{size.to_s.parameterize}"] = image.thumbnail(pixels).url
+          thumbnail_urls[:"data-#{size.to_s.parameterize}"] = compute_public_path(image.thumbnail(pixels).url, '')
         end
 -%>
         <li<%= " class='selected'" if @image_id == image.id %>>


### PR DESCRIPTION
Use asset_host for url returned from image picker dialog

It was returning a path always, even if you set asset_host.

Now it will return a url with host when asset_host is defined, and it will continue returning a path when asset_host is not defined
