### PR TITLE
forcefully inject kaminari extension before subclassing AR::Base for Sett

### DIFF
--- a/settings/app/models/refinery/setting.rb
+++ b/settings/app/models/refinery/setting.rb
@@ -1,3 +1,9 @@
+# Have to explicitly require kaminari here so it injects its
+# ActiveRecord::Base.inherited magic before Setting subclasses.
+require 'kaminari'
+require 'kaminari/models/active_record_extension'
+::ActiveRecord::Base.send :include, Kaminari::ActiveRecordExtension
+
 module Refinery
   class Setting < ActiveRecord::Base
 


### PR DESCRIPTION
forcefully inject kaminari extension before subclassing AR::Base for Setting, because kaminari's initializer doesn't occur early enough apparently.
