### PR TITLE
1 0 stable Menu CSS Selectable from Settings

### DIFF
--- a/core/app/views/shared/_menu.html.erb
+++ b/core/app/views/shared/_menu.html.erb
@@ -3,7 +3,7 @@
   # Refinery::Menu is smart enough to remember all of the items in the original collection.
   if (roots = local_assigns[:roots] || (collection ||= @menu_pages).roots).present?
     dom_id ||= 'menu'
-    css = [(css || 'menu'), 'clearfix'].flatten.join(' ')
+    css = [menu_css_class].join(' ').html_safe
     hide_children = RefinerySetting.find_or_set(:menu_hide_children, false) if hide_children.nil?
 -%>
 <nav id='<%= dom_id %>' class='<%= css %>'>

--- a/core/app/views/shared/_menu_branch.html.erb
+++ b/core/app/views/shared/_menu_branch.html.erb
@@ -8,7 +8,7 @@
 <li<%= ['', css, dom_id].compact.join(' ').gsub(/\ *$/, '').html_safe %>>
   <%= link_to menu_branch.title, menu_branch.url -%>
   <% if (children = menu_branch.children unless hide_children).present? -%>
-    <ul class='clearfix'>
+ 	<ul class="<%= [menu_subtree_css_class].join(' ').html_safe %>">
       <%= render :partial => '/shared/menu_branch', :collection => children,
                  :locals => {
                    :apply_css => local_assigns[:apply_css],

--- a/core/lib/refinery/helpers/menu_helper.rb
+++ b/core/lib/refinery/helpers/menu_helper.rb
@@ -91,7 +91,15 @@ module Refinery
         # finally passing to rails' "current_page?" method.
         [path, URI.decode(path)].include?(url) || path == "/#{page.id}" || current_page?(page)
       end
-
+	  
+	  # Provide default css or use custom for Menu
+	  def menu_css_class
+		RefinerySetting.find_or_set(:menu_css_class, ['menu', 'clearfix' ])
+      end
+     # Provide default css or use custom for Submenu
+	  def menu_subtree_css_class
+		RefinerySetting.find_or_set(:menu_subtree_css_class, [ 'clearfix' ])
+      end
     end
   end
 end


### PR DESCRIPTION
I've modified refinery that it's possible for a user to specify which CSS Class to use for the generating the Menus and Submenus via Refinery Settings

This was in my case needed as I integrated Refinery into a larger existing application
