### PR TITLE
Fix for [DEPRECATION WARNING] Nested I18n namespace lookup under "activer

### DIFF
--- a/authentication/config/locales/bg.yml
+++ b/authentication/config/locales/bg.yml
@@ -62,14 +62,12 @@ bg:
       signed_in: Успешен вход в системата.
   activerecord:
     models:
-      refinery:
-        user: потребител
+      refinery/user: потребител
     attributes:
-      refinery:
-        user:
-          login: Вход
-          username: Потребителско име
-          password: Парола
-          password_confirmation: Потвърждение на паролата
-          email: Е-поща
-          remember_me: Запомняне данните за вход
+      refinery/user:
+        login: Вход
+        username: Потребителско име
+        password: Парола
+        password_confirmation: Потвърждение на паролата
+        email: Е-поща
+        remember_me: Запомняне данните за вход

--- a/authentication/config/locales/cs.yml
+++ b/authentication/config/locales/cs.yml
@@ -65,14 +65,12 @@ cs:
       signed_in: Úspěšné přihlášení.
   activerecord:
     models:
-      refinery:
-        user: uživatel
+      refinery/user: uživatel
     attributes:
-      refinery:
-        user:
-          login: Přihlásit
-          email: Email
-          username: Uživatelské jméno
-          password: Heslo
-          password_confirmation: Potvrdit heslo
-          remember_me: Zapamatovat heslo
+      refinery/user:
+        login: Přihlásit
+        email: Email
+        username: Uživatelské jméno
+        password: Heslo
+        password_confirmation: Potvrdit heslo
+        remember_me: Zapamatovat heslo

--- a/authentication/config/locales/da.yml
+++ b/authentication/config/locales/da.yml
@@ -62,14 +62,12 @@ da:
       signed_in: Du er nu logget ind.
   activerecord:
     models:
-      refinery:
-        user: bruger
+      refinery/user: bruger
     attributes:
-      refinery:
-        user:
-          login: Log ind
-          username: Brugernavn
-          password: Adgangskode
-          password_confirmation: Bekræft adgangskode
-          email: Email
-          remember_me: Husk mig
+      refinery/user:
+        login: Log ind
+        username: Brugernavn
+        password: Adgangskode
+        password_confirmation: Bekræft adgangskode
+        email: Email
+        remember_me: Husk mig

--- a/authentication/config/locales/de.yml
+++ b/authentication/config/locales/de.yml
@@ -62,14 +62,12 @@ de:
       signed_in: Erfolgreich angemeldet.
   activerecord:
     models:
-      refinery:
-        user: Benutzer
+      refinery/user: Benutzer
     attributes:
-      refinery:
-        user:
-          login: Login
-          username: Benutzername
-          password: Passwort
-          password_confirmation: Passwort Bestätigung
-          email: E-Mail
-          remember_me: Login merken
+      refinery/user:
+        login: Login
+        username: Benutzername
+        password: Passwort
+        password_confirmation: Passwort Bestätigung
+        email: E-Mail
+        remember_me: Login merken

--- a/authentication/config/locales/el.yml
+++ b/authentication/config/locales/el.yml
@@ -62,14 +62,12 @@ el:
       signed_in: Συνδεθείκατε επιτυχώς.
   activerecord:
     models:
-      refinery:
-        user: χρήστης
+      refinery/user: χρήστης
     attributes:
-      refinery:
-        user:
-          login: Login
-          username: Όνομα χρήστη
-          password: Κωδικός
-          password_confirmation: Επιβεβαίωση Κωδικού
-          email: Email
-          remember_me: Θυμήσου με
+      refinery/user:
+        login: Login
+        username: Όνομα χρήστη
+        password: Κωδικός
+        password_confirmation: Επιβεβαίωση Κωδικού
+        email: Email
+        remember_me: Θυμήσου με

--- a/authentication/config/locales/en.yml
+++ b/authentication/config/locales/en.yml
@@ -62,14 +62,12 @@ en:
       signed_in: Signed in successfully.
   activerecord:
     models:
-      refinery:
-        user: user
+      refinery/user: user
     attributes:
-      refinery:
-        user:
-          login: Login
-          username: Username
-          password: Password
-          password_confirmation: Password confirmation
-          email: Email
-          remember_me: Remember me
+      refinery/user:
+        login: Login
+        username: Username
+        password: Password
+        password_confirmation: Password confirmation
+        email: Email
+        remember_me: Remember me

--- a/authentication/config/locales/es.yml
+++ b/authentication/config/locales/es.yml
@@ -56,17 +56,15 @@ es:
       refinery: Refinery
   activerecord:
     models:
-      refinery:
-        user: usuario
+      refinery/user: usuario
     attributes:
-      refinery:
-        user:
-          login: Usuario
-          username: Usuario
-          email: E-mail
-          password: Contraseña
-          password_confirmation: Confirmar contraseña
-          remember_me: Recordarme
+      refinery/user:
+        login: Usuario
+        username: Usuario
+        email: E-mail
+        password: Contraseña
+        password_confirmation: Confirmar contraseña
+        remember_me: Recordarme
   devise:
     failure:
       unauthenticated: 'Necesitas acceder a tu cuenta o registrarte antes de continuar.'

--- a/authentication/config/locales/fi.yml
+++ b/authentication/config/locales/fi.yml
@@ -62,14 +62,12 @@ fi:
       signed_in: Kirjautuminen onnistui.
   activerecord:
     models:
-      refinery:
-        user: käyttäjä
+      refinery/user: käyttäjä
     attributes:
-      refinery:
-        user:
-          login: Käyttäjätunnus
-          username: Käyttäjätunnus
-          password: Salasana
-          password_confirmation: Salasana (uudelleen)
-          email: Sähköpostiosoite
-          remember_me: Muista kirjautumiseni tällä tietokoneella
+      refinery/user:
+        login: Käyttäjätunnus
+        username: Käyttäjätunnus
+        password: Salasana
+        password_confirmation: Salasana (uudelleen)
+        email: Sähköpostiosoite
+        remember_me: Muista kirjautumiseni tällä tietokoneella

--- a/authentication/config/locales/fr.yml
+++ b/authentication/config/locales/fr.yml
@@ -62,14 +62,12 @@ fr:
       signed_in: Réussite de la connexion.
   activerecord:
     models:
-      refinery:
-        user: utilisateur
+      refinery/user: utilisateur
     attributes:
-      refinery:
-        user:
-          login: Nom d'utilisateur
-          username: Nom d'utilisateur
-          email: E-mail
-          password: Mot de passe
-          password_confirmation: Confirmer mot de passe
-          remember_me: Se souvenir de moi
+      refinery/user:
+        login: Nom d'utilisateur
+        username: Nom d'utilisateur
+        email: E-mail
+        password: Mot de passe
+        password_confirmation: Confirmer mot de passe
+        remember_me: Se souvenir de moi

--- a/authentication/config/locales/it.yml
+++ b/authentication/config/locales/it.yml
@@ -53,12 +53,11 @@ it:
         remain_same_if_no_action: "La password rimarrà la stessa se non si effettua una scelta"
   activerecord:
     attributes:
-      refinery:
-        user:
-          login: accesso
-          email: email
-          password: password
-          remember_me: Ricordati di me
+      refinery/user:
+        login: accesso
+        email: email
+        password: password
+        remember_me: Ricordati di me
   devise:
     failure:
       unauthenticated: "Devi accedere o registrarti per continuare."

--- a/authentication/config/locales/jp.yml
+++ b/authentication/config/locales/jp.yml
@@ -62,14 +62,12 @@ jp:
       signed_in: サインインしました。
   activerecord:
     models:
-      refinery:
-        user: ユーザ
+      refinery/user: ユーザ
     attributes:
-      refinery:
-        user:
-          login: ログイン
-          username: アカウント名
-          password: パスワード
-          password_confirmation: パスワードの確認
-          email: メールアドレス
-          remember_me: ユーザ情報を記憶する
+      refinery/user:
+        login: ログイン
+        username: アカウント名
+        password: パスワード
+        password_confirmation: パスワードの確認
+        email: メールアドレス
+        remember_me: ユーザ情報を記憶する

--- a/authentication/config/locales/ko.yml
+++ b/authentication/config/locales/ko.yml
@@ -62,14 +62,12 @@ ko:
       signed_in: 로그인에 성공했습니다.
   activerecord:
     models:
-      refinery:
-        user: 사용자
+      refinery/user: 사용자
     attributes:
-      refinery:
-        user:
-          login: 아이디
-          username: 아이디
-          password: 비밀번호
-          password_confirmation: 비밀번호 확인
-          email: 이메일
-          remember_me: 자동접속
+      refinery/user:
+        login: 아이디
+        username: 아이디
+        password: 비밀번호
+        password_confirmation: 비밀번호 확인
+        email: 이메일
+        remember_me: 자동접속

--- a/authentication/config/locales/lolcat.yml
+++ b/authentication/config/locales/lolcat.yml
@@ -47,12 +47,10 @@ lolcat:
         subject: LINK 2 RESET UR PASWORD
   activerecord:
     models:
-      refinery:
-        user: USR
+      refinery/user: USR
     attributes:
-      refinery:
-        user:
-          login: LOGIN
-          email: EMAIL
-          password: PASWORD
-          remember_me: REMEMBR ME
+      refinery/user:
+        login: LOGIN
+        email: EMAIL
+        password: PASWORD
+        remember_me: REMEMBR ME

--- a/authentication/config/locales/lt.yml
+++ b/authentication/config/locales/lt.yml
@@ -47,12 +47,10 @@ lt:
         subject: Nuoroda slaptažodžio keitimui
   activerecord:
     models:
-      refinery:
-        user: vartotojas
+      refinery/user: vartotojas
     attributes:
-      refinery:
-        user:
-          login: Prisijungti
-          email: El. paštas
-          password: Slaptažodis
-          remember_me: Prisiminti mane
+      refinery/user:
+        login: Prisijungti
+        email: El. paštas
+        password: Slaptažodis
+        remember_me: Prisiminti mane

--- a/authentication/config/locales/lv.yml
+++ b/authentication/config/locales/lv.yml
@@ -62,14 +62,12 @@ lv:
       signed_in: Autentifikācija noritēja veiksmīgi.
   activerecord:
     models:
-      refinery:
-        user: lietotājs
+      refinery/user: lietotājs
     attributes:
