### PR TITLE
Smaller flags in administration (they are ugly resized)

### DIFF
--- a/pages/app/views/refinery/admin/pages/_locale_picker.html.erb
+++ b/pages/app/views/refinery/admin/pages/_locale_picker.html.erb
@@ -3,7 +3,7 @@
   <ul id='switch_locale_picker' class='clearfix'>
     <% locales.each do |locale| %>
       <li<%= " class='selected'" if locale.to_s == local_assigns[:current_locale].to_s %>>
-        <%= link_to refinery_icon_tag("flags/#{locale}.png", '16x11'),
+        <%= link_to refinery_icon_tag("flags/#{locale}.png", :size => '16x11'),
                     main_app.url_for(:switch_locale => locale) %>
       </li>
     <% end %>


### PR DESCRIPTION
We need to find bigger images if we need bigger flags. Resizing small images is not good idea I think.
