### PR TITLE
Removed (commented out) adding of redundant index on :id fields in engine tables.

### DIFF
--- a/lib/refinery/generators/engine/templates/db/migrate/create_plural_name.rb
+++ b/lib/refinery/generators/engine/templates/db/migrate/create_plural_name.rb
@@ -17,9 +17,6 @@ class Create<%= class_name.pluralize %> < ActiveRecord::Migration
       t.timestamps
     end
 
-    # rails adds a primary key to the :id field automagically, so adding the following index was redundant
-    #add_index :refinery_<%= table_name %>, :id
-
     load(Rails.root.join('db', 'seeds', '<%= class_name.pluralize.underscore.downcase %>.rb'))
   end
 


### PR DESCRIPTION
Removed (commented out) adding of index on :id fields in engine tables. Rails automatically creates a primary key on :id, so another index was/is not necessary.
