### PR TITLE
Added a section for running tests in translation guide 

### DIFF
--- a/doc/guides/3 - Essentials/3 - Translate Refinery into your language.textile
+++ b/doc/guides/3 - Essentials/3 - Translate Refinery into your language.textile
@@ -57,6 +57,16 @@ TIP: If you're starting a new translation, copy +en.yml+ to "your_locale".yml</p
 
 WARNING: Make sure you change +en:+ to your locale's key at the top of "your_locale".yml to avoid overriding the English translation (e.g. +nl:+)
 
+h3. Run the Refinery tests
+
+Run the Refinery tests to be sure you produced valid YAML or didn't break something.
+
+<shell>
+$ rake
+</shell>
+
+If this doesn't work. Follow the "How to test Refinery guide":/guides/how-to-test-refinery
+
 h3. Commit & Push
 
 Add the modified files to the git repository


### PR DESCRIPTION
It is helpful if running tests is explicitly mentioned in the translation guide like in 'how to contribute'. This way translators might be more careful.
