### PR TITLE
Fixed tooltip hover glitch in admin panel

### DIFF
--- a/core/app/assets/javascripts/refinery/admin.js
+++ b/core/app/assets/javascripts/refinery/admin.js
@@ -346,7 +346,7 @@ init_tooltips = function(args){
           }
 
           tooltip.css({
-            'top': $(this).offset().top - tooltip.outerHeight() - 2
+            'top': $(this).offset().top - tooltip.outerHeight() - 10
           });
 
           nib.css({


### PR DESCRIPTION
Before if you hovered on an image in the admin panel to edit a page, or view the page it would flicker and cause the tooltip to disappear then reappear.  I solved this by adding more distance between the tooltip and the div.
