### PR TITLE
Changed 'User-agent' casing to maximise crawler compatibility.

### DIFF
--- a/core/public/robots.txt
+++ b/core/public/robots.txt
@@ -1,2 +1,2 @@
-User-Agent: *
+User-agent: *
 Disallow: /refinery/


### PR DESCRIPTION
Ran the robots.txt through a validator on a site and it suggested making the "User-agent" casing the same as to match the specification. It's not case sensitive, but there may be poorly implemented spiders which rely on the example casing in the specification.
