### PR TITLE
Change Refinery's authentication_keys config to be specific to the User Model

### DIFF
--- a/authentication/app/models/refinery/user.rb
+++ b/authentication/app/models/refinery/user.rb
@@ -11,7 +11,7 @@ module Refinery
     # Include default devise modules. Others available are:
     # :token_authenticatable, :confirmable, :lockable and :timeoutable
     if self.respond_to?(:devise)
-      devise :database_authenticatable, :registerable, :recoverable, :rememberable, :trackable, :validatable
+      devise :database_authenticatable, :registerable, :recoverable, :rememberable, :trackable, :validatable, :authentication_keys => [:login]
     end
 
     # Setup accessible (or protected) attributes for your model

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -22,7 +22,7 @@ require 'devise'
   # authenticating an user, both parameters are required. Remember that those
   # parameters are used only when authenticating and not when retrieving from
   # session. If you need permissions, you should implement that in a before filter.
-  config.authentication_keys = [ :login ]
+  # config.authentication_keys = [ :login ]
 
   # Tell if authentication through request.params is enabled. True by default.
   # config.params_authenticatable = true

--- a/testing/lib/generators/files/spec/dummy/config/initializers/devise.rb
+++ b/testing/lib/generators/files/spec/dummy/config/initializers/devise.rb
@@ -22,7 +22,7 @@ require 'devise'
   # authenticating an user, both parameters are required. Remember that those
   # parameters are used only when authenticating and not when retrieving from
   # session. If you need permissions, you should implement that in a before filter.
-  config.authentication_keys = [ :login ]
+  # config.authentication_keys = [ :login ]
 
   # Tell if authentication through request.params is enabled. True by default.
   # config.params_authenticatable = true


### PR DESCRIPTION
I've got an application with a partitioned devise configuration (https://github.com/strangeloop/site/tree/split-devise).  Currently Refinery needs a global authentication_keys config, like the following in config/initializers/devise.rb:

config.authentication_keys = [ :login ]

This prevents me from using different authentication_keys for the other devise model in the application (I want to use the default :email key).  Changing Refinery have the authentication_key attached to the User class rather than a global config fixes this issue.
