### PR TITLE
Use globalize3 beta gem instead of master branch of git repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ gemspec
 
 # gem 'refinerycms', '~> 2.0.0'
 gem 'seo_meta', :git => 'git://github.com/parndt/seo_meta.git'
-gem 'globalize3', :git => 'git://github.com/svenfuchs/globalize3.git'
 gem 'awesome_nested_set', :git => 'git://github.com/collectiveidea/awesome_nested_set.git'
 
 # END REFINERY CMS ============================================================

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,15 +29,6 @@ GIT
       refinerycms-generators (~> 2.0)
 
 GIT
-  remote: git://github.com/svenfuchs/globalize3.git
-  revision: f2022afe9729517834a0e929ec0df93447b24906
-  specs:
-    globalize3 (0.2.0.beta1)
-      activemodel (>= 3.0.0)
-      activerecord (>= 3.0.0)
-      paper_trail (~> 2)
-
-GIT
   remote: git://github.com/thoughtbot/capybara-webkit.git
   revision: 82ae0c298f11098e3393806a595d1ffa8615c4fc
   specs:
@@ -67,7 +58,7 @@ PATH
       awesome_nested_set (~> 2.0)
       coffee-rails (>= 3.1.0.rc5)
       friendly_id_globalize3 (~> 3.2.1)
-      globalize3 (~> 0.1)
+      globalize3 (~> 0.2.0.beta3)
       jquery-rails
       kaminari (~> 0.12)
       rails (>= 3.1.0.rc5)
@@ -87,7 +78,6 @@ PATH
     refinerycms-pages (2.0.0)
       awesome_nested_set (~> 2.0)
       friendly_id_globalize3 (~> 3.2.1)
-      globalize3 (~> 0.1)
       refinerycms-core (= 2.0.0)
       seo_meta (~> 1.1)
     refinerycms-resources (2.0.0)
@@ -185,6 +175,10 @@ GEM
       rspec (~> 2.0)
       rspec-instafail (~> 0.1.8)
       ruby-progressbar (~> 0.0.10)
+    globalize3 (0.2.0.beta3)
+      activemodel (>= 3.0.0)
+      activerecord (>= 3.0.0)
+      paper_trail (~> 2)
     growl (1.0.3)
     guard (0.6.0)
       thor (~> 0.14.6)
@@ -302,7 +296,6 @@ DEPENDENCIES
   awesome_nested_set!
   capybara-webkit!
   coffee-rails (~> 3.1.0.rc)
-  globalize3!
   growl (~> 1.0.3)
   guard-rspec!
   guard-spork

--- a/core/lib/gemspec.rb
+++ b/core/lib/gemspec.rb
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'refinerycms-generators',      '= #{::Refinery::Version}'
   s.add_dependency 'acts_as_indexed',             '~> 0.7'
   s.add_dependency 'friendly_id_globalize3',      '~> 3.2.1'
-  s.add_dependency 'globalize3',                  '~> 0.1'
+  s.add_dependency 'globalize3',                  '~> 0.2.0.beta3'
   s.add_dependency 'awesome_nested_set',          '~> 2.0'
   s.add_dependency 'rails',                       '>= 3.1.0.rc5'
   s.add_dependency 'truncate_html',               '~> 0.5'

--- a/core/refinerycms-core.gemspec
+++ b/core/refinerycms-core.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.version           = %q{2.0.0}
   s.summary           = %q{Core engine for Refinery CMS}
   s.description       = %q{The core of Refinery CMS. This handles the common functionality and is required by most engines}
-  s.date              = %q{2011-08-14}
+  s.date              = %q{2011-08-15}
   s.email             = %q{info@refinerycms.com}
   s.homepage          = %q{http://refinerycms.com}
   s.rubyforge_project = %q{refinerycms}
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'refinerycms-generators',      '= 2.0.0'
   s.add_dependency 'acts_as_indexed',             '~> 0.7'
   s.add_dependency 'friendly_id_globalize3',      '~> 3.2.1'
-  s.add_dependency 'globalize3',                  '~> 0.1'
+  s.add_dependency 'globalize3',                  '~> 0.2.0.beta3'
   s.add_dependency 'awesome_nested_set',          '~> 2.0'
   s.add_dependency 'rails',                       '>= 3.1.0.rc5'
   s.add_dependency 'truncate_html',               '~> 0.5'

--- a/pages/lib/gemspec.rb
+++ b/pages/lib/gemspec.rb
@@ -29,7 +29,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'refinerycms-core',            '= #{::Refinery::Version}'
   s.add_dependency 'friendly_id_globalize3',      '~> 3.2.1'
-  s.add_dependency 'globalize3',                  '~> 0.1'
   s.add_dependency 'awesome_nested_set',          '~> 2.0'
   s.add_dependency 'seo_meta',                    '~> 1.1'
 end

--- a/pages/refinerycms-pages.gemspec
+++ b/pages/refinerycms-pages.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.version           = %q{2.0.0}
   s.summary           = %q{Pages engine for Refinery CMS}
   s.description       = %q{The default content engine of Refinery CMS. This engine handles the administration and display of user-editable pages.}
-  s.date              = %q{2011-08-14}
+  s.date              = %q{2011-08-15}
   s.email             = %q{info@refinerycms.com}
   s.homepage          = %q{http://refinerycms.com}
   s.rubyforge_project = %q{refinerycms}
@@ -131,7 +131,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'refinerycms-core',            '= 2.0.0'
   s.add_dependency 'friendly_id_globalize3',      '~> 3.2.1'
-  s.add_dependency 'globalize3',                  '~> 0.1'
   s.add_dependency 'awesome_nested_set',          '~> 2.0'
   s.add_dependency 'seo_meta',                    '~> 1.1'
 end


### PR DESCRIPTION
We should lock third party gems at stable, rc, or beta gems where possible!
