### PR TITLE
Remove the public dir from project root

### DIFF
--- a/public/javascripts/translations.js
+++ b/public/javascripts/translations.js
@@ -1,2 +1,0 @@
-var I18n = I18n || {};
-I18n.translations = {"fi":{"js":{"admin":{"confirm_changes":"Kaikki muutoksesi menetet\u00e4\u00e4n. Oletko varma, ett\u00e4 haluat jatkaa tallentamatta?"}}}};


### PR DESCRIPTION
No longer required - refinerycms isn't a rails app
