### PR TITLE
Fix Refinery::MenuItem typo

### DIFF
--- a/core/lib/refinery/menu_item.rb
+++ b/core/lib/refinery/menu_item.rb
@@ -67,7 +67,7 @@ module Refinery
     end
 
     def siblings
-      @siblings ||= ((has_parent? ? children : menu.roots) - [self])
+      @siblings ||= ((has_parent? ? parent.children : menu.roots) - [self])
     end
     alias_method :shown_siblings, :siblings
 


### PR DESCRIPTION
Fixed an omission that would have led to querying a menu item's children for siblings.
