### PR TITLE
Make fast_menu include all slugs

### DIFF
--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -97,7 +97,7 @@ module Refinery
     scope :fast_menu, proc {
       # First, apply a filter to determine which pages to show.
       # We need to join to the page's slug to avoid multiple queries.
-      pages = live.in_menu.includes(:slug).order('lft ASC')
+      pages = live.in_menu.includes(:slug, :slugs).order('lft ASC')
 
       # Now we only want to select particular columns to avoid any further queries.
       # Title and menu_title are retrieved in the next block below so they are not here.


### PR DESCRIPTION
fast_menu was making a query for each slug. this fixes it (thanks @parndt)