-      refinery:
-        user:
-          login: Lietotāja vārds/Epasts
-          username: Lietotāja vārds
-          password: Parole
-          password_confirmation: Parole atkārtoti
-          email: Epasts
-          remember_me: Atcerēties mani
+      refinery/user:
+        login: Lietotāja vārds/Epasts
+        username: Lietotāja vārds
+        password: Parole
+        password_confirmation: Parole atkārtoti
+        email: Epasts
+        remember_me: Atcerēties mani

--- a/authentication/config/locales/nb.yml
+++ b/authentication/config/locales/nb.yml
@@ -62,14 +62,12 @@ nb:
       signed_in: Du er nå logget inn.
   activerecord:
       models:
-        refinery:
-          user: bruker
+        refinery/user: bruker
       attributes:
-        refinery:
-          user:
-            login: Logg inn
-            username: Brukernavn
-            password: Passord
-            password_confirmation: Bekreft passord
-            email: E-post
-            remember_me: Husk meg
+        refinery/user:
+          login: Logg inn
+          username: Brukernavn
+          password: Passord
+          password_confirmation: Bekreft passord
+          email: E-post
+          remember_me: Husk meg

--- a/authentication/config/locales/nl.yml
+++ b/authentication/config/locales/nl.yml
@@ -62,12 +62,10 @@ nl:
       signed_in: Je bent ingelogd.
   activerecord:
     models:
-      refinery:
-        user: gebruiker
+      refinery/user: gebruiker
     attributes:
-      refinery:
-        user:
-          login: Gebruikersnaam
-          email: e-mail
-          password: Wachtwoord
-          remember_me: Onthoud mijn gegevens
+      refinery/user:
+        login: Gebruikersnaam
+        email: e-mail
+        password: Wachtwoord
+        remember_me: Onthoud mijn gegevens

--- a/authentication/config/locales/pl.yml
+++ b/authentication/config/locales/pl.yml
@@ -54,15 +54,13 @@ pl:
         remain_same_if_no_action: Twoje hasło nie zostanie zmienione jeśli nie odwiedzisz strony
   activerecord:
     models:
-      refinery:
-        user: użytkownik
+      refinery/user: użytkownik
     attributes:
-      refinery:
-        user:
-          login: Login
-          email: E-mail
-          password: Hasło
-          remember_me: Zapamiętaj mnie
+      refinery/user:
+        login: Login
+        email: E-mail
+        password: Hasło
+        remember_me: Zapamiętaj mnie
   devise:
     failure:
       unauthenticated: 'Musisz się zalogować lub zarejestrować aby kontynuować.'

--- a/authentication/config/locales/pt-BR.yml
+++ b/authentication/config/locales/pt-BR.yml
@@ -59,13 +59,11 @@ pt-BR:
       signed_in: Fez login com sucesso.
   activerecord:
     models:
-      refinery:
-        user: Usuário
+      refinery/user: Usuário
     attributes:
-      refinery:
-        user:
-          login: Login
-          email: Email
-          password: Senha
-          password_confirmation: Confirmação da senha
-          remember_me: Lembrar de mim
+      refinery/user:
+        login: Login
+        email: Email
+        password: Senha
+        password_confirmation: Confirmação da senha
+        remember_me: Lembrar de mim

--- a/authentication/config/locales/rs.yml
+++ b/authentication/config/locales/rs.yml
@@ -62,8 +62,7 @@ rs:
       signed_in: Uspešno logovanje.
   activerecord:
     models:
-      refinery:
-        user: administrator
+      refinery/user: administrator
     attributes:
       refinery:
         user:

--- a/authentication/config/locales/ru.yml
+++ b/authentication/config/locales/ru.yml
@@ -82,14 +82,12 @@ ru:
       signed_in: 'Вы вошли.'
   activerecord:
     models:
-      refinery:
-        user: пользователь
+      refinery/user: пользователь
     attributes:
-      refinery:
-        user:
-          login: Имя или почта пользователя
-          username: Имя пользователя
-          email: Эл. почта
-          password: Пароль
-          password_confirmation: Подтверждение пароля
-          remember_me: Запомнить меня
+      refinery/user:
+        login: Имя или почта пользователя
+        username: Имя пользователя
+        email: Эл. почта
+        password: Пароль
+        password_confirmation: Подтверждение пароля
+        remember_me: Запомнить меня

--- a/authentication/config/locales/sk.yml
+++ b/authentication/config/locales/sk.yml
@@ -62,14 +62,12 @@ sk:
       signed_in: Úspešné prihlásenie.
   activerecord:
     models:
-      refinery:
-        user: užívateľ
+      refinery/user: užívateľ
     attributes:
-      refinery:
-        user:
-          login: Prihlásiť
-          username: Užívateľské meno
-          password: Heslo
-          password_confirmation: Potvrdiť heslo
-          email: Email
-          remember_me: Zapamätať heslo
+      refinery/user:
+        login: Prihlásiť
+        username: Užívateľské meno
+        password: Heslo
+        password_confirmation: Potvrdiť heslo
+        email: Email
+        remember_me: Zapamätať heslo

--- a/authentication/config/locales/sv.yml
+++ b/authentication/config/locales/sv.yml
@@ -56,12 +56,10 @@ sv:
       unauthenticated: Du måste logga in innan du kan fortsätta.
   activerecord:
     models:
-      refinery:
-        user: användare
+      refinery/user: användare
     attributes:
-      refinery:
-        user:
-          login: Inloggningsnamn
-          email: E-postadress
-          password: Lösenord
-          remember_me: Kom ihåg mig
+      refinery/user:
+        login: Inloggningsnamn
+        email: E-postadress
+        password: Lösenord
+        remember_me: Kom ihåg mig

--- a/authentication/config/locales/vi.yml
+++ b/authentication/config/locales/vi.yml
@@ -62,14 +62,12 @@ vi:
       signed_in: Đăng nhập thành công.
   activerecord:
     models:
-      refinery:
-        user: người dùng
+      refinery/user: người dùng
     attributes:
-      refinery:
-        user:
-          login: Đăng nhập
-          username: Tên người dùng
-          password: Mật khẩu
-          password_confirmation: Kiểm định mật khẩu
-          email: Thư điện tử
-          remember_me: Nhớ đăng nhập cho lần sau
+      refinery/user:
+        login: Đăng nhập
+        username: Tên người dùng
+        password: Mật khẩu
+        password_confirmation: Kiểm định mật khẩu
+        email: Thư điện tử
+        remember_me: Nhớ đăng nhập cho lần sau

--- a/authentication/config/locales/zh-CN.yml
+++ b/authentication/config/locales/zh-CN.yml
@@ -62,14 +62,12 @@ zh-CN:
       signed_in: 登录成功.
   activerecord:
     models:
-      refinery:
-        user: 用户
+      refinery/user: 用户
     attributes:
-      refinery:
-        user:
-          login: 登录
-          username: 用户名
-          password: 密码
-          password_confirmation: 确认密码
-          email: Email
-          remember_me: 记住我
+      refinery/user:
+        login: 登录
+        username: 用户名
+        password: 密码
+        password_confirmation: 确认密码
+        email: Email
+        remember_me: 记住我

--- a/authentication/config/locales/zh-TW.yml
+++ b/authentication/config/locales/zh-TW.yml
@@ -62,14 +62,12 @@ zh-TW:
       signed_in: 登入成功.
   activerecord:
     models:
-      refinery:
-        user: 使用者
+      refinery/user: 使用者
     attributes:
-      refinery:
-        user:
-          login: 登入
-          username: 使用者名稱
-          password: 密碼
-          password_confirmation: 再次確認密碼
-          email: 電子郵件
-          remember_me: 記住我的設定
+      refinery/user:
+        login: 登入
+        username: 使用者名稱
+        password: 密碼
+        password_confirmation: 再次確認密碼
+        email: 電子郵件
+        remember_me: 記住我的設定

--- a/core/config/locales/it.yml
+++ b/core/config/locales/it.yml
@@ -76,15 +76,6 @@ it:
       enable_javascript: È necessario che JavaScript sia abilitato per poter visualizzare correttamente questa pagina.
       here_are: ""
       instructions_enable_javascript: Istruzioni su come attivare JavaScript nel tuo browser
-  activerecord:
-    models:
-      page: pagina
-      user: utente
-      image: immagine
-      inquiry: richiesta
-      resource: risorsa
-      setting: impostazione di Refinery
-      inquiry_setting: impostazione della richiesta
   pagination:
     next: "&raquo;"
     previous: "&laquo;"

--- a/images/config/locales/bg.yml
+++ b/images/config/locales/bg.yml
@@ -35,10 +35,10 @@ bg:
           new_image: Качване
   activerecord:
     models:
-      image: изображение
+      refinery/image: изображение
     errors:
       models:
-        image:
+        refinery/image:
           blank: Трябва да укажете изображение за качване
           too_big: Размерът на изображението трябва да бъде по-малък от %{size} мегабайта
           incorrect_format: 'Вашето изображение трябва да бъде JPG, PNG или GIF'

--- a/images/config/locales/cs.yml
+++ b/images/config/locales/cs.yml
@@ -35,12 +35,10 @@ cs:
           new_image: Nový obrázek
   activerecord:
     models:
-      refinery:
-        image: obrázek
+      refinery/image: obrázek
     errors:
       models:
-        refinery:
-          image:
-            blank: Musíte zadat obrázek který chcete nahrát
-            too_big: Maximální velikost obrázku je %{size} MB
-            incorrect_format: 'Obrázek musí být ve formátu JPG, PNG nebo GIF'
+        refinery/image:
+          blank: Musíte zadat obrázek který chcete nahrát
+          too_big: Maximální velikost obrázku je %{size} MB
+          incorrect_format: 'Obrázek musí být ve formátu JPG, PNG nebo GIF'

--- a/images/config/locales/da.yml
+++ b/images/config/locales/da.yml
@@ -35,12 +35,10 @@ da:
           new_image: Upload
   activerecord:
     models:
-      refinery:
-        image: billede
+      refinery/image: billede
     errors:
       models:
-        refinery:
-          image:
-            blank: Du skal angive et billede, der skal uploades
-            too_big: Filer må højest være på %{size} megabytes
-            incorrect_format: 'Dit billede skal være enten JPG, PNG eller GIF format'
+        refinery/image:
+          blank: Du skal angive et billede, der skal uploades
+          too_big: Filer må højest være på %{size} megabytes
+          incorrect_format: 'Dit billede skal være enten JPG, PNG eller GIF format'

--- a/images/config/locales/de.yml
+++ b/images/config/locales/de.yml
@@ -35,12 +35,10 @@ de:
           new_image: Neues Bild
   activerecord:
     models:
-      refinery:
-        image: Bild
+      refinery/image: Bild
     errors:
       models:
