### PR TITLE
bump capybara and capybara-webkit versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ group :development, :test do
   gem 'refinerycms-testing',    '~> 2.0.0'
   gem 'rcov', :platform => :mri_18
   gem 'simplecov', :platform => :mri_19
-  gem 'capybara-webkit'
+  gem 'capybara-webkit', '~> 0.6.1'
   gem 'spork', '0.9.0.rc9', :platforms => :ruby
   gem 'guard-spork', :platforms => :ruby
 
@@ -89,8 +89,8 @@ end
 # Gems used only for assets and not required
 # in production environments by default.
 group :assets do
-  gem 'sass-rails'
-  gem 'coffee-rails'
+  gem 'sass-rails', '~> 3.1.0'
+  gem 'coffee-rails', '~> 3.1.0'
   gem 'uglifier'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ PATH
     refinerycms-testing (2.0.0)
       capybara (~> 1.0.0)
       database_cleaner
-      factory_girl (~> 2.0.3)
+      factory_girl_rails (~> 1.2.0)
       fuubar
       guard-rspec (~> 0.4.2)
       json_pure
@@ -148,7 +148,10 @@ GEM
     erubis (2.7.0)
     execjs (1.2.4)
       multi_json (~> 1.0)
-    factory_girl (2.0.5)
+    factory_girl (2.1.0)
+    factory_girl_rails (1.2.0)
+      factory_girl (~> 2.1.0)
+      railties (>= 3.0.0)
     ffi (1.0.9)
     friendly_id_globalize3 (3.2.1.5)
       babosa (~> 0.3.0)
@@ -278,8 +281,8 @@ PLATFORMS
 
 DEPENDENCIES
   awesome_nested_set!
-  capybara-webkit
-  coffee-rails
+  capybara-webkit (~> 0.6.1)
+  coffee-rails (~> 3.1.0)
   growl (~> 1.0.3)
   guard-spork
   jquery-rails
@@ -291,7 +294,7 @@ DEPENDENCIES
   refinerycms!
   refinerycms-i18n (~> 2.0.0)!
   refinerycms-testing (~> 2.0.0)
-  sass-rails
+  sass-rails (~> 3.1.0)
   simplecov
   spork (= 0.9.0.rc9)
   sqlite3

--- a/testing/lib/gemspec.rb
+++ b/testing/lib/gemspec.rb
@@ -25,18 +25,18 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'database_cleaner'
   s.add_dependency 'launchy'
-  s.add_dependency 'factory_girl',      '~> 2.0.3'
+  s.add_dependency 'factory_girl_rails',      '~> 1.2.0'
   s.add_dependency 'json_pure'
-  s.add_dependency 'rack-test',         '>= 0.5.6'
+  s.add_dependency 'rack-test',               '>= 0.5.6'
 
   # RSpec
-  s.add_dependency 'rspec-rails',       '2.6.1'
+  s.add_dependency 'rspec-rails',             '2.6.1'
   s.add_dependency 'fuubar'
   s.add_dependency 'rspec-instafail'
-  s.add_dependency 'capybara',          '~> 1.0.0'
+  s.add_dependency 'capybara',                '~> 1.0.0'
 
   # Guard
-  s.add_dependency 'guard-rspec',       '~> 0.4.2'
+  s.add_dependency 'guard-rspec',             '~> 0.4.2'
 
   s.files             = [
     '#{%w( **/{*,.rspec,.gitignore,.yardopts} ).map { |file| Pathname.glob(gempath.join(file)) }.flatten.reject{|f|

--- a/testing/refinerycms-testing.gemspec
+++ b/testing/refinerycms-testing.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.version           = %q{2.0.0}
   s.summary           = %q{Testing plugin for Refinery CMS}
   s.description       = %q{This plugin adds the ability to run cucumber and rspec against the RefineryCMS gem while inside a RefineryCMS project}
-  s.date              = %q{2011-09-03}
+  s.date              = %q{2011-09-04}
   s.email             = %q{info@refinerycms.com}
   s.homepage          = %q{http://refinerycms.com}
   s.rubyforge_project = %q{refinerycms}
@@ -19,18 +19,18 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'database_cleaner'
   s.add_dependency 'launchy'
-  s.add_dependency 'factory_girl',      '~> 2.0.3'
+  s.add_dependency 'factory_girl_rails',      '~> 1.2.0'
   s.add_dependency 'json_pure'
-  s.add_dependency 'rack-test',         '>= 0.5.6'
+  s.add_dependency 'rack-test',               '>= 0.5.6'
 
   # RSpec
-  s.add_dependency 'rspec-rails',       '2.6.1'
+  s.add_dependency 'rspec-rails',             '2.6.1'
   s.add_dependency 'fuubar'
   s.add_dependency 'rspec-instafail'
-  s.add_dependency 'capybara',          '~> 1.0.0'
+  s.add_dependency 'capybara',                '~> 1.0.0'
 
   # Guard
-  s.add_dependency 'guard-rspec',       '~> 0.4.2'
+  s.add_dependency 'guard-rspec',             '~> 0.4.2'
 
   s.files             = [
     '.rspec',
@@ -112,6 +112,7 @@ Gem::Specification.new do |s|
     'lib/generators/files/spec/dummy/public/favicon.ico',
     'lib/generators/files/spec/dummy/script',
     'lib/generators/files/spec/dummy/script/rails',
+    'lib/generators/files/spec/dummy/tmp',
     'lib/generators/files/spec/dummy/version.rb',
     'lib/generators/files/spec/rcov.opts',
     'lib/generators/files/spec/spec_helper.rb',


### PR DESCRIPTION
lock proper rails asset gem versions
use factory_girl_rails instead of factory_girl to gain the additional rails support
