### PR TITLE
Now you can use Guard to test all of Refinery!

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,8 @@ group :development, :test do
   gem 'capybara-webkit', :git => 'git://github.com/thoughtbot/capybara-webkit.git'
   gem 'spork', '0.9.0.rc9', :platforms => :ruby
   gem 'guard-spork', :platforms => :ruby
+  # Guard::RSpec spec_paths option added in this commit. Specified because Gem has not been cut yet.
+  gem 'guard-rspec', :git => "git://github.com/guard/guard-rspec.git", :branch => "23476db8d97ceae44f5d6efb51411e717645e76d"
 end
 
 # Bundle edge Rails instead:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,14 @@ GIT
       activerecord (>= 3.0.0)
 
 GIT
+  remote: git://github.com/guard/guard-rspec.git
+  revision: 23476db8d97ceae44f5d6efb51411e717645e76d
+  branch: 23476db8d97ceae44f5d6efb51411e717645e76d
+  specs:
+    guard-rspec (0.4.1)
+      guard (>= 0.4.0)
+
+GIT
   remote: git://github.com/parndt/refinerycms-i18n
   revision: 3376b2a27093c6c94db06fb74f3d8aed5cb20c6e
   specs:
@@ -187,8 +195,6 @@ GEM
     growl (1.0.3)
     guard (0.5.1)
       thor (~> 0.14.6)
-    guard-rspec (0.4.1)
-      guard (>= 0.4.0)
     guard-spork (0.2.1)
       guard (>= 0.2.2)
       spork (>= 0.8.4)
@@ -307,6 +313,7 @@ DEPENDENCIES
   capybara-webkit!
   coffee-rails (~> 3.1.0.rc)
   globalize3!
+  guard-rspec!
   guard-spork
   jquery-rails
   mysql2

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,32 @@
+guard 'rspec', :version => 2, :spec_paths => ['authentication/spec', 'core/spec', 'dashboard/spec', 'images/spec', 'pages/spec', 'resources/spec', 'settings/spec'], :cli => "--format Fuubar --color --drb" do
+  [ 
+    'authentication',
+    'core',
+    'dashboard',
+    'images',
+    'pages',
+    'resources',
+    'settings'
+  ].each do |engine|
+    watch(%r{^#{engine}/spec/.+_spec\.rb$})
+    watch(%r{^#{engine}/app/(.+)\.rb$})                           { |m| "#{engine}/spec/#{m[1]}_spec.rb" }
+    watch(%r{^#{engine}/lib/(.+)\.rb$})                           { |m| "#{engine}/spec/lib/#{m[1]}_spec.rb" }
+    watch(%r{^#{engine}/app/controllers/(.+)_(controller)\.rb$})  { |m| ["#{engine}/spec/routing/#{m[1]}_routing_spec.rb", "#{engine}/spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb", "#{engine}/spec/acceptance/#{m[1]}_spec.rb"] }
+    watch(%r{^#{engine}/spec/support/(.+)\.rb$})                  { "#{engine}/spec" }
+    watch("#{engine}/spec/spec_helper.rb")                        { "#{engine}/spec" }
+    watch("#{engine}/config/routes.rb")                           { "#{engine}/spec/routing" }
+    watch("#{engine}/app/controllers/application_controller.rb")  { "#{engine}/spec/controllers" }
+    # Capybara request specs
+    # TODO: Requests specs do not follow a convention that matches view locations so this "suggested" watch and match
+    # doesn't function. Should we refactor the request_specs or babysit this file?
+    # watch(%r{^#{engine}/app/views/(.+)/.*\.(erb|haml)$})          { |m| "#{engine}/spec/requests/#{m[1]}_spec.rb" }
+  end
+end
+
+guard 'spork', :wait => 60, :cucumber => false, :rspec_env => { 'RAILS_ENV' => 'test' } do
+  watch('config/application.rb')
+  watch('config/environment.rb')
+  watch(%r{^config/environments/.+\.rb$})
+  watch(%r{^config/initializers/.+\.rb$})
+  watch('spec/spec_helper.rb')
+end

--- a/testing/lib/generators/files/Guardfile
+++ b/testing/lib/generators/files/Guardfile
@@ -1,6 +1,3 @@
-# A sample Guardfile
-# More info at https://github.com/guard/guard#readme
-
 guard 'rspec', :version => 2 do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }


### PR DESCRIPTION
Add a Guardfile to the refinerycms main project. Now you can use Guard to test all of Refinery!

note: a specific commit_id is specific in the Gemfile for guard-rspec. I added functionality to guard-rspec which has not been cut into a gem yet which is required because of how the refinery project is laid out. I'll keep on this and update it when the gem has been cut.