-        refinery:
-          image:
-            blank: Sie müssen ein Bild zum Hochladen angeben
-            too_big: Bild sollte kleiner als %{size} Megabytes sein
-            incorrect_format: 'Ihr Bild sollte ein JPG, PNG oder GIF sein'
+        refinery/image:
+          blank: Sie müssen ein Bild zum Hochladen angeben
+          too_big: Bild sollte kleiner als %{size} Megabytes sein
+          incorrect_format: 'Ihr Bild sollte ein JPG, PNG oder GIF sein'

--- a/images/config/locales/el.yml
+++ b/images/config/locales/el.yml
@@ -35,12 +35,10 @@ el:
           new_image: Ανέβασμα
   activerecord:
     models:
-      refinery:
-        image: εικόνα
+      refinery/image: εικόνα
     errors:
       models:
-        refinery:
-          image:
-            blank: Πρέπει να επιλέξετε εικόνα για ανέβασμα
-            too_big: Η εικόνα πρέπει να είναι μικρότερη από %{size} megabytes σε μέγεθος
-            incorrect_format: 'Η εικόνα σας πρέπει να είναι JPG, PNG ή GIF'
+        refinery/image:
+          blank: Πρέπει να επιλέξετε εικόνα για ανέβασμα
+          too_big: Η εικόνα πρέπει να είναι μικρότερη από %{size} megabytes σε μέγεθος
+          incorrect_format: 'Η εικόνα σας πρέπει να είναι JPG, PNG ή GIF'

--- a/images/config/locales/en.yml
+++ b/images/config/locales/en.yml
@@ -35,12 +35,10 @@ en:
           new_image: Upload
   activerecord:
     models:
-      refinery:
-        image: image
+      refinery/image: image
     errors:
       models:
-        refinery:
-          image:
-            blank: You must specify an image for upload
-            too_big: Image should be smaller than %{size} megabytes in size
-            incorrect_format: 'Your image must be either a JPG, PNG or GIF'
+        refinery/image:
+          blank: You must specify an image for upload
+          too_big: Image should be smaller than %{size} megabytes in size
+          incorrect_format: 'Your image must be either a JPG, PNG or GIF'

--- a/images/config/locales/es.yml
+++ b/images/config/locales/es.yml
@@ -36,12 +36,10 @@ es:
           new_image: Nueva imagen
   activerecord:
     models:
-      refinery:
-        image: imagen
+      refinery/image: imagen
     errors:
       models:
-        refinery:
-          image:
-            blank: Debes indicar qué imagen quieres subir
-            too_big: La imagen debe pesar menos de %{size} megabytes
-            incorrect_format: Tu imagen debe ser un archivo JPG, PNG o GIF
+        refinery/image:
+          blank: Debes indicar qué imagen quieres subir
+          too_big: La imagen debe pesar menos de %{size} megabytes
+          incorrect_format: Tu imagen debe ser un archivo JPG, PNG o GIF

--- a/images/config/locales/fi.yml
+++ b/images/config/locales/fi.yml
@@ -35,12 +35,10 @@ fi:
           new_image: Lisää
   activerecord:
     models:
-      refinery:
-        image: kuva
+      refinery/image: kuva
     errors:
       models:
-        refinery:
-          image:
-            blank: Sinun pitää lähettää kuva
-            too_big: Kuvan tulee olla pienempi kuin %{size} megatavua kooltaan
-            incorrect_format: 'Kuvan pitää olla joko JPG, PNG tai GIF- muodossa'
+        refinery/image:
+          blank: Sinun pitää lähettää kuva
+          too_big: Kuvan tulee olla pienempi kuin %{size} megatavua kooltaan
+          incorrect_format: 'Kuvan pitää olla joko JPG, PNG tai GIF- muodossa'

--- a/images/config/locales/fr.yml
+++ b/images/config/locales/fr.yml
@@ -35,12 +35,10 @@ fr:
           new_image: Nouvelle image
   activerecord:
     models:
-      refinery:
-        image: image
+      refinery/image: image
     errors:
       models:
-        refinery:
-          image:
-            blank: Vous devez sélectionner une image à télécharger
-            too_big: L'image doit être plus petite que %{size} megaoctets
-            incorrect_format: 'Seules les images aux formats JPG, PNG or GIF sont acceptées'
+        refinery/image:
+          blank: Vous devez sélectionner une image à télécharger
+          too_big: L'image doit être plus petite que %{size} megaoctets
+          incorrect_format: 'Seules les images aux formats JPG, PNG or GIF sont acceptées'

--- a/images/config/locales/jp.yml
+++ b/images/config/locales/jp.yml
@@ -35,12 +35,10 @@ jp:
           new_image: アップロード
   activerecord:
     models:
-      refinery:
-        image: 画像
+      refinery/image: 画像
     errors:
       models:
-        refinery:
-          image:
-            blank: アップロードする画像を選択して下さい。
-            too_big: '画像は最大で%{size}MBまでです。'
-            incorrect_format: '使用出来る画像のフォーマットはJPG、GIFまたはPNGです。'
+        refinery/image:
+          blank: アップロードする画像を選択して下さい。
+          too_big: '画像は最大で%{size}MBまでです。'
+          incorrect_format: '使用出来る画像のフォーマットはJPG、GIFまたはPNGです。'

--- a/images/config/locales/ko.yml
+++ b/images/config/locales/ko.yml
@@ -35,12 +35,10 @@ ko:
           new_image: 새 이미지
   activerecord:
     models:
-      refinery:
-        image: 이미지
+      refinery/image: 이미지
     errors:
       models:
-        refinery:
-          image:
-            blank: 업로드할 이미지를 선택해주세요.
-            too_big: 이미지의 크기는 %{size}MB 이하여야 합니다.
-            incorrect_format: 'JPG, PNG 또는 GIF 형식의 이미지만 업로드할 수 있습니다.'
+        refinery/image:
+          blank: 업로드할 이미지를 선택해주세요.
+          too_big: 이미지의 크기는 %{size}MB 이하여야 합니다.
+          incorrect_format: 'JPG, PNG 또는 GIF 형식의 이미지만 업로드할 수 있습니다.'

--- a/images/config/locales/lolcat.yml
+++ b/images/config/locales/lolcat.yml
@@ -35,12 +35,10 @@ lolcat:
           new_image: NEW IMAGE
   activerecord:
     models:
-      refinery:
-        image: IMAGE
+      refinery/image: IMAGE
     errors:
       models:
-        refinery:
-          image:
-            blank: U MUST SPECIFY AN IMAGE 4 UPLOAD
-            too_big: IMAGE SHUD BE SMALLR THAN %{size} MEGABYTEZ IN SIZE
-            incorrect_format: UR IMAGE MUST BE EITHR JPG, PNG OR GIF
+        refinery/image:
+          blank: U MUST SPECIFY AN IMAGE 4 UPLOAD
+          too_big: IMAGE SHUD BE SMALLR THAN %{size} MEGABYTEZ IN SIZE
+          incorrect_format: UR IMAGE MUST BE EITHR JPG, PNG OR GIF

--- a/images/config/locales/lt.yml
+++ b/images/config/locales/lt.yml
@@ -35,12 +35,10 @@ lt:
           new_image: Naujas paveikslėlis
   activerecord:
     models:
-      refinery:
-        image: paveikslėlis
+      refinery/image: paveikslėlis
     errors:
       models:
-        refinery:
-          image:
-            blank: Turite nurodyti paveikslėlį įkėlimui
-            too_big: "Paveikslėlio dydis turėtų būti mažesnis, nei %{size} megabaitų"
-            incorrect_format: 'Paveikslėlis turi būti JPG, PNG arba GIF formatu'
+        refinery/image:
+          blank: Turite nurodyti paveikslėlį įkėlimui
+          too_big: "Paveikslėlio dydis turėtų būti mažesnis, nei %{size} megabaitų"
+          incorrect_format: 'Paveikslėlis turi būti JPG, PNG arba GIF formatu'

--- a/images/config/locales/lv.yml
+++ b/images/config/locales/lv.yml
@@ -35,12 +35,10 @@ lv:
           new_image: Jauna Bilde
   activerecord:
     models:
-      refinery:
-        image: bilde
+      refinery/image: bilde
     errors:
       models:
-        refinery:
-          image:
-            blank: Jānorāda bilde pirms augšupielādes
-            too_big: Bildes izmēram jābūt mazākam par %{size} megabaitiem
-            incorrect_format: "Bilde drīkst būt tikai sekojošos formātos: JPG, PNG vai GIF"
+        refinery/image:
+          blank: Jānorāda bilde pirms augšupielādes
+          too_big: Bildes izmēram jābūt mazākam par %{size} megabaitiem
+          incorrect_format: "Bilde drīkst būt tikai sekojošos formātos: JPG, PNG vai GIF"

--- a/images/config/locales/nb.yml
+++ b/images/config/locales/nb.yml
@@ -35,12 +35,10 @@ nb:
           new_image: Nytt bilde
   activerecord:
     models:
-      refinery:
-        image: bilde
+      refinery/image: bilde
     errors:
       models:
-        refinery:
-          image:
-            blank: Du må angi bildet som skal lastet opp
-            too_big: Bildet må være mindre enn %{size} MB
-            incorrect_format: 'Bildefilen må være av filtypen JPG, PNG eller GIF'
+        refinery/image:
+          blank: Du må angi bildet som skal lastet opp
+          too_big: Bildet må være mindre enn %{size} MB
+          incorrect_format: 'Bildefilen må være av filtypen JPG, PNG eller GIF'

--- a/images/config/locales/nl.yml
+++ b/images/config/locales/nl.yml
@@ -34,12 +34,10 @@ nl:
           new_image: Uploaden
   activerecord:
     models:
-      refinery:
-        image: afbeelding
+      refinery/image: afbeelding
     errors:
       models:
-        refinery:
-          image:
-            blank: U moet een afbeelding kiezen om te uploaden.
-            too_big: Afbeeldingen mogen niet groter dan %{size} megabytes zijn.
-            incorrect_format: Uw afbeelding moet een JPG, PNG of GIF zijn.
+        refinery/image:
+          blank: U moet een afbeelding kiezen om te uploaden.
+          too_big: Afbeeldingen mogen niet groter dan %{size} megabytes zijn.
+          incorrect_format: Uw afbeelding moet een JPG, PNG of GIF zijn.

--- a/images/config/locales/pl.yml
+++ b/images/config/locales/pl.yml
@@ -36,12 +36,10 @@ pl:
           new_image: Nowy obraz
   activerecord:
     models:
-      refinery:
-        image: obraz
+      refinery/image: obraz
     errors:
       models:
