### PR TITLE
Refactor globalize3 seo_meta extensions into an initializer

### DIFF
--- a/db/seeds/pages.rb
+++ b/db/seeds/pages.rb
@@ -1,14 +1,6 @@
 module Refinery
   ::Refinery::Page.reset_column_information
 
-  # Check whether all columns are applied yet by seo_meta.
-  unless !defined?(::SeoMeta) || ::SeoMeta.attributes.keys.all? { |k|
-    ::Refinery::Page.translation_class.instance_methods.include?(k)
-  }
-    # Make pages model seo_meta because not all columns are accessible.
-    ::Refinery::Page.translation_class.send :is_seo_meta
-  end
-
   page_position = -1
 
   unless ::Refinery::Page.where(:menu_match => "^/$").any?

--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -1,5 +1,3 @@
-require 'globalize3'
-
 module Refinery
   class Page < ActiveRecord::Base
 
@@ -12,47 +10,30 @@ module Refinery
     # when collecting the pages path how is each of the pages seperated?
     PATH_SEPARATOR = " - "
 
-    if self.respond_to?(:translates)
-      translates :title, :custom_title, :meta_keywords, :meta_description, :browser_title, :include => :seo_meta
+    translates :title, :custom_title, :meta_keywords, :meta_description, :browser_title, :include => :seo_meta
 
-      # Set up support for meta tags through translations.
-      if self.respond_to?(:translation_class)
-        attr_accessible :title
-        # set allowed attributes for mass assignment
-        self.translation_class.send :attr_accessible, :browser_title, :meta_description, :meta_keywords, :locale
+    attr_accessible :title
 
-        if self.translation_class.table_exists?
-          # Instruct the Translation model to have meta tags.
-          self.translation_class.send :is_seo_meta
+    # Delegate SEO Attributes to globalize3 translation
+    seo_fields = ::SeoMeta.attributes.keys.map{|a| [a, :"#{a}="]}.flatten
+    delegate *(seo_fields << {:to => :translation})
+    
+    after_save proc {|m| m.translation.save}
 
-          fields = ::SeoMeta.attributes.keys.reject{|f|
-            self.column_names.map(&:to_sym).include?(f)
-          }.map{|a| [a, :"#{a}="]}.flatten
-          delegate *(fields << {:to => :translation})
-          after_save proc {|m| m.translation.save}
-        end
-
-        # Wrap up the logic of finding the pages based on the translations table.
-        def self.with_globalize(conditions = {})
-          conditions = {:locale => Globalize.locale}.merge(conditions)
-          globalized_conditions = {}
-          conditions.keys.each do |key|
-            if (translated_attribute_names.map(&:to_s) | %w(locale)).include?(key.to_s)
-              globalized_conditions["#{self.translation_class.table_name}.#{key}"] = conditions.delete(key)
-            end
-          end
-          # A join implies readonly which we don't really want.
-          joins(:translations).where(globalized_conditions).where(conditions).readonly(false)
-        end
-      else
-        # No translations, just default to normal behaviour.
-        def self.with_globalize(conditions = {})
-          where(conditions)
+    # Wrap up the logic of finding the pages based on the translations table.
+    def self.with_globalize(conditions = {})
+      conditions = {:locale => Globalize.locale}.merge(conditions)
+      globalized_conditions = {}
+      conditions.keys.each do |key|
+        if (translated_attribute_names.map(&:to_s) | %w(locale)).include?(key.to_s)
+          globalized_conditions["#{self.translation_class.table_name}.#{key}"] = conditions.delete(key)
         end
       end
-
-      before_create :ensure_locale, :if => proc { |c| ::Refinery.i18n_enabled? }
+      # A join implies readonly which we don't really want.
+      joins(:translations).where(globalized_conditions).where(conditions).readonly(false)
     end
+
+    before_create :ensure_locale, :if => proc { |c| ::Refinery.i18n_enabled? }
 
     attr_accessible :id, :deletable, :link_url, :menu_match, :meta_keywords,
                     :skip_to_first_child, :position, :show_in_menu, :draft,

--- a/pages/db/migrate/20110329080451_create_seo_meta.rb
+++ b/pages/db/migrate/20110329080451_create_seo_meta.rb
@@ -28,9 +28,6 @@ class CreateSeoMeta < ActiveRecord::Migration
     # Reset column information because otherwise the old columns will still exist.
     ::Refinery::Page.translation_class.reset_column_information
 
-    # Re-attach seo_meta
-    ::Refinery::Page.translation_class.send :is_seo_meta
-
     # Migrate data
     existing_translations.each do |translation|
       ::Refinery::Page.translation_class.find(translation['id']).update_attributes(

--- a/pages/db/seeds/pages.rb
+++ b/pages/db/seeds/pages.rb
@@ -1,14 +1,6 @@
 module Refinery
   ::Refinery::Page.reset_column_information
 
-  # Check whether all columns are applied yet by seo_meta.
-  unless !defined?(::SeoMeta) || ::SeoMeta.attributes.keys.all? { |k|
-    ::Refinery::Page.translation_class.instance_methods.include?(k)
-  }
-    # Make pages model seo_meta because not all columns are accessible.
-    ::Refinery::Page.translation_class.send :is_seo_meta
-  end
-
   page_position = -1
 
   unless ::Refinery::Page.where(:menu_match => "^/$").any?

--- a/pages/lib/refinerycms-pages.rb
+++ b/pages/lib/refinerycms-pages.rb
@@ -62,6 +62,12 @@ module Refinery
           }
         end
       end
+      
+      initializer "extend globalize3 with seo_meta", :after => :load_config_initializers do
+        Page.translation_class.send(:is_seo_meta)
+        # set allowed attributes for mass assignment
+        Page.translation_class.send :attr_accessible, :browser_title, :meta_description, :meta_keywords, :locale
+      end
 
     end
   end


### PR DESCRIPTION
Refactor defensive programming out of Page model surrounding Globalize3 and seo_meta

This will clean the Page model up quite a bit and is a good start for abstracting Globalize3 extensions out of the Pages engine
