### PR TITLE
Move initialization code for Dragonfly from the Image and Resource model 

### DIFF
--- a/images/app/models/refinery/image.rb
+++ b/images/app/models/refinery/image.rb
@@ -1,7 +1,3 @@
-# encoding: utf-8
-require 'refinery/images/dragonfly'
-::Refinery::Images::Dragonfly.setup!
-
 module Refinery
   class Image < ActiveRecord::Base
 

--- a/images/lib/refinerycms-images.rb
+++ b/images/lib/refinerycms-images.rb
@@ -18,7 +18,8 @@ module Refinery
     class Engine < ::Rails::Engine
       isolate_namespace ::Refinery
 
-      initializer 'images-with-dragonfly' do |app|
+      initializer 'images-with-dragonfly', :before => :load_config_initializers do |app|
+        ::Refinery::Images::Dragonfly.setup!
         ::Refinery::Images::Dragonfly.attach!(app)
       end
 

--- a/images/spec/models/refinery/image_spec.rb
+++ b/images/spec/models/refinery/image_spec.rb
@@ -31,6 +31,11 @@ module Refinery
       end
 
       it "should use right geometry when given a thumbnail name" do
+        ::Refinery::Setting.find_or_set(:user_image_sizes, {
+          :small => '110x110>',
+          :medium => '225x255>',
+          :large => '450x450>'
+        }, :destroyable => false)
         name, geometry = ::Refinery::Image.user_image_sizes.first
         image.thumbnail(name).url.should == image.thumbnail(geometry).url
       end

--- a/resources/app/models/refinery/resource.rb
+++ b/resources/app/models/refinery/resource.rb
@@ -1,6 +1,3 @@
-require 'refinery/resources/dragonfly'
-::Refinery::Resources::Dragonfly.setup!
-
 module ::Refinery
   class Resource < ActiveRecord::Base
 

--- a/resources/lib/refinerycms-resources.rb
+++ b/resources/lib/refinerycms-resources.rb
@@ -18,7 +18,8 @@ module Refinery
     class Engine < ::Rails::Engine
       isolate_namespace ::Refinery
 
-      initializer 'resources-with-dragonfly', :before => "init plugin" do |app|
+      initializer 'resources-with-dragonfly', :before => :load_config_initializers do |app|
+        ::Refinery::Resources::Dragonfly.setup!
         ::Refinery::Resources::Dragonfly.attach!(app)
       end
 


### PR DESCRIPTION
Move initialization code for Dragonfly from the Image and Resource model into an initializer
Image and Resource iniitialization will occur before load_config_initializers to enable developers to override Dragonfly's configuration