-        refinery:
-          image:
-            blank: Musisz określić obraz do wgrania
-            too_big: Obraz powinien być mniejszy niż %{size} megabajtów
-            incorrect_format: 'Obraz musi być plikiem typu JPG, PNG lub GIF'
+        refinery/image:
+          blank: Musisz określić obraz do wgrania
+          too_big: Obraz powinien być mniejszy niż %{size} megabajtów
+          incorrect_format: 'Obraz musi być plikiem typu JPG, PNG lub GIF'

--- a/images/config/locales/pt-BR.yml
+++ b/images/config/locales/pt-BR.yml
@@ -36,12 +36,10 @@ pt-BR:
           new_image: Nova Imagem
   activerecord:
     models:
-      refinery:
-        image: Imagem
+      refinery/image: Imagem
     errors:
       models:
-        refinery:
-          image:
-            blank: Você deve escolher uma imagem para enviar
-            too_big: "Imagem deve possuir menos de %{size} megabytes de tamanho"
-            incorrect_format: 'Sua imagem deve ser uma JPG, PNG ou GIF'
+        refinery/image:
+          blank: Você deve escolher uma imagem para enviar
+          too_big: "Imagem deve possuir menos de %{size} megabytes de tamanho"
+          incorrect_format: 'Sua imagem deve ser uma JPG, PNG ou GIF'

--- a/images/config/locales/rs.yml
+++ b/images/config/locales/rs.yml
@@ -35,13 +35,10 @@ rs:
           new_image: Upload
   activerecord:
     models:
-      refinery:
-        image: slika
+      refinery/image: slika
     errors:
       models:
-        refinery:
-          image:
-            blank: Moraš izabrati sliku za upload
-            too_big: Slika bi trebalo da bude manja od %{size} megabajta
-            incorrect_format: 'Slika mora biti u JPG, PNG ili GIF formatu'
-
+        refinery/image:
+          blank: Moraš izabrati sliku za upload
+          too_big: Slika bi trebalo da bude manja od %{size} megabajta
+          incorrect_format: 'Slika mora biti u JPG, PNG ili GIF formatu'

--- a/images/config/locales/ru.yml
+++ b/images/config/locales/ru.yml
@@ -35,12 +35,10 @@ ru:
           new_image: Новое изображение
   activerecord:
     models:
-      refinery:
-        image: изображение
+      refinery/image: изображение
     errors:
       models:
-        refinery:
-          image:
-            blank: Вы должны выбрать файл для загрузки
-            too_big: "Файлы должны быть меньше по размеру, чем %{size} МБ"
-            incorrect_format: "Ваше изображение может быть только в форматах JPG, PNG или GIF"
+        refinery/image:
+          blank: Вы должны выбрать файл для загрузки
+          too_big: "Файлы должны быть меньше по размеру, чем %{size} МБ"
+          incorrect_format: "Ваше изображение может быть только в форматах JPG, PNG или GIF"

--- a/images/config/locales/sk.yml
+++ b/images/config/locales/sk.yml
@@ -35,12 +35,10 @@ sk:
           new_image: Nový obrázok
   activerecord:
     models:
-      refinery:
-        image: obrázok
+      refinery/image: obrázok
     errors:
       models:
-        refinery:
-          image:
-            blank: Musíte zadať obrázok ktorý chcete nahrať.
-            too_big: Maximálna veľkosť obrázku %{size}MB in size.
-            incorrect_format: 'Obrázok musí byť vo formáte JPG, PNG alebo GIF.'
+        refinery/image:
+          blank: Musíte zadať obrázok ktorý chcete nahrať.
+          too_big: Maximálna veľkosť obrázku %{size}MB in size.
+          incorrect_format: 'Obrázok musí byť vo formáte JPG, PNG alebo GIF.'

--- a/images/config/locales/sl.yml
+++ b/images/config/locales/sl.yml
@@ -34,12 +34,10 @@ sl:
           new_image: Nova Slika
   activerecord:
     models:
-      refinery:
-        image: slika
+      refinery/image: slika
     errors:
       models:
-        refinery:
-          image:
-            blank: Izbrati morate datoteko, ki jo želite naložiti
-            too_big: Velikost slike mora biti manjša od %{size} megabajtov
-            incorrect_format: Slika mora biti tipa JPG, PNG ali GIF
+        refinery/image:
+          blank: Izbrati morate datoteko, ki jo želite naložiti
+          too_big: Velikost slike mora biti manjša od %{size} megabajtov
+          incorrect_format: Slika mora biti tipa JPG, PNG ali GIF

--- a/images/config/locales/sv.yml
+++ b/images/config/locales/sv.yml
@@ -35,12 +35,10 @@ sv:
           new_image: Ny bild
   activerecord:
     models:
-      refinery:
-        image: bild
+      refinery/image: bild
     errors:
       models:
-        refinery:
-          image:
-            blank: Du måste ange en bild att ladda upp
-            too_big: Bilden ska vara mindre än %{size} megabytes stor
-            incorrect_format: 'Din bild måste vara antingen JPG, PNG eller GIF'
+        refinery/image:
+          blank: Du måste ange en bild att ladda upp
+          too_big: Bilden ska vara mindre än %{size} megabytes stor
+          incorrect_format: 'Din bild måste vara antingen JPG, PNG eller GIF'

--- a/images/config/locales/vi.yml
+++ b/images/config/locales/vi.yml
@@ -35,12 +35,10 @@ vi:
           new_image: Tải lên
   activerecord:
     models:
-      refinery:
-        image: ảnh
+      refinery/image: ảnh
     errors:
       models:
-        refinery:
-          image:
-            blank: Bạn phải chọn ảnh để tải lên
-            too_big: Ảnh phải có kích thước nhỏ hơn %{size} megabytes
-            incorrect_format: 'Ảnh phải ở một trong các định dạng JPG, PNG hoặc GIF'
+        refinery/image:
+          blank: Bạn phải chọn ảnh để tải lên
+          too_big: Ảnh phải có kích thước nhỏ hơn %{size} megabytes
+          incorrect_format: 'Ảnh phải ở một trong các định dạng JPG, PNG hoặc GIF'

--- a/images/config/locales/zh-CN.yml
+++ b/images/config/locales/zh-CN.yml
@@ -35,12 +35,10 @@ zh-CN:
           new_image: 上传
   activerecord:
     models:
-      refinery:
-        image: 图片
+      refinery/image: 图片
     errors:
       models:
-        refinery:
-          image:
-            blank: 你必须选择一个图片来上传
-            too_big: 图片应该小于 %{size} MB 大小
-            incorrect_format: '你的图片必须是JPG, PNG 或者 GIF'
+        refinery/image:
+          blank: 你必须选择一个图片来上传
+          too_big: 图片应该小于 %{size} MB 大小
+          incorrect_format: '你的图片必须是JPG, PNG 或者 GIF'

--- a/images/config/locales/zh-TW.yml
+++ b/images/config/locales/zh-TW.yml
@@ -35,12 +35,10 @@ zh-TW:
           new_image: 上傳
   activerecord:
     models:
-      refinery:
-        image: 圖片
+      refinery/image: 圖片
     errors:
       models:
-        refinery:
-          image:
-            blank: 您必須指定一張圖片來上傳
-            too_big: 圖片必須小於 %{size} MB 這個大小
-            incorrect_format: '您的圖片必須是 JPG, PNG 或是 GIF'
+        refinery/image:
+          blank: 您必須指定一張圖片來上傳
+          too_big: 圖片必須小於 %{size} MB 這個大小
+          incorrect_format: '您的圖片必須是 JPG, PNG 或是 GIF'

--- a/pages/config/locales/bg.yml
+++ b/pages/config/locales/bg.yml
@@ -81,7 +81,7 @@ bg:
         translator_access: Нямате нужните права да променяте страници на този език.
   activerecord:
     models:
-      page: страница
+      refinery/page: страница
     attributes:
-      page:
+      refinery/page:
         title: Заглавие

--- a/pages/config/locales/cs.yml
+++ b/pages/config/locales/cs.yml
@@ -72,9 +72,7 @@ cs:
           no_pages_yet: Zatím nebyly vytvořeny žádné stránky.
   activerecord:
     models:
-      refinery:
-        page: stránka
+      refinery/page: stránka
     attributes:
-      refinery:
-        page:
-          title: Název
+      refinery/page:
+        title: Název

--- a/pages/config/locales/da.yml
+++ b/pages/config/locales/da.yml
@@ -72,9 +72,7 @@ da:
           no_pages_yet: Der er ingen sider endnu. Klik på "Tilføj en ny side" for at oprette den første."
   activerecord:
     models:
-      refinery:
-        page: side
+      refinery/page: side
     attributes:
-      refinery:
-        page:
-          title: Titel
+      refinery/page:
+        title: Titel

--- a/pages/config/locales/de.yml
+++ b/pages/config/locales/de.yml
@@ -72,9 +72,7 @@ de:
           no_pages_yet: Es sind noch keine Seiten vorhanden. Klicken Sie auf "Neue Seite anlegen", um Ihre erste Seite zu erstellen.
   activerecord:
     models:
-      refinery:
-        page: Seite
+      refinery/page: Seite
     attributes:
-      refinery:
-        page:
-          title: Titel
+      refinery/page:
+        title: Titel

--- a/pages/config/locales/el.yml
+++ b/pages/config/locales/el.yml
@@ -72,9 +72,7 @@ el:
           no_pages_yet: There are no pages yet. Click "Add new page" to add your first page.
   activerecord:
     models:
-      refinery:
-        page: σελίδα
+      refinery/page: σελίδα
     attributes:
-      refinery:
-        page:
-          title: τίτλος
+      refinery/page:
+        title: τίτλος

--- a/pages/config/locales/en.yml
+++ b/pages/config/locales/en.yml
@@ -81,9 +81,7 @@ en:
         translator_access: You do not have the required permission to modify pages in this language.
   activerecord:
     models:
-      refinery:
-        page: page
+      refinery/page: page
     attributes:
-      refinery:
-        page:
-          title: Title
+      refinery/page:
+        title: Title

--- a/pages/config/locales/es.yml
+++ b/pages/config/locales/es.yml
@@ -73,9 +73,7 @@ es:
           no_pages_yet: "Aún no hay páginas. Pulsa \"Crear nueva página\" para añadir tu primera página."
   activerecord:
     models:
-      refinery:
-        page: página
+      refinery/page: página
     attributes:
-      refinery:
-        page:
-          title: Título
+      refinery/page:
+        title: Título

