### PR TITLE
Move page finding logic into a before_filter.

### DIFF
--- a/pages/app/controllers/refinery/pages_controller.rb
+++ b/pages/app/controllers/refinery/pages_controller.rb
@@ -51,7 +51,7 @@ module Refinery
       end
     end
 
-    alias page find_page
+    alias_method :page, :find_page
 
     def render_with_templates?
       layouts = ::Refinery::Setting.find_or_set(:use_layout_templates, false, :scoping => 'pages')


### PR DESCRIPTION
I moved the logic for finding the current page out of the #home and #show actions into a before_filter, so that I can add filters that can depend on the page being populated.

Also, I added an alias for #find_page called #page, so that instead of assuming @page is populated I can use #page and be assured of getting the current page.
