### PR TITLE
Deprecation warning contained incorrect generator name

### DIFF
--- a/bin/refinerycms
+++ b/bin/refinerycms
@@ -58,7 +58,7 @@ module Refinery
           puts "To update your application:"
           puts "- Change the version of the 'refinerycms' gem in your Gemfile."
           puts "- Run bundle install"
-          puts "- Run bundle exec rails generate refinerycms --update"
+          puts "- Run bundle exec rails generate refinery:cms --update"
           puts "\n"
           exit(1)
         end

--- a/doc/guides/6 - Updating Refinery/2 - How to upgrade to edge Refinery.textile
+++ b/doc/guides/6 - Updating Refinery/2 - How to upgrade to edge Refinery.textile
@@ -18,12 +18,24 @@ First clone the git source in order to get the newest app generator.
 $ git clone git://github.com/resolve/refinerycms.git ~/refinerycms-edge
 </shell>
 
-h3. Overwrite your current application
+h3. Upgrade your current application
 
-Now use that generator to overwrite your current application.
+Replace the line that looks like this:
+
+<ruby>
+gem 'refinerycms'
+</ruby>
+
+With a line that looks like this:
+
+<ruby>
+gem 'refinerycms', :path => '~/refinerycms-edge'
+</ruby>
+
+Now use the refinerycms generator to update your application:
 
 <shell>
-$ ~/refinerycms-edge/bin/refinerycms path/to/my/app --update
+$ bundle exec rails generate refinery:cms --update
 </shell>
 
 h3. Solve any deprecation problems.


### PR DESCRIPTION
Updated guide to reflect new way of ugprading a refinery application
