### PR TITLE
Improve usability for people who are just including controller_macros in 

### DIFF
--- a/testing/lib/refinery/testing/controller_macros/authentication.rb
+++ b/testing/lib/refinery/testing/controller_macros/authentication.rb
@@ -1,3 +1,5 @@
+require 'refinery/testing/factories/user'
+
 module Refinery
   module Testing
     module ControllerMacros

--- a/testing/lib/refinery/testing/request_macros/authentication.rb
+++ b/testing/lib/refinery/testing/request_macros/authentication.rb
@@ -1,3 +1,5 @@
+require 'refinery/testing/factories/user'
+
 module Refinery
   module Testing
     module RequestMacros


### PR DESCRIPTION
Improve usability for people who are just including controller_macros in their spec helpers. The user factory is required by these macro files.
