### PR TITLE
Fix for Refinery::MenuItem.siblings

### DIFF
--- a/core/lib/refinery/menu_item.rb
+++ b/core/lib/refinery/menu_item.rb
@@ -67,7 +67,7 @@ module Refinery
     end
 
     def siblings
-      @siblings ||= ((has_parent? ? children : menu.roots) - [self])
+      @siblings ||= ((has_parent? ? parent.children : menu.roots) - [self])
     end
     alias_method :shown_siblings, :siblings
 


### PR DESCRIPTION
`MenuItem.siblings` was returning its own children, causing menus to render strangely when relying on first/last CSS classes. Presumably, the method should be returning the menu-item's parent's children -- in other words, the menu-item's siblings.
