### PR TITLE
therubyracer is not being used

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ gem 'awesome_nested_set', :git => 'git://github.com/collectiveidea/awesome_neste
 # REFINERY CMS DEVELOPMENT ====================================================
 
 gem 'arel', '2.1.4' # 2.1.5 was broken. see https://github.com/rails/arel/issues/72
-gem 'therubyracer'
 
 group :development, :test do
   gem 'refinerycms-testing',    '~> 2.0.0'


### PR DESCRIPTION
Doesn't look like we are actually using therubyracer anywhere in the project. 

Fixing build error:
/home/vagrant/builds/resolve/refinerycms/config/database.yml.sqlite3 to /home/vagrant/builds/resolve/refinerycms/config/database.yml
148ruby: symbol lookup error: /home/vagrant/.rvm/gems/ruby-1.9.2-p290/gems/therubyracer-0.9.3/ext/v8/v8.so: undefined symbol: _ZN2v86LockerC1Ev

According to this [IRC conversation](http://irclogger.com/.travis/2011-07-03) between svenfuchs and anatres_, therubyracer is built on the travis platform by default with a precompiled x86-64 version of libv8. We could fix this by specifying the libv8 gem with a platform of x86-64 explicitly, but like I said, it doesn't look like we actually use therubyracer anywhere right now.
