### PR TITLE
Fix for will_paginate version 3.0.1

### DIFF
--- a/core/config/initializers/will_paginate_monkeypatch.rb
+++ b/core/config/initializers/will_paginate_monkeypatch.rb
@@ -3,9 +3,8 @@ module WillPaginate
     class LinkRenderer < ViewHelpers::LinkRenderer
       def url(page)
         @base_url_params ||= begin
-          url_params = base_url_params
+          url_params = merge_get_params(default_url_params)
           merge_optional_params(url_params)
-          url_params
         end
 
         url_params = @base_url_params.dup

--- a/core/lib/gemspec.rb
+++ b/core/lib/gemspec.rb
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'awesome_nested_set',          '~> 2.0'
   s.add_dependency 'rails',                       '>= 3.1.1.rc1'
   s.add_dependency 'truncate_html',               '~> 0.5'
-  s.add_dependency 'will_paginate',               '~> 3.0'
+  s.add_dependency 'will_paginate',               '~> 3.0.1'
   s.add_dependency 'sass-rails',                  '~> 3.1.0'
   s.add_dependency 'coffee-rails',                '~> 3.1.0'
   s.add_dependency 'uglifier'

--- a/core/refinerycms-core.gemspec
+++ b/core/refinerycms-core.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.version           = %q{2.0.0}
   s.summary           = %q{Core engine for Refinery CMS}
   s.description       = %q{The core of Refinery CMS. This handles the common functionality and is required by most engines}