--- a/pages/config/locales/fi.yml
+++ b/pages/config/locales/fi.yml
@@ -73,9 +73,7 @@ fi:
         translator_access: Sinulla ei ole lupaa muokata sivuja tällä kielellä.
   activerecord:
     models:
-      refinery:
-        page: sivu
+      refinery/page: sivu
     attributes:
-      refinery:
-        page:
-          title: Otsikko
+      refinery/page:
+        title: Otsikko

--- a/pages/config/locales/fr.yml
+++ b/pages/config/locales/fr.yml
@@ -72,9 +72,7 @@ fr:
           no_pages_yet: "Il n'y a actuellement aucune page. Cliquer sur 'Créer une nouvelle page' pour en ajouter une."
   activerecord:
     models:
-      refinery:
-        page: page
+      refinery/page: page
     attributes:
-      refinery:
-        page:
-          title: Titre
+      refinery/page:
+        title: Titre

--- a/pages/config/locales/jp.yml
+++ b/pages/config/locales/jp.yml
@@ -70,9 +70,7 @@ jp:
           no_pages_yet: まだページはありません。"新規ページを追加"をクリックして下さい。
   activerecord:
     models:
-      refinery:
-        page: ページ
+      refinery/page: ページ
     attributes:
-      refinery:
-        page:
-          title: タイトル
+      refinery/page:
+        title: タイトル

--- a/pages/config/locales/ko.yml
+++ b/pages/config/locales/ko.yml
@@ -81,9 +81,7 @@ ko:
         translator_access: 해당 언어로 페이지를 수정할 권한이 없습니다.
   activerecord:
     models:
-      refinery:
-        page: 페이지
+      refinery/page: 페이지
     attributes:
-      refinery:
-        page:
-          title: 제목
+      refinery/page:
+        title: 제목

--- a/pages/config/locales/lolcat.yml
+++ b/pages/config/locales/lolcat.yml
@@ -71,9 +71,7 @@ lolcat:
           no_pages_yet: THAR R NO PAGEZ YET. CLICK "ADD NEW PAEG" 2 ADD UR FURST PAEG.
   activerecord:
     models:
-      refinery:
-        page: PAEG
+      refinery/page: PAEG
     attributes:
-      refinery:
-        page:
-          title: TITLE
+      refinery/page:
+        title: TITLE

--- a/pages/config/locales/lt.yml
+++ b/pages/config/locales/lt.yml
@@ -73,9 +73,7 @@ lt:
           no_pages_yet: Dar nėra puslapių. Paspauskite "Pridėti naują puslapį" norėdami sukurti pirmą puslapį.
   activerecord:
     models:
-      refinery:
-        page: puslapis
+      refinery/page: puslapis
     attributes:
-      refinery:
-        page:
-          title: Antraštė
+      refinery/page:
+        title: Antraštė

--- a/pages/config/locales/lv.yml
+++ b/pages/config/locales/lv.yml
@@ -74,9 +74,7 @@ lv:
           no_pages_yet: Vēl nav nevienas lapas. Spied "Izveidot jaunu lapu", lai izveidotu pirmo lapu.
   activerecord:
     models:
-      refinery:
-        page: lapa
+      refinery/page: lapa
     attributes:
-      refinery:
-        page:
-          title: Nosaukums
+      refinery/page:
+        title: Nosaukums

--- a/pages/config/locales/nb.yml
+++ b/pages/config/locales/nb.yml
@@ -72,10 +72,8 @@ nb:
           no_pages_yet: Det er ingen sider her enda. Klikk på "Legg til ny side" for å legge til din første side.
   activerecord:
     models:
-      refinery:
-        page: side
+      refinery/page: side
     attributes:
-      refinery:
-        page:
-          title: Tittel
+      refinery/page:
+        title: Tittel
         

--- a/pages/config/locales/nl.yml
+++ b/pages/config/locales/nl.yml
@@ -72,5 +72,4 @@ nl:
           no_pages_yet: "Er zijn nog geen pagina's. Druk op 'Maak een nieuwe pagina' om de eerste aan te maken."
   activerecord:
     models:
-      refinery:
-        page: Pagina
+      refinery/page: Pagina

--- a/pages/config/locales/pl.yml
+++ b/pages/config/locales/pl.yml
@@ -73,9 +73,7 @@ pl:
           no_pages_yet: Nie ma jeszcze żadnej strony. Kliknij "Dodaj nową stronę" aby stworzyć pierwszą.
   activerecord:
     models:
-      refinery:
-        page: strona
+      refinery/page: strona
     attributes:
-      refinery:
-        page:
-          title: Tytuł
+      refinery/page:
+        title: Tytuł

--- a/pages/config/locales/pt-BR.yml
+++ b/pages/config/locales/pt-BR.yml
@@ -73,9 +73,7 @@ pt-BR:
           no_pages_yet: Ainda não existem páginas. Clique em "Criar Nova Página" para adicionar sua primeira página.
   activerecord:
     models:
-      refinery:
-        page: Página
+      refinery/page: Página
     attributes:
-      refinery:
-        page:
-          title: Título
+      refinery/page:
+        title: Título

--- a/pages/config/locales/rs.yml
+++ b/pages/config/locales/rs.yml
@@ -72,9 +72,7 @@ rs:
           no_pages_yet: Ne postoji nijedna strana. Klinki na "Dodaj novu stranu" da dodaš prvu stranu.
   activerecord:
     models:
-      refinery:
-        page: strana
+      refinery/page: strana
     attributes:
-      refinery:
-        page:
-          title: Naslov
+      refinery/page:
+        title: Naslov

--- a/pages/config/locales/ru.yml
+++ b/pages/config/locales/ru.yml
@@ -75,9 +75,7 @@ ru:
           no_pages_yet: Страниц ещё нет.
   activerecord:
     models:
-      refinery:
-        page: страница
+      refinery/page: страница
     attributes:
-      refinery:
-        page:
-          title: Заголовок
+      refinery/page:
+        title: Заголовок

--- a/pages/config/locales/sk.yml
+++ b/pages/config/locales/sk.yml
@@ -72,9 +72,7 @@ sk:
           no_pages_yet: Zatiaľ neboli vytvorené žiadne stránky. Kliknite na "Pridať novú stránku" pre pridanie prvej.
   activerecord:
     models:
-      refinery:
-        page: stránka
+      refinery/page: stránka
     attributes:
-      refinery:
-        page:
-          title: Názov
+      refinery/page:
+        title: Názov

--- a/pages/config/locales/sl.yml
+++ b/pages/config/locales/sl.yml
@@ -71,9 +71,7 @@ sl:
           no_pages_yet: Trenutno še ni nobene strani. Za dodajanje prve strani kliknite "Dodaj novo stran".
   activerecord:
     models:
-      refinery:
-        page: stran
+      refinery/page: stran
     attributes:
-      refinery:
-        page:
-          title: Naslov
+      refinery/page:
+        title: Naslov

--- a/pages/config/locales/sv.yml
+++ b/pages/config/locales/sv.yml
@@ -72,9 +72,7 @@ sv:
           no_pages_yet: Det finns inga sidor ännu. Klicka på "Lägg till en ny sida" för att skapa din första sida.
   activerecord:
     models:
-      refinery:
-        page: sida
+      refinery/page: sida
     attributes:
-      refinery:
-        page:
-          title: Titel
+      refinery/page:
+        title: Titel

--- a/pages/config/locales/vi.yml
+++ b/pages/config/locales/vi.yml
@@ -72,9 +72,7 @@ vi:
           no_pages_yet: Hiện chưa có trang nào. Ấn vào "Tạo trang mới" để tạo trang.
   activerecord:
     models:
-      refinery:
-        page: trang
+      refinery/page: trang
     attributes:
-      refinery:
-        page:
-          title: Tiêu đề
+      refinery/page:
+        title: Tiêu đề

--- a/pages/config/locales/zh-CN.yml
+++ b/pages/config/locales/zh-CN.yml
@@ -72,9 +72,7 @@ zh-CN:
           no_pages_yet: 这里还没有页面. 点击 "添加新页面" 去添加您的第一个页面.
   activerecord:
     models:
-      refinery:
-        page: 页面
+      refinery/page: 页面
     attributes:
-      refinery:
-        page:
-          title: 标题
+      refinery/page:
+        title: 标题

--- a/pages/config/locales/zh-TW.yml
+++ b/pages/config/locales/zh-TW.yml
@@ -72,9 +72,7 @@ zh-TW:
           no_pages_yet: 目前沒有任何頁面. 點選 "新增頁面" 來加入您的第一個頁面.
   activerecord:
     models:
-      refinery:
-        page: 頁面
+      refinery/page: 頁面
     attributes:
-      refinery:
-        page:
-          title: 標題
+      refinery/page:
+        title: 標題

--- a/resources/config/locales/cs.yml
+++ b/resources/config/locales/cs.yml
@@ -28,8 +28,7 @@ cs:
           button_text: Vložit
   activerecord:
     models:
-      refinery:
-        resource: soubor
+      refinery/resource: soubor
     errors:
       models:
         refinery:

--- a/resources/config/locales/da.yml
+++ b/resources/config/locales/da.yml
@@ -28,11 +28,9 @@ da:
           button_text: Indsæt
   activerecord:
     models:
-      refinery:
-        resource: fil
+      refinery/resource: fil
     errors:
       models:
-        refinery:
-          resource:
-            blank: Du skal vælge en fil, der skal uploades
-            too_big: Filer må højest være på %{size} megabytes
+        refinery/resource:
+          blank: Du skal vælge en fil, der skal uploades
+          too_big: Filer må højest være på %{size} megabytes

--- a/resources/config/locales/de.yml
+++ b/resources/config/locales/de.yml
@@ -28,11 +28,9 @@ de:
           button_text: Einfügen
   activerecord:
     models:
-      refinery:
-        resource: Datei
+      refinery/resource: Datei
     errors:
       models:
-        refinery:
-          resource:
-            blank: Sie müssen eine Datei zum Hochladen angeben
-            too_big: Die Dateien sollten kleiner als %{size} Megabyte sein
+        refinery/resource:
+          blank: Sie müssen eine Datei zum Hochladen angeben
+          too_big: Die Dateien sollten kleiner als %{size} Megabyte sein

--- a/resources/config/locales/el.yml
+++ b/resources/config/locales/el.yml
@@ -28,11 +28,9 @@ el:
           button_text: Εισαγωγή
   activerecord:
     models:
-      refinery:
-        resource: αρχείο
+      refinery/resource: αρχείο
     errors:
       models:
