### PR TITLE
explicitly define refinerycms-testing in development group will remedy Re

### DIFF
--- a/testing/lib/generators/files/Gemfile
+++ b/testing/lib/generators/files/Gemfile
@@ -8,7 +8,9 @@ gemspec
 
 gem 'jquery-rails'
 
-group :development, :test do  
+group :development, :test do
+  gem 'refinerycms-testing', '~> 2.0.0'
+  
   require 'rbconfig'
   
   platforms :mswin, :mingw do
@@ -43,7 +45,9 @@ group :development, :test do
 end
 
 group :assets do
-  gem 'sass-rails', "~> 3.1.0.rc"
-  gem 'coffee-rails', "~> 3.1.0.rc"
+  gem 'sass-rails', "~> 3.1.0.rc.5"
+  gem 'coffee-rails', "~> 3.1.0.rc.5"
   gem 'uglifier'
 end
+
+gem 'arel', '2.1.4' # 2.1.5 is broken. see https://github.com/rails/arel/issues/72


### PR DESCRIPTION
explicitly define refinerycms-testing in development group will remedy Refinery::Testing not being loaded in testing environment. Without this set the Refinery.roots("testing") pathname is not found causing the Image factory to not be able to find it's assets directory.