-  s.date              = %q{2011-09-20}
+  s.date              = %q{2011-09-22}
   s.email             = %q{info@refinerycms.com}
   s.homepage          = %q{http://refinerycms.com}
   s.rubyforge_project = %q{refinerycms}
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'awesome_nested_set',          '~> 2.0'
   s.add_dependency 'rails',                       '>= 3.1.1.rc1'
   s.add_dependency 'truncate_html',               '~> 0.5'
-  s.add_dependency 'will_paginate',               '~> 3.0'
+  s.add_dependency 'will_paginate',               '~> 3.0.1'
   s.add_dependency 'sass-rails',                  '~> 3.1.0'
   s.add_dependency 'coffee-rails',                '~> 3.1.0'
   s.add_dependency 'uglifier'


### PR DESCRIPTION
Hello,

Using a fresh refinerycms install using the master branch, I'm getting an error visiting the settings page for the second time, that's right, the first time I visit the page http://localhost:3030/refinery/settings everything works as expected but the second time I do I get this exception:

``` ruby
undefined local variable or method `base_url_params' for #<WillPaginate::ActionView::LinkRenderer:0x00000103a00ec0>
```

``` ruby
/usr/local/rvm/gems/ruby-1.9.3-preview1/bundler/gems/refinerycms-eaeb7414eab9/core/config/initializers/will_paginate_monkeypatch.rb:6:in `url'
will_paginate (3.0.1) lib/will_paginate/view_helpers/link_renderer.rb:93:in `link'
will_paginate (3.0.1) lib/will_paginate/view_helpers/link_renderer.rb:45:in `page_number'
will_paginate (3.0.1) lib/will_paginate/view_helpers/link_renderer.rb:28:in `block in to_html'
will_paginate (3.0.1) lib/will_paginate/view_helpers/link_renderer.rb:26:in `map'
will_paginate (3.0.1) lib/will_paginate/view_helpers/link_renderer.rb:26:in `to_html'
will_paginate (3.0.1) lib/will_paginate/view_helpers.rb:95:in `will_paginate'
will_paginate (3.0.1) lib/will_paginate/view_helpers/action_view.rb:33:in `will_paginate'
/usr/local/rvm/gems/ruby-1.9.3-preview1/bundler/gems/refinerycms-eaeb7414eab9/settings/app/views/refinery/admin/settings/_settings.html.erb:1:in `__usr_local_rvm_gems_ruby_______preview__bundler_gems_refinerycms_eaeb____eab__settings_app_views_refinery_admin_settings__settings_html_erb___3431403035821896973_2157785960'
actionpack (3.1.1.rc1) lib/action_view/template.rb:144:in `block in render'
activesupport (3.1.1.rc1) lib/active_support/notifications.rb:55:in `instrument'
actionpack (3.1.1.rc1) lib/action_view/template.rb:142:in `render'
actionpack (3.1.1.rc1) lib/action_view/renderer/partial_renderer.rb:256:in `render_partial'
actionpack (3.1.1.rc1) lib/action_view/renderer/partial_renderer.rb:228:in `block (2 levels) in render'
actionpack (3.1.1.rc1) lib/action_view/renderer/abstract_renderer.rb:33:in `block in instrument'
activesupport (3.1.1.rc1) lib/active_support/notifications.rb:53:in `block in instrument'
activesupport (3.1.1.rc1) lib/active_support/notifications/instrumenter.rb:21:in `instrument'
activesupport (3.1.1.rc1) lib/active_support/notifications.rb:53:in `instrument'
actionpack (3.1.1.rc1) lib/action_view/renderer/abstract_renderer.rb:33:in `instrument'
actionpack (3.1.1.rc1) lib/action_view/renderer/partial_renderer.rb:227:in `block in render'
actionpack (3.1.1.rc1) lib/action_view/renderer/abstract_renderer.rb:22:in `wrap_formats'
actionpack (3.1.1.rc1) lib/action_view/renderer/partial_renderer.rb:219:in `render'
actionpack (3.1.1.rc1) lib/action_view/renderer/renderer.rb:41:in `render_partial'
actionpack (3.1.1.rc1) lib/action_view/renderer/renderer.rb:15:in `render'
actionpack (3.1.1.rc1) lib/action_view/helpers/rendering_helper.rb:24:in `render'
/usr/local/rvm/gems/ruby-1.9.3-preview1/bundler/gems/refinerycms-eaeb7414eab9/settings/app/views/refinery/admin/settings/_records.html.erb:8:in `__usr_local_rvm_gems_ruby_______preview__bundler_gems_refinerycms_eaeb____eab__settings_app_views_refinery_admin_settings__records_html_erb___1823773779860543659_2174935460'
actionpack (3.1.1.rc1) lib/action_view/template.rb:144:in `block in render'
activesupport (3.1.1.rc1) lib/active_support/notifications.rb:55:in `instrument'
actionpack (3.1.1.rc1) lib/action_view/template.rb:142:in `render'
actionpack (3.1.1.rc1) lib/action_view/renderer/partial_renderer.rb:256:in `render_partial'
actionpack (3.1.1.rc1) lib/action_view/renderer/partial_renderer.rb:228:in `block (2 levels) in render'
actionpack (3.1.1.rc1) lib/action_view/renderer/abstract_renderer.rb:33:in `block in instrument'
activesupport (3.1.1.rc1) lib/active_support/notifications.rb:53:in `block in instrument'
activesupport (3.1.1.rc1) lib/active_support/notifications/instrumenter.rb:21:in `instrument'
activesupport (3.1.1.rc1) lib/active_support/notifications.rb:53:in `instrument'
actionpack (3.1.1.rc1) lib/action_view/renderer/abstract_renderer.rb:33:in `instrument'
actionpack (3.1.1.rc1) lib/action_view/renderer/partial_renderer.rb:227:in `block in render'
actionpack (3.1.1.rc1) lib/action_view/renderer/abstract_renderer.rb:22:in `wrap_formats'
actionpack (3.1.1.rc1) lib/action_view/renderer/partial_renderer.rb:219:in `render'
actionpack (3.1.1.rc1) lib/action_view/renderer/renderer.rb:41:in `render_partial'
actionpack (3.1.1.rc1) lib/action_view/renderer/renderer.rb:15:in `render'
actionpack (3.1.1.rc1) lib/action_view/helpers/rendering_helper.rb:24:in `render'
/usr/local/rvm/gems/ruby-1.9.3-preview1/bundler/gems/refinerycms-eaeb7414eab9/settings/app/views/refinery/admin/settings/index.html.erb:2:in `__usr_local_rvm_gems_ruby_______preview__bundler_gems_refinerycms_eaeb____eab__settings_app_views_refinery_admin_settings_index_html_erb___4018989157236564863_2178575720'
actionpack (3.1.1.rc1) lib/action_view/template.rb:144:in `block in render'
activesupport (3.1.1.rc1) lib/active_support/notifications.rb:55:in `instrument'
actionpack (3.1.1.rc1) lib/action_view/template.rb:142:in `render'
actionpack (3.1.1.rc1) lib/action_view/renderer/template_renderer.rb:40:in `block (2 levels) in render_template'
actionpack (3.1.1.rc1) lib/action_view/renderer/abstract_renderer.rb:33:in `block in instrument'
activesupport (3.1.1.rc1) lib/active_support/notifications.rb:53:in `block in instrument'
activesupport (3.1.1.rc1) lib/active_support/notifications/instrumenter.rb:21:in `instrument'
activesupport (3.1.1.rc1) lib/active_support/notifications.rb:53:in `instrument'
actionpack (3.1.1.rc1) lib/action_view/renderer/abstract_renderer.rb:33:in `instrument'
actionpack (3.1.1.rc1) lib/action_view/renderer/template_renderer.rb:39:in `block in render_template'
actionpack (3.1.1.rc1) lib/action_view/renderer/template_renderer.rb:47:in `render_with_layout'
actionpack (3.1.1.rc1) lib/action_view/renderer/template_renderer.rb:38:in `render_template'
actionpack (3.1.1.rc1) lib/action_view/renderer/template_renderer.rb:12:in `block in render'
actionpack (3.1.1.rc1) lib/action_view/renderer/abstract_renderer.rb:22:in `wrap_formats'
actionpack (3.1.1.rc1) lib/action_view/renderer/template_renderer.rb:9:in `render'
actionpack (3.1.1.rc1) lib/action_view/renderer/renderer.rb:36:in `render_template'
actionpack (3.1.1.rc1) lib/action_view/renderer/renderer.rb:17:in `render'
actionpack (3.1.1.rc1) lib/abstract_controller/rendering.rb:120:in `_render_template'
actionpack (3.1.1.rc1) lib/action_controller/metal/streaming.rb:250:in `_render_template'
actionpack (3.1.1.rc1) lib/abstract_controller/rendering.rb:114:in `render_to_body'
actionpack (3.1.1.rc1) lib/action_controller/metal/renderers.rb:30:in `render_to_body'
actionpack (3.1.1.rc1) lib/action_controller/metal/compatibility.rb:43:in `render_to_body'
actionpack (3.1.1.rc1) lib/abstract_controller/rendering.rb:99:in `render'
actionpack (3.1.1.rc1) lib/action_controller/metal/rendering.rb:16:in `render'
actionpack (3.1.1.rc1) lib/action_controller/metal/instrumentation.rb:40:in `block (2 levels) in render'
activesupport (3.1.1.rc1) lib/active_support/core_ext/benchmark.rb:5:in `block in ms'
/usr/local/rvm/rubies/ruby-1.9.3-preview1/lib/ruby/1.9.1/benchmark.rb:295:in `realtime'
activesupport (3.1.1.rc1) lib/active_support/core_ext/benchmark.rb:5:in `ms'
actionpack (3.1.1.rc1) lib/action_controller/metal/instrumentation.rb:40:in `block in render'
actionpack (3.1.1.rc1) lib/action_controller/metal/instrumentation.rb:78:in `cleanup_view_runtime'
activerecord (3.1.1.rc1) lib/active_record/railties/controller_runtime.rb:24:in `cleanup_view_runtime'
actionpack (3.1.1.rc1) lib/action_controller/metal/instrumentation.rb:39:in `render'
actionpack (3.1.1.rc1) lib/action_controller/metal/implicit_render.rb:10:in `default_render'
actionpack (3.1.1.rc1) lib/action_controller/metal/implicit_render.rb:5:in `send_action'
actionpack (3.1.1.rc1) lib/abstract_controller/base.rb:167:in `process_action'
actionpack (3.1.1.rc1) lib/action_controller/metal/rendering.rb:10:in `process_action'
actionpack (3.1.1.rc1) lib/abstract_controller/callbacks.rb:18:in `block in process_action'
activesupport (3.1.1.rc1) lib/active_support/callbacks.rb:479:in `_run__2679481237275294099__process_action__95867221147127301__callbacks'
activesupport (3.1.1.rc1) lib/active_support/callbacks.rb:386:in `_run_process_action_callbacks'
activesupport (3.1.1.rc1) lib/active_support/callbacks.rb:81:in `run_callbacks'
actionpack (3.1.1.rc1) lib/abstract_controller/callbacks.rb:17:in `process_action'
actionpack (3.1.1.rc1) lib/action_controller/metal/rescue.rb:17:in `process_action'
actionpack (3.1.1.rc1) lib/action_controller/metal/instrumentation.rb:30:in `block in process_action'
activesupport (3.1.1.rc1) lib/active_support/notifications.rb:53:in `block in instrument'
activesupport (3.1.1.rc1) lib/active_support/notifications/instrumenter.rb:21:in `instrument'
activesupport (3.1.1.rc1) lib/active_support/notifications.rb:53:in `instrument'
actionpack (3.1.1.rc1) lib/action_controller/metal/instrumentation.rb:29:in `process_action'
actionpack (3.1.1.rc1) lib/action_controller/metal/params_wrapper.rb:201:in `process_action'
activerecord (3.1.1.rc1) lib/active_record/railties/controller_runtime.rb:18:in `process_action'
actionpack (3.1.1.rc1) lib/abstract_controller/base.rb:121:in `process'
actionpack (3.1.1.rc1) lib/abstract_controller/rendering.rb:45:in `process'
actionpack (3.1.1.rc1) lib/action_controller/metal.rb:193:in `dispatch'
actionpack (3.1.1.rc1) lib/action_controller/metal/rack_delegation.rb:14:in `dispatch'
actionpack (3.1.1.rc1) lib/action_controller/metal.rb:236:in `block in action'
actionpack (3.1.1.rc1) lib/action_dispatch/routing/route_set.rb:65:in `call'
actionpack (3.1.1.rc1) lib/action_dispatch/routing/route_set.rb:65:in `dispatch'
actionpack (3.1.1.rc1) lib/action_dispatch/routing/route_set.rb:29:in `call'
rack-mount (0.8.3) lib/rack/mount/route_set.rb:152:in `block in call'
routing-filter (0.2.4) lib/routing_filter/adapters/rails_3.rb:74:in `call'
routing-filter (0.2.4) lib/routing_filter/adapters/rails_3.rb:74:in `recognize_with_filtering'
rack-mount (0.8.3) lib/rack/mount/route_set.rb:141:in `call'
actionpack (3.1.1.rc1) lib/action_dispatch/routing/route_set.rb:531:in `call'
warden (1.0.5) lib/warden/manager.rb:35:in `block in call'
warden (1.0.5) lib/warden/manager.rb:34:in `catch'
warden (1.0.5) lib/warden/manager.rb:34:in `call'
actionpack (3.1.1.rc1) lib/action_dispatch/middleware/best_standards_support.rb:17:in `call'
rack (1.3.3) lib/rack/etag.rb:23:in `call'
rack (1.3.3) lib/rack/conditionalget.rb:25:in `call'
actionpack (3.1.1.rc1) lib/action_dispatch/middleware/head.rb:14:in `call'
actionpack (3.1.1.rc1) lib/action_dispatch/middleware/params_parser.rb:21:in `call'
actionpack (3.1.1.rc1) lib/action_dispatch/middleware/flash.rb:243:in `call'
rack (1.3.3) lib/rack/session/abstract/id.rb:195:in `context'
rack (1.3.3) lib/rack/session/abstract/id.rb:190:in `call'
actionpack (3.1.1.rc1) lib/action_dispatch/middleware/cookies.rb:331:in `call'
activerecord (3.1.1.rc1) lib/active_record/query_cache.rb:62:in `call'
activerecord (3.1.1.rc1) lib/active_record/connection_adapters/abstract/connection_pool.rb:477:in `call'
actionpack (3.1.1.rc1) lib/action_dispatch/middleware/callbacks.rb:29:in `block in call'
activesupport (3.1.1.rc1) lib/active_support/callbacks.rb:392:in `_run_call_callbacks'
activesupport (3.1.1.rc1) lib/active_support/callbacks.rb:81:in `run_callbacks'
actionpack (3.1.1.rc1) lib/action_dispatch/middleware/callbacks.rb:28:in `call'
actionpack (3.1.1.rc1) lib/action_dispatch/middleware/reloader.rb:68:in `call'
rack (1.3.3) lib/rack/sendfile.rb:101:in `call'
actionpack (3.1.1.rc1) lib/action_dispatch/middleware/remote_ip.rb:48:in `call'
actionpack (3.1.1.rc1) lib/action_dispatch/middleware/show_exceptions.rb:47:in `call'
railties (3.1.1.rc1) lib/rails/rack/logger.rb:13:in `call'
rack (1.3.3) lib/rack/methodoverride.rb:24:in `call'
rack (1.3.3) lib/rack/runtime.rb:17:in `call'
dragonfly (0.9.8) lib/dragonfly/middleware.rb:13:in `call'
rack-cache (1.0.3) lib/rack/cache/context.rb:132:in `forward'
rack-cache (1.0.3) lib/rack/cache/context.rb:243:in `fetch'
rack-cache (1.0.3) lib/rack/cache/context.rb:181:in `lookup'
rack-cache (1.0.3) lib/rack/cache/context.rb:65:in `call!'
rack-cache (1.0.3) lib/rack/cache/context.rb:50:in `call'
dragonfly (0.9.8) lib/dragonfly/middleware.rb:13:in `call'
rack-cache (1.0.3) lib/rack/cache/context.rb:132:in `forward'
rack-cache (1.0.3) lib/rack/cache/context.rb:243:in `fetch'
rack-cache (1.0.3) lib/rack/cache/context.rb:181:in `lookup'
rack-cache (1.0.3) lib/rack/cache/context.rb:65:in `call!'
rack-cache (1.0.3) lib/rack/cache/context.rb:50:in `call'
rack (1.3.3) lib/rack/lock.rb:15:in `call'
dragonfly (0.9.8) lib/dragonfly/cookie_monster.rb:9:in `call'
actionpack (3.1.1.rc1) lib/action_dispatch/middleware/static.rb:53:in `call'
railties (3.1.1.rc1) lib/rails/engine.rb:456:in `call'
railties (3.1.1.rc1) lib/rails/rack/content_length.rb:16:in `call'
railties (3.1.1.rc1) lib/rails/rack/log_tailer.rb:14:in `call'
rack (1.3.3) lib/rack/handler/webrick.rb:59:in `service'
/usr/local/rvm/rubies/ruby-1.9.3-preview1/lib/ruby/1.9.1/webrick/httpserver.rb:138:in `service'
/usr/local/rvm/rubies/ruby-1.9.3-preview1/lib/ruby/1.9.1/webrick/httpserver.rb:94:in `run'
/usr/local/rvm/rubies/ruby-1.9.3-preview1/lib/ruby/1.9.1/webrick/server.rb:191:in `block in start_thread'
```

Steps to reproduce:
- Create a new application using refinerycms from the master branch (any database doesn't matter)
- launch the server, create the user and name the site
- Go to the Settings tab, it should work
- Go to the Images tab
- Go back to the Settings tab and you should get an exception

Digging further, I found out that going to the images tab add two more settings in the settings table and, having more than 12 settings as defined in the settings model, will_paginate will fire up and the exception is raised.

The will_paginate gem removed the function base_url_params and replaced it with 'merge_get_params(default_url_params)' in the commit [b385f386b2613797f391903e8179a098cb4da1e6](https://github.com/mislav/will_paginate/commit/b385f386b2613797f391903e8179a098cb4da1e6)