-        refinery:
-          resource:
-            blank: Πρέπει να διαλέξετε αρχείο για ανέβασμα
-            too_big: Το αρχείο πρέπει να είναι μικρότερο από %{size} megabytes σε μέγεθος
+        refinery/resource:
+          blank: Πρέπει να διαλέξετε αρχείο για ανέβασμα
+          too_big: Το αρχείο πρέπει να είναι μικρότερο από %{size} megabytes σε μέγεθος

--- a/resources/config/locales/en.yml
+++ b/resources/config/locales/en.yml
@@ -28,11 +28,9 @@ en:
           button_text: Insert
   activerecord:
     models:
-      refinery:
-        resource: file
+      refinery/resource: file
     errors:
       models:
-        refinery:
-          resource:
-            blank: You must specify file for upload
-            too_big: File should be smaller than %{size} megabytes in size
+        refinery/resource:
+          blank: You must specify file for upload
+          too_big: File should be smaller than %{size} megabytes in size

--- a/resources/config/locales/es.yml
+++ b/resources/config/locales/es.yml
@@ -29,11 +29,9 @@ es:
           button_text: Insertar
   activerecord:
     models:
-      refinery:
-        resource: archivo
+      refinery/resource: archivo
     errors:
       models:
-        refinery:
-          resource:
-            blank: Selecciona qué archivo quieres subir
-            too_big: El archivo debe pesar menos de %{size} megabytes
+        refinery/resource:
+          blank: Selecciona qué archivo quieres subir
+          too_big: El archivo debe pesar menos de %{size} megabytes

--- a/resources/config/locales/fi.yml
+++ b/resources/config/locales/fi.yml
@@ -28,11 +28,9 @@ fi:
           button_text: Lisää
   activerecord:
     models:
-      refinery:
-        resource: tiedosto
+      refinery/resource: tiedosto
     errors:
       models:
-        refinery:
-          resource:
-            blank: Sinun pitää lähettää tiedosto
-            too_big: Tiedoston tulee olla pienempi kuin %{count} megatavua kooltaan
+        refinery/resource:
+          blank: Sinun pitää lähettää tiedosto
+          too_big: Tiedoston tulee olla pienempi kuin %{count} megatavua kooltaan

--- a/resources/config/locales/fr.yml
+++ b/resources/config/locales/fr.yml
@@ -28,11 +28,9 @@ fr:
           button_text: Insertion
   activerecord:
     models:
-      refinery:
-        resource: fichier
+      refinery/resource: fichier
     errors:
       models:
-        refinery:
-          resource:
-            blank: Vous devez spécifier un fichier à télécharger
-            too_big: Le poids maximal des fichiers est de %{size} megaoctets
+        refinery/resource:
+          blank: Vous devez spécifier un fichier à télécharger
+          too_big: Le poids maximal des fichiers est de %{size} megaoctets

--- a/resources/config/locales/jp.yml
+++ b/resources/config/locales/jp.yml
@@ -28,11 +28,9 @@ jp:
           button_text: 挿入
   activerecord:
     models:
-      refinery:
-        resource: ファイル
+      refinery/resource: ファイル
     errors:
       models:
-        refinery:
-          resource:
-            blank: アップロードするファイルを指定して下さい。
-            too_big: "ファイルは最大で%{size}MBまでです。"
+        refinery/resource:
+          blank: アップロードするファイルを指定して下さい。
+          too_big: "ファイルは最大で%{size}MBまでです。"

--- a/resources/config/locales/ko.yml
+++ b/resources/config/locales/ko.yml
@@ -28,11 +28,9 @@ ko:
           button_text: 삽입
   activerecord:
     models:
-      refinery:
-        resource: 파일
+      refinery/resource: 파일
     errors:
       models:
-        refinery:
-          resource:
-            blank: 업로드할 파일을 선택해주세요.
-            too_big: 파일의 크기는 %{size}MB 이하여야 합니다.
+        refinery/resource:
+          blank: 업로드할 파일을 선택해주세요.
+          too_big: 파일의 크기는 %{size}MB 이하여야 합니다.

--- a/resources/config/locales/lolcat.yml
+++ b/resources/config/locales/lolcat.yml
@@ -28,11 +28,9 @@ lolcat:
           button_text: INSERT
   activerecord:
     models:
-      refinery:
-        resource: FILE
+      refinery/resource: FILE
     errors:
       models:
-        refinery:
-          resource:
-            blank: U MUST SPECIFY FILE 4 UPLOAD
-            too_big: FILE SHUD BE SMALLR THAN %{size} MEGABYTEZ IN SIZE
+        refinery/resource:
+          blank: U MUST SPECIFY FILE 4 UPLOAD
+          too_big: FILE SHUD BE SMALLR THAN %{size} MEGABYTEZ IN SIZE

--- a/resources/config/locales/lt.yml
+++ b/resources/config/locales/lt.yml
@@ -28,11 +28,9 @@ lt:
           button_text: Įterpti
   activerecord:
     models:
-      refinery:
-        resource: failas
+      refinery/resource: failas
     errors:
       models:
-        refinery:
-          resource:
-            blank: Nurodykite failą įkėlimui
-            too_big: Failas turėtų būti mažesnio dydžio nei %{size} megabaitų
+        refinery/resource:
+          blank: Nurodykite failą įkėlimui
+          too_big: Failas turėtų būti mažesnio dydžio nei %{size} megabaitų

--- a/resources/config/locales/lv.yml
+++ b/resources/config/locales/lv.yml
@@ -28,11 +28,9 @@ lv:
           button_text: Ievietot
   activerecord:
     models:
-      refinery:
-        resource: fails
+      refinery/resource: fails
     errors:
       models:
-        refinery:
-          resource:
-            blank: Jānorāda fails pirms augšupielādes
-            too_big: Faila izmēram jābūt mazākam par %{size} megabaitiem
+        refinery/resource:
+          blank: Jānorāda fails pirms augšupielādes
+          too_big: Faila izmēram jābūt mazākam par %{size} megabaitiem

--- a/resources/config/locales/nb.yml
+++ b/resources/config/locales/nb.yml
@@ -28,11 +28,9 @@ nb:
           button_text: Legg inn
   activerecord:
     models:
-      refinery:
-        resource: fil
+      refinery/resource: fil
     errors:
       models:
-        refinery:
-          resource:
-            blank: Du må angi en fil som skal lastes opp
-            too_big: Filstørrelsen må være mindre enn %{size} MB
+        refinery/resource:
+          blank: Du må angi en fil som skal lastes opp
+          too_big: Filstørrelsen må være mindre enn %{size} MB

--- a/resources/config/locales/nl.yml
+++ b/resources/config/locales/nl.yml
@@ -27,11 +27,9 @@ nl:
           button_text: Invoegen
   activerecord:
     models:
-      refinery:
-        resource: bestand
+      refinery/resource: bestand
     errors:
       models:
-        refinery:
-          resource:
-            blank: U moet een bestand kiezen dat u wilt uploaden.
-            too_big: Bestanden mogen niet groter dan %{size} megabytes zijn.
+        refinery/resource:
+          blank: U moet een bestand kiezen dat u wilt uploaden.
+          too_big: Bestanden mogen niet groter dan %{size} megabytes zijn.

--- a/resources/config/locales/pl.yml
+++ b/resources/config/locales/pl.yml
@@ -29,11 +29,9 @@ pl:
           button_text: Wstaw
   activerecord:
     models:
-      refinery:
-        resource: plik
+      refinery/resource: plik
     errors:
       models:
-        refinery:
-          resource:
-            blank: Musisz określić plik do wgrania
-            too_big: Plik powinien być mniejszy niż %{size} megabajtów
+        refinery/resource:
+          blank: Musisz określić plik do wgrania
+          too_big: Plik powinien być mniejszy niż %{size} megabajtów

--- a/resources/config/locales/pt-BR.yml
+++ b/resources/config/locales/pt-BR.yml
@@ -28,11 +28,9 @@ pt-BR:
           button_text: Inserir
   activerecord:
     models:
-      refinery:
-        resource: Arquivo
+      refinery/resource: Arquivo
     errors:
       models:
-        refinery:
-          resource:
-            blank: Você deve escolher um arquivo para enviar
-            too_big: "Arquivos devem ser menores que %{size} megabytes em tamanho"
+        refinery/resource:
+          blank: Você deve escolher um arquivo para enviar
+          too_big: "Arquivos devem ser menores que %{size} megabytes em tamanho"

--- a/resources/config/locales/rs.yml
+++ b/resources/config/locales/rs.yml
@@ -28,11 +28,9 @@ rs:
           button_text: Unesi
   activerecord:
     models:
-      refinery:
-        resource: fajl
+      refinery/resource: fajl
     errors:
       models:
-        refinery:
-          resource:
-            blank: Moraš izabrati fajl za upload
-            too_big: Fajl bi trebalo da je manji od %{size} megabajta
+        refinery/resource:
+          blank: Moraš izabrati fajl za upload
+          too_big: Fajl bi trebalo da je manji od %{size} megabajta

--- a/resources/config/locales/ru.yml
+++ b/resources/config/locales/ru.yml
@@ -28,11 +28,9 @@ ru:
           button_text: Вставить
   activerecord:
     models:
-      refinery:
-        resource: файл
+      refinery/resource: файл
     errors:
       models:
-        refinery:
-          resource:
-            blank: Вы должны выбрать файл для загрузки
-            too_big: "Файлы должны быть по размеру меньше чем %{size} МБ"
+        refinery/resource:
+          blank: Вы должны выбрать файл для загрузки
+          too_big: "Файлы должны быть по размеру меньше чем %{size} МБ"

--- a/resources/config/locales/sk.yml
+++ b/resources/config/locales/sk.yml
@@ -28,11 +28,9 @@ sk:
           button_text: Vložiť
   activerecord:
     models:
-      refinery:
-        resource: súbor
+      refinery/resource: súbor
     errors:
       models:
-        refinery:
-          resource:
-            blank: Musíte vybrať súbor pre nahranie.
-            too_big: Maximálna veľkosť súboru je %{size} MB.
+        refinery/resource:
+          blank: Musíte vybrať súbor pre nahranie.
+          too_big: Maximálna veľkosť súboru je %{size} MB.

--- a/resources/config/locales/sl.yml
+++ b/resources/config/locales/sl.yml
@@ -27,11 +27,9 @@ sl:
           button_text: Vstavi
   activerecord:
     models:
-      refinery:
-        resource: datoteka
+      refinery/resource: datoteka
     errors:
       models:
-        refinery:
-          resource:
-            blank: Izbrati morate datoteko za prenos
-            too_big: Velikost datoteke mora biti manjša od %{size} megabajtov
+        refinery/resource:
+          blank: Izbrati morate datoteko za prenos
+          too_big: Velikost datoteke mora biti manjša od %{size} megabajtov

