### PR TITLE
Only run dragonfly monkeypatch if refinery images engine is loaded

### DIFF
--- a/core/config/initializers/dragonfly_monkeypatch.rb
+++ b/core/config/initializers/dragonfly_monkeypatch.rb
@@ -1,10 +1,12 @@
 # TODO: remove this monkeypatch as soon as
 # https://github.com/markevans/dragonfly/pull/99 gets merged in
 # and new version of dragonfly gets released.
-module Dragonfly
-  module ActiveModelExtensions
-    class Attachment
-      alias_method :length, :size
+if defined?(::Refinery::Image) && ::Refinery::Image.respond_to?(:dragonfly)
+  module Dragonfly
+    module ActiveModelExtensions
+      class Attachment
+        alias_method :length, :size
+      end
     end
   end
 end


### PR DESCRIPTION
This ensure that core can be run independently without images engine.
