### PR TITLE
Support for Limiting Menu Depth

### DIFF
--- a/core/app/views/refinery/_menu_branch.html.erb
+++ b/core/app/views/refinery/_menu_branch.html.erb
@@ -6,12 +6,13 @@
 <li<%= ['', css].compact.join(' ').gsub(/\ *$/, '').html_safe %>>
 <%= link_to(menu_branch.title, main_app.url_for(menu_branch.url)) -%>
   <% if ( (children = menu_branch.children unless hide_children).present? &&
-          (!local_assigns[:menu_levels] || menu_branch.depth < local_assigns[:menu_levels]) ) -%>
+          (!local_assigns[:menu_levels] || menu_branch.ancestors.length < local_assigns[:menu_levels]) ) -%>
     <ul class='clearfix'>
       <%= render :partial => '/refinery/menu_branch', :collection => children,
                  :locals => {
                    :apply_css => local_assigns[:apply_css],
-                   :hide_children => !!hide_children
+                   :hide_children => !!hide_children,
+									 :menu_levels => local_assigns[:menu_levels]
                  } -%>
     </ul>
   <% end -%>


### PR DESCRIPTION
Support for limiting the depth of rendering for child menu items.

Defaults to showing all levels if 'menu_levels' local is passed, but if the 'menu_levels' local is set to an integer when calling the partial '/refinery/menu_branch' then that number of child pages will be rendered.
