### PR TITLE
Temporary workaround for missing Role constant in request macros

### DIFF
--- a/authentication/spec/factories/user.rb
+++ b/authentication/spec/factories/user.rb
@@ -1,3 +1,11 @@
+# This is a temporary hack to get around some fuckery with Devise when
+# using the authentication macros in request specs that are defined in
+# refinerycms-testing. If you remove this line ensure that tests pass
+# in an engine that is testing against this Factory via the 
+# authentication macros in refinerycms-testing.
+# 10-11-2011 - Jamie Winsor - jamie@enmasse.com
+require Refinery.roots("authentication").join("app/models/refinery/role.rb")
+
 FactoryGirl.define do
   factory :user, :class => Refinery::User do
     sequence(:username) { |n| "refinery#{n}" }


### PR DESCRIPTION
When using factories and rspec request/controller macros from outside
of the main refinerycms project we are getting a missing constant for
the authentication model Role. This is a temporary workaround until
the real solution is found.
