### PR TITLE
Revert "Comment i18n generator because it's currently broken."

### DIFF
--- a/core/lib/generators/refinery/cms/cms_generator.rb
+++ b/core/lib/generators/refinery/cms/cms_generator.rb
@@ -82,10 +82,10 @@ module Refinery
       end
 
       # Ensure i18n exists and is up to date.
-      # if Refinery.i18n_enabled?
-      #   require 'generators/i18n_generator'
-      #   Refinery::I18nGenerator.start
-      # end
+      if Refinery.i18n_enabled?
+        require 'generators/i18n_generator'
+        Refinery::I18nGenerator.start
+      end
     end
 
     protected


### PR DESCRIPTION
This commit was made by Ugisozols because I forgot to submit a pull request for refinerycms-i18n. I have since made a request and it has been merged.

This change can now be reverted