--- a/resources/config/locales/sv.yml
+++ b/resources/config/locales/sv.yml
@@ -28,11 +28,9 @@ sv:
           button_text: Lägg till
   activerecord:
     models:
-      refinery:
-        resource: fil
+      refinery/resource: fil
     errors:
       models:
-        refinery:
-          resource:
-            blank: Du måste ange en fil att ladda upp
-            too_big: Filen måste vara mindre än %{size} megabytes stor
+        refinery/resource:
+          blank: Du måste ange en fil att ladda upp
+          too_big: Filen måste vara mindre än %{size} megabytes stor

--- a/resources/config/locales/vi.yml
+++ b/resources/config/locales/vi.yml
@@ -28,11 +28,9 @@ vi:
           button_text: Chèn
   activerecord:
     models:
-      refinery:
-        refinery:resource: tập tin
+      refinery/resource: tập tin
     errors:
       models:
-        refinery:
-          resource:
-            blank: Bạn phải xác định tập tin để tải lên
-            too_big: Tập tin phải nhỏ hơn %{size} megabytes về kích thước
+        refinery/resource:
+          blank: Bạn phải xác định tập tin để tải lên
+          too_big: Tập tin phải nhỏ hơn %{size} megabytes về kích thước

--- a/resources/config/locales/zh-CN.yml
+++ b/resources/config/locales/zh-CN.yml
@@ -28,11 +28,9 @@ zh-CN:
           button_text: 插入
   activerecord:
     models:
-      refinery:
-        resource: 文件
+      refinery/resource: 文件
     errors:
       models:
-        refinery:
-          resource:
-            blank: 您必须选择一个文件来上传
-            too_big: 文件应该小于 %{size} MB 大小
+        refinery/resource:
+          blank: 您必须选择一个文件来上传
+          too_big: 文件应该小于 %{size} MB 大小

--- a/resources/config/locales/zh-TW.yml
+++ b/resources/config/locales/zh-TW.yml
@@ -28,11 +28,9 @@ zh-TW:
           button_text: 插入
   activerecord:
     models:
-      refinery:
-        resource: 檔案
+      refinery/resource: 檔案
     errors:
       models:
-        refinery:
-          resource:
-            blank: 您必須選取檔案來上傳
-            too_big: 檔案必須要小於 %{size} MB 這個大小
+        refinery/resource:
+          blank: 您必須選取檔案來上傳
+          too_big: 檔案必須要小於 %{size} MB 這個大小

--- a/settings/config/locales/bg.yml
+++ b/settings/config/locales/bg.yml
@@ -41,11 +41,9 @@ bg:
             cache_pages_full: Активиране на пълно кеширане на страници (full-page-cache). Тази настройка осъществява кеширането на страници чрез Nginx или чрез файла .htaccess в Apache.
   activerecord:
     models:
-      refinery:
-        setting: настройка
+      refinery/setting: настройка
     attributes:
-      refinery:
-        setting:
-          name: Наименование
-          value: Стойност
-          restricted: Ограничена
+      refinery/setting:
+        name: Наименование
+        value: Стойност
+        restricted: Ограничена

--- a/settings/config/locales/cs.yml
+++ b/settings/config/locales/cs.yml
@@ -39,11 +39,9 @@ cs:
             use_resource_caching: Doporučujeme zapnout toto nastavení v produkčním módu, protože rapidně urychlí načítání stránek. Komprimuje JavaSript a kaskádové styly do jednotlivých souborů, což vám ušetří požadavky na server.
   activerecord:
     models:
-      refinery:
-        setting: nastavení
+      refinery/setting: nastavení
     attributes:
-      refinery:
-        setting:
-          name: Jméno
-          value: Hodnota
-          restricted: Omezení
+      refinery/setting:
+        name: Jméno
+        value: Hodnota
+        restricted: Omezení

--- a/settings/config/locales/da.yml
+++ b/settings/config/locales/da.yml
@@ -40,11 +40,9 @@ da:
             approximate_ascii: Sæt til 'true', hvis du vil konvertere karakterer som ā, č og ž til a, c og z i side-URLer.
   activerecord:
     models:
-      refinery:
-        setting: indstilling
+      refinery/setting: indstilling
     attributes:
-      refinery:
-        setting:
-          name: Navn
-          value: Værdi
-          restricted: Begrænset adgang
+      refinery/setting:
+        name: Navn
+        value: Værdi
+        restricted: Begrænset adgang

--- a/settings/config/locales/de.yml
+++ b/settings/config/locales/de.yml
@@ -41,8 +41,7 @@ de:
             cache_pages_full: Aktiviert den Full-Page-Cache. Damit können die Seiten mit einer .htaccess-Rewrite-Regel vom Apache oder Nginx ausgeliefert werden.
   activerecord:
     models:
-      refinery:
-        setting: Einstellungen
+      refinery/setting: Einstellungen
     attributes:
       refinery:
         setting:

--- a/settings/config/locales/el.yml
+++ b/settings/config/locales/el.yml
@@ -40,11 +40,9 @@ el:
             approximate_ascii: Set this to true if you use Latin characters with accents and other diacritics in page titles. It'll convert characters like ā, č, ž into a, c, z and this way those characters won't appear strangely in the address bar of some web browsers.
   activerecord:
     models:
-      refinery:
-        setting: ρύθμιση
+      refinery/setting: ρύθμιση
     attributes:
-      refinery:
-        setting:
-          name: Όνονα
-          value: Τιμή
-          restricted: Περιορισμένο
+      refinery/setting:
+        name: Όνονα
+        value: Τιμή
+        restricted: Περιορισμένο

--- a/settings/config/locales/en.yml
+++ b/settings/config/locales/en.yml
@@ -41,11 +41,9 @@ en:
             cache_pages_full: Activates the full-page-cache. It allows cached page delivery via Nginx or .htaccess file from Apache.
   activerecord:
     models:
-      refinery:
-        setting: setting
+      refinery/setting: setting
     attributes:
-      refinery:
-        setting:
-          name: Name
-          value: Value
-          restricted: Restricted
+      refinery/setting:
+        name: Name
+        value: Value
+        restricted: Restricted

--- a/settings/config/locales/es.yml
+++ b/settings/config/locales/es.yml
@@ -41,11 +41,9 @@ es:
             approximate_ascii: Ponlo a true si usas caracteres latinos con tildes y otros signos diacríticos en los títulos de página. Convertirá caracteres como ā, č, ž en a, c, z y así estos caracteres no aparecerán como símbolos extraños en la barra de direcciones de algunos navegadores.
   activerecord:
     models:
-      refinery:
-        setting: opción
+      refinery/setting: opción
     attributes:
-      refinery:
-        setting:
-          name: Nombre
-          value: Valor
-          restricted: Restringido
+      refinery/setting:
+        name: Nombre
+        value: Valor
+        restricted: Restringido

--- a/settings/config/locales/fi.yml
+++ b/settings/config/locales/fi.yml
@@ -40,11 +40,9 @@ fi:
             approximate_ascii: "Pistä tämä asetus päälle, jos käytät merkkejä joissa on aksentteja ja muita erikoismerkkejä sivujen otsikoissa. Se muuntaa merkit kuten ā, č, ž muotoihin a, c, z, jotta nämä merkit eivät näytä oudoilta joittenkin selainten osoitepalkeissa."
   activerecord:
     models:
-      refinery:
-        setting: asetus
+      refinery/setting: asetus
     attributes:
-      refinery:
-        setting:
-          name: Nimi
-          value: Arvo
-          restricted: Rajoitettu
+      refinery/setting:
+        name: Nimi
+        value: Arvo
+        restricted: Rajoitettu

--- a/settings/config/locales/fr.yml
+++ b/settings/config/locales/fr.yml
@@ -38,11 +38,9 @@ fr:
             use_resource_caching: Il est recommandé de cocher cette option en production. Cela permet de regrouper les fichiers javascripts et CSS dans deux fichiers uniques afin d'augmenter la vitesse de service des pages et diminuer la charge sur le serveur.
   activerecord:
     models:
-      refinery:
-        setting: paramètre
+      refinery/setting: paramètre
     attributes:
-      refinery:
-        setting:
-          name: Nom
-          value: Valeur
-          restricted: Restriction
+      refinery/setting:
+        name: Nom
+        value: Valeur
+        restricted: Restriction

--- a/settings/config/locales/jp.yml
+++ b/settings/config/locales/jp.yml
@@ -40,11 +40,9 @@ jp:
             approximate_ascii: 'ラテン文字にアクセント記号を付けたものをページのタイトルに使用する際にはこれを有効にして下さい。ā, č, žをa, c, zへと変換します。'
   activerecord:
     models:
-      refinery:
-        setting: 設定
+      refinery/setting: 設定
     attributes:
-      refinery:
-        setting:
-          name: 名前
-          value: 値
-          restricted: 制限あり
+      refinery/setting:
+        name: 名前
+        value: 値
+        restricted: 制限あり

--- a/settings/config/locales/ko.yml
+++ b/settings/config/locales/ko.yml
@@ -41,11 +41,9 @@ ko:
             cache_pages_full: 전체 페이지 캐싱 기능을 활성화합니다. Apache의 .htaccess 파일이나 Nginx를 통해 페이지 캐시를 이용할 수 있습니다.
   activerecord:
     models:
-      refinery:
-        setting: 설정
+      refinery/setting: 설정
     attributes:
-      refinery:
-        setting:
-          name: 항목
-          value: 값
-          restricted: 접근 제한
+      refinery/setting:
+        name: 항목
+        value: 값
+        restricted: 접근 제한

--- a/settings/config/locales/lolcat.yml
+++ b/settings/config/locales/lolcat.yml
@@ -37,11 +37,9 @@ lolcat:
             use_resource_caching: RECOMMENDD 2 ENABLE DIS IN PRODUCSHUN MODE AS IT BUNDLEZ JAVASCRIPT ASSETS AN STYLESHEET ASSETS INTO SINGLE FILE PACKAGEZ 2 REDUCE TEH NUMBR OV WEB REQUESTS ON UR SIET AN SPED IT UP.
   activerecord:
     models:
-      refinery:
-        setting: SETTIN
+      refinery/setting: SETTIN
     attributes:
-      refinery:
-        setting:
-          name: NAYM
-          value: VALUE
-          restricted: RESTRICTD
+      refinery/setting:
+        name: NAYM
+        value: VALUE
+        restricted: RESTRICTD

