### PR TITLE
Don't invoke is_seo_meta while precompiling assets

### DIFF
--- a/pages/lib/refinery/pages/engine.rb
+++ b/pages/lib/refinery/pages/engine.rb
@@ -12,7 +12,7 @@ module Refinery
       config.autoload_paths += %W( #{config.root}/lib )
 
       config.to_prepare do |app|
-        Refinery::Page.translation_class.send(:is_seo_meta)
+        Refinery::Page.translation_class.send(:is_seo_meta) unless $rake_assets_precompiling
         Refinery::Page.translation_class.send(:attr_accessible, :browser_title, :meta_description, :meta_keywords, :locale)
       end
 


### PR DESCRIPTION
Somewhere along the line since a146d07f273dbabd88b845ac770e7d66d8935a71, making sure $rake_assets_precompiling was false when adding seo_meta was removed. This puts it back in.

This was required to get Heroku deployment working.
