### PR TITLE
Make resource's max file size configurable via settings

### DIFF
--- a/resources/app/models/refinery/resource.rb
+++ b/resources/app/models/refinery/resource.rb
@@ -3,7 +3,7 @@ module ::Refinery
 
     attr_accessible :id, :file
     # What is the max resource size a user can upload
-    MAX_SIZE_IN_MB = 50
+    MAX_SIZE_IN_MB = RefinerySetting.find_or_set(:resource_max_size, 50)
 
     resource_accessor :file
 


### PR DESCRIPTION
Easy one-liner to make resource's max file size configurable via settings.

I'd love it if somebody would confirm that this works on master. I'm not ready to upgrade to 3.1.0 yet so I only tested it on 1.0.8.