--- a/settings/config/locales/lt.yml
+++ b/settings/config/locales/lt.yml
@@ -40,11 +40,9 @@ lt:
             use_resource_caching: "Rekomenduojama įjungti šį nustatymą paleidus svetainę darbiniu režimu, nes supakuos javascript ir stilių failus į vieną failą, kad sumažinti užklausų skaičių jūsų svetainė ir pagreitinti jos veikimą."
   activerecord:
     models:
-      refinery:
-        setting: nustatymas
+      refinery/setting: nustatymas
     attributes:
-      refinery:
-        setting:
-          name: Pavadinimas
-          value: Reikšmė
-          restricted: Apribotas
+      refinery/setting:
+        name: Pavadinimas
+        value: Reikšmė
+        restricted: Apribotas

--- a/settings/config/locales/lv.yml
+++ b/settings/config/locales/lv.yml
@@ -40,11 +40,9 @@ lv:
             approximate_ascii: "Ja izmantojat Latīņu burtus ar mīkstinājuma zīmēm, akcentiem utml., tad iespējojot šo uzstādījumu (vērtība: true) burti ā, č, ž u.c. tiks pārkonvertēti attiecīgi uz a, c un z, tāda veidā šie burti neizskatīsies savādi dažu parlūku adreses laukā."
   activerecord:
     models:
-      refinery:
-        setting: uzstādījums
+      refinery/setting: uzstādījums
     attributes:
-      refinery:
-        setting:
-          name: Nosaukums
-          value: Vērtība
-          restricted: Ierobežots
+      refinery/setting:
+        name: Nosaukums
+        value: Vērtība
+        restricted: Ierobežots

--- a/settings/config/locales/nb.yml
+++ b/settings/config/locales/nb.yml
@@ -40,12 +40,10 @@ nb:
             approximate_ascii: Sett denne verdien til true dersom du benytter Latinske bokstavar med aksenter eller andre varianter i sidetitler. Jeg vil da konvertere bokstaver som ā, č, ž til a, c, z. På denne måten vil ikke disse bokstavene oppføre seg merkelig i noen nettlesere.
   activerecord:
     models:
-      refinery:
-        setting: innstilling
+      refinery/setting: innstilling
     attributes:
-      refinery:
-        setting:
-          name: Navn
-          value: Verdi
-          restricted: Begrenset
+      refinery/setting:
+        name: Navn
+        value: Verdi
+        restricted: Begrenset
           

--- a/settings/config/locales/nl.yml
+++ b/settings/config/locales/nl.yml
@@ -40,11 +40,9 @@ nl:
             approximate_ascii: Zet dit aan, als je Latijnse karakters gebruikt met accenten en dergelijke in de pagina titels. Het converteert karakters zoals ā, č, ž naar a, c, z zodat ze er niet raar uitzien in de adresbalk van browsers.
   activerecord:
     models:
-      refinery:
-        setting: installing
+      refinery/setting: installing
     attributes:
-      refinery:
-        setting:
-          name: Naam
-          value: Waarde
-          restricted: Beveligd
+      refinery/setting:
+        name: Naam
+        value: Waarde
+        restricted: Beveligd

--- a/settings/config/locales/pl.yml
+++ b/settings/config/locales/pl.yml
@@ -40,11 +40,9 @@ pl:
             use_resource_caching: Zaleca się uaktywnienie tego ustawienia w produkcji, ponieważ powoduje zebranie zasobów CSS i Javascript w pojedyncze pliki, zmniejszając ilość zapytań HTTP i szybkość działania strony.
   activerecord:
     models:
-      refinery:
-        setting: ustawienie
+      refinery/setting: ustawienie
     attributes:
-      refinery:
-        setting:
-          name: Nazwa
-          value: Wartość
-          restricted: Zastrzeżone
+      refinery/setting:
+        name: Nazwa
+        value: Wartość
+        restricted: Zastrzeżone

--- a/settings/config/locales/pt-BR.yml
+++ b/settings/config/locales/pt-BR.yml
@@ -38,11 +38,9 @@ pt-BR:
             use_resource_caching: "Recomendado habilitar está opção em produção pois os javascript e stylesheet serão colocados em um único arquivo, o que diminui o número de requisições e aumenta a velocidade do site."
   activerecord:
     models:
-      refinery:
-        setting: setting
+      refinery/setting: setting
     attributes:
-      refinery:
-        setting:
-          name: Nome
-          value: Valor
-          restricted: Restrito
+      refinery/setting:
+        name: Nome
+        value: Valor
+        restricted: Restrito

--- a/settings/config/locales/rs.yml
+++ b/settings/config/locales/rs.yml
@@ -40,11 +40,9 @@ rs:
             approximate_ascii: Podesi ovo na true ako koristiš Latin karaktere u naslovu. Konvertovaće karaktere kao što su ā, č, ž u a, c, z i na ovaj način će se ova slova ispravno prikazivati u  URL adresama.
   activerecord:
     models:
-      refinery:
-        setting: podešavanje
+      refinery/setting: podešavanje
     attributes:
-      refinery:
-        setting:
-          name: Naziv
-          value: Vrednost
-          restricted: Ograničeno
+      refinery/setting:
+        name: Naziv
+        value: Vrednost
+        restricted: Ograničeno

--- a/settings/config/locales/ru.yml
+++ b/settings/config/locales/ru.yml
@@ -37,11 +37,9 @@ ru:
             use_resource_caching: "Рекомендуется включить этот параметр в рабочем режиме сайта, чтобы файлы джаваскриптов и таблиц стилей собирались в единый пакет, что снизит число запросов к вашему сайту, тем самым увеличится его скорость."
   activerecord:
     models:
-      refinery:
-        setting: Параметр системы
+      refinery/setting: Параметр системы
     attributes:
-      refinery:
-        setting:
-          name: Имя
-          value: Значение
-          restricted: Ограничение доступа
+      refinery/setting:
+        name: Имя
+        value: Значение
+        restricted: Ограничение доступа

--- a/settings/config/locales/sk.yml
+++ b/settings/config/locales/sk.yml
@@ -40,11 +40,9 @@ sk:
             approximate_ascii: Nastavte na hodnotu true, ak používaťe latinské znaky s akcentmi a diakritikou v názvoch stránok. Pokúsi sa previesť znaky, ako je ā, č, ž na a, c, z, a tak sa tieto znaky nezobrazia podivne v adresnom riadku niektorých webových prehliadačov.
   activerecord:
     models:
-      refinery:
-        setting: nastavenie
+      refinery/setting: nastavenie
     attributes:
-      refinery:
-        setting:
-          name: Meno
-          value: Hodnota
-          restricted: Obmedzenia
+      refinery/setting:
+        name: Meno
+        value: Hodnota
+        restricted: Obmedzenia

--- a/settings/config/locales/sl.yml
+++ b/settings/config/locales/sl.yml
@@ -20,10 +20,8 @@ sl:
             restricted: To omogoča da nastavitev lahko vidijo in urejajo samo super-uporabniki (kot ste vi).
   activerecord:
     models:
-      refinery:
-        setting: Refinery nastavitve
+      refinery/setting: Refinery nastavitve
     attributes:
-      refinery:
-        setting:
-          name: Ime
-          value: Vrednost
+      refinery/setting:
+        name: Ime
+        value: Vrednost

--- a/settings/config/locales/sv.yml
+++ b/settings/config/locales/sv.yml
@@ -39,11 +39,9 @@ sv:
             use_resource_caching: Rekomenderat att aktivera den här inställningen i produktionsläget då den buffrar javascript, stilmallar m.m. till ett enskilt paket att skicka vilket minimerar antalet kopplingar till din webbplats och snabbar upp laddningstiden.
   activerecord:
     models:
-      refinery:
-        setting: inställning
+      refinery/setting: inställning
     attributes:
-      refinery:
-        setting:
-          name: Namn
-          value: Värde
-          restricted: Begränsad
+      refinery/setting:
+        name: Namn
+        value: Värde
+        restricted: Begränsad

--- a/settings/config/locales/vi.yml
+++ b/settings/config/locales/vi.yml
@@ -40,11 +40,9 @@ vi:
             approximate_ascii: "Thiết lập này cho đúng nếu bạn sử dụng ký tự Latin với dấu và bỏ dấu trong tiêu đề của trang. Nó sẽ chuyển đổi các ký tự như ā, č, ž into a, c, z và bằng cách này những ký tự sẽ không xuất hiện kỳ lạ trong thanh địa chỉ của một số trình duyệt web."
   activerecord:
     models:
-      refinery:
-        setting: Thiết lập
+      refinery/setting: Thiết lập
     attributes:
-      refinery:
-        setting:
-          name: Tên
-          value: Giá trị
-          restricted: Giới hạn
+      refinery/setting:
+        name: Tên
+        value: Giá trị
+        restricted: Giới hạn

--- a/settings/config/locales/zh-CN.yml
+++ b/settings/config/locales/zh-CN.yml
@@ -40,11 +40,9 @@ zh-CN:
             approximate_ascii: 如果您使用带有口音或是变音符号的拉丁字母请设定为 true. 它会将像是 ā, č, ž 的字母转为 a, c, z , 在某些网页浏览器中, 这些字母就不会奇怪地出现在网址列上.
   activerecord:
     models:
-      refinery:
-        setting: 设置
+      refinery/setting: 设置
     attributes:
-      refinery:
-        setting:
-          name: 名称
-          value: 设置值
-          restricted: 限制
+      refinery/setting:
+        name: 名称
+        value: 设置值
+        restricted: 限制

--- a/settings/config/locales/zh-TW.yml
+++ b/settings/config/locales/zh-TW.yml
@@ -40,11 +40,9 @@ zh-TW:
             approximate_ascii: 如果您使用帶有口音或是變音符號的拉丁字母請設定為 true. 它會將像是 ā, č, ž 的字母轉為 a, c, z , 在某些網頁瀏覽器中, 這些字母就不會奇怪地出現在網址列上.
   activerecord:
     models:
-      refinery:
-        setting: 設定
+      refinery/setting: 設定
     attributes:
-      refinery:
-        setting:
-          name: 名稱
-          value: 設定值
-          restricted: 限制
+      refinery/setting:
+        name: 名稱
+        value: 設定值
+        restricted: 限制


### PR DESCRIPTION
Fix for [DEPRECATION WARNING] Nested I18n namespace lookup under "activerecord.attributes.refinery" is no longer supported
Fix for [DEPRECATION WARNING] Nested I18n namespace lookup under "activerecord.models.refinery" is no longer supported

See rails ticket https://github.com/rails/rails/issues/1402 for details
