### PR TITLE
Ignore Guard notification gems if we are running bundle install from Travis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,23 +54,27 @@ group :development, :test do
     gem 'spork', '0.9.0.rc9'
     gem 'guard-spork'
     
-    if Config::CONFIG['target_os'] =~ /darwin/i
-      gem 'rb-fsevent', '>= 0.3.9'
-      gem 'growl',      '~> 1.0.3'
-    end
-    if Config::CONFIG['target_os'] =~ /linux/i
-      gem 'rb-inotify', '>= 0.5.1'
-      gem 'libnotify',  '~> 0.1.3'
+    unless ENV['TRAVIS']
+      if Config::CONFIG['target_os'] =~ /darwin/i
+        gem 'rb-fsevent', '>= 0.3.9'
+        gem 'growl',      '~> 1.0.3'
+      end
+      if Config::CONFIG['target_os'] =~ /linux/i
+        gem 'rb-inotify', '>= 0.5.1'
+        gem 'libnotify',  '~> 0.1.3'
+      end
     end
   end
 
   platforms :jruby do
-    if Config::CONFIG['target_os'] =~ /darwin/i
-      gem 'growl',      '~> 1.0.3'
-    end
-    if Config::CONFIG['target_os'] =~ /linux/i
-      gem 'rb-inotify', '>= 0.5.1'
-      gem 'libnotify',  '~> 0.1.3'
+    unless ENV['TRAVIS']
+      if Config::CONFIG['target_os'] =~ /darwin/i
+        gem 'growl',      '~> 1.0.3'
+      end
+      if Config::CONFIG['target_os'] =~ /linux/i
+        gem 'rb-inotify', '>= 0.5.1'
+        gem 'libnotify',  '~> 0.1.3'
+      end
     end
   end
 end


### PR DESCRIPTION
It would be great if this could be tested in a remote branch on Travis before merging into master. From reading Travis' documentation the TRAVIS env variable should be set to true which would ignore the installation of the guard notification gems.

Currently we have failing travis builds because libnotify is not found because the ubuntu libnotify-bin package isn't part of any of the cookbooks that travis runs when setting up it's vagrant environment.
