### PR TITLE
Fix the URL to the generators.md file in the readme.md.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -96,7 +96,7 @@ Extend Refinery easily by running the Refinery engine generator
 
     rails generate refinery:engine
 
-to get help on how to use that. Or read the full documentation on [writing engines for Refinery](https://github.com/resolve/refinerycms/blob/master/dec/generators.md)
+to get help on how to use that. Or read the full documentation on [writing engines for Refinery](https://github.com/resolve/refinerycms/blob/master/doc/generators.md)
 
 ### Popular Engines
 


### PR DESCRIPTION
Like the title says, fixes a minor typo in the readme file that lead me to a 404 page while looking up more information on engines

Thanks guys :)
