### PR TITLE
Add alt text for images.

### DIFF
--- a/images/app/models/refinery/image.rb
+++ b/images/app/models/refinery/image.rb
@@ -13,7 +13,7 @@ module Refinery
     acts_as_indexed :fields => [:title]
 
     # allows Mass-Assignment
-    attr_accessible :id, :image, :image_size
+    attr_accessible :id, :image, :image_size, :alt
 
     delegate :size, :mime_type, :url, :width, :height, :to => :image
 
@@ -94,10 +94,10 @@ module Refinery
       { :width => width.to_i, :height => height.to_i }
     end
 
-    # Returns a titleized version of the filename
-    # my_file.jpg returns My File
+    # If the image has alt text, return that. Otherwise, return a titleized
+    # version of the filename, ie, my_file.jpg returns My File
     def title
-      CGI::unescape(image_name.to_s).gsub(/\.\w+$/, '').titleize
+      alt.presence || CGI::unescape(image_name.to_s).gsub(/\.\w+$/, '').titleize
     end
 
   end

--- a/images/app/views/refinery/admin/images/_form.html.erb
+++ b/images/app/views/refinery/admin/images/_form.html.erb
@@ -27,6 +27,12 @@
     <label><%= t('.maximum_image_size', :bytes => ::Refinery::Images.max_image_size) %></label>
   </div>
 
+
+  <div class='field'>
+    <%= f.label :alt %>
+    <%= f.text_field :alt, :class => 'widest' %>
+  </div>
+
   <input type='hidden' name='wymeditor' value='<%= params[:wymeditor] %>'>
 
   <%= render :partial => "/refinery/admin/form_actions",

--- a/images/config/locales/en.yml
+++ b/images/config/locales/en.yml
@@ -42,3 +42,6 @@ en:
           blank: You must specify an image for upload
           too_big: Image should be smaller than %{size} bytes in size
           incorrect_format: 'Your image must be either a JPG, PNG or GIF'
+    attributes:
+      refinery/image:
+        alt: "Alt Text"

--- a/images/db/migrate/20111126213714_add_alt_text_to_images.rb
+++ b/images/db/migrate/20111126213714_add_alt_text_to_images.rb
@@ -1,0 +1,5 @@
+class AddAltTextToImages < ActiveRecord::Migration
+  def change
+    add_column ::Refinery::Image.table_name, :alt, :text
+  end
+end

--- a/images/spec/controllers/refinery/admin/images_controller_spec.rb
+++ b/images/spec/controllers/refinery/admin/images_controller_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+module Refinery
+  module Admin
+    describe ImagesController do
+      describe "#images_from_params" do
+        let(:images) do
+          ["beach.jpeg", "id-rather-be-here.jpg"].map do |file|
+            Rack::Test::UploadedFile.new(
+              Refinery.roots(:'refinery/images').join("spec/fixtures/#{file}"),
+              "image/jpeg",
+            )
+          end
+        end
+
+        before do
+          controller.stub(:params => params)
+        end
+
+        subject { controller.send(:images_from_params) }
+
+        context "with no images" do
+          let(:params) do
+            { :image => { :alt => "batman" } }
+          end
+
+          it "does not create an image" do
+            image = subject.first
+            image.should_not be_persisted
+            image.alt.should eq("batman")
+          end
+        end
+
+        context "with one image" do
+          let(:params) do
+            { :image => { :alt => "superman", :image => [images.first] } }
+          end
+
+          it "creates an image" do
+            image = subject.first
+            image.should be_persisted
+            image.image_name.should eq("beach.jpeg")
+            image.alt.should eq("superman")
+          end
+        end
+
+        context "with multiple images" do
+          let(:params) do
+            { :image => { :alt => "aquaman", :image => images } }
+          end
+
+          it "creates multiple images" do
+            one, two = subject
+
+            one.should be_persisted
+            one.image_name.should eq("beach.jpeg")
+            one.alt.should eq("aquaman")
+
+            two.should be_persisted
+            two.image_name.should eq("id-rather-be-here.jpg")
+            two.alt.should eq("aquaman")
+          end
+        end
+      end
+    end
+  end
+end

--- a/images/spec/models/refinery/image_spec.rb
+++ b/images/spec/models/refinery/image_spec.rb
@@ -40,8 +40,24 @@ module Refinery
     end
 
     describe "#title" do
-      it "returns a titleized version of the filename" do
-        image.title.should == "Beach"
+      context "with alt text" do
+        before do
+          image.alt = "Alt text"
+        end
+
+        it "returns the alt text" do
+          image.title.should == "Alt text"
+        end
+      end
+
+      context "with no alt text" do
+        before do
+          image.alt = ""
+        end
+
+        it "returns a titleized version of the filename" do
+          image.title.should == "Beach"
+        end
       end
     end
 

--- a/images/spec/requests/refinery/admin/images_spec.rb
+++ b/images/spec/requests/refinery/admin/images_spec.rb
@@ -22,12 +22,23 @@ module Refinery
         visit refinery_admin_images_path
         click_link "Add new image"
 
-        within_frame "dialog_iframe" do
-          attach_file "image_image", Refinery.roots(:'refinery/images').join("spec/fixtures/beach.jpeg")
-          click_button "Save"
-        end
+        attach_file "image_image", Refinery.roots(:'refinery/images').join("spec/fixtures/beach.jpeg")
+        click_button "Save"
 
         page.should have_content("'Beach' was successfully added.")
+        Refinery::Image.count.should == 1
+      end
+
+      it "allows setting alt text for new images", :js => true do
+        visit refinery_admin_images_path
+        click_link "Add new image"
+
+        attach_file "image_image", Refinery.roots(:'refinery/images').join("spec/fixtures/beach.jpeg")
+        fill_in "Alt Text", :with => "A beautiful beach scene."
+
+        click_button "Save"
+
+        page.should have_content("'A beautiful beach scene.' was successfully added.")
         Refinery::Image.count.should == 1
       end
     end
@@ -48,6 +59,19 @@ module Refinery
         click_button "Save"
 
         page.should have_content("'Id Rather Be Here' was successfully updated.")
+        Refinery::Image.count.should == 1
+      end
+
+      it "updates image's alt text" do
+        visit refinery_admin_images_path
+        page.should have_selector("a[href='/refinery/images/#{image.id}/edit']")
+
+        click_link "Edit this image"
+
+        fill_in "Alt Text", :with => "Descriptive text."
+        click_button "Save"
+
+        page.should have_content("'Descriptive text.' was successfully updated.")
         Refinery::Image.count.should == 1
       end
     end


### PR DESCRIPTION
Included in this pull request:
- Add alt text to the refinery_images table.
- Add a field to the admin images new/edit form for the alt text.
- Change Refinery::Image#title to use the alt text if it is present before falling back to the current behavior (a titleized version of the filename).
- A bit of refactoring for one part of Refinery::Admin::ImagesController#create.

Notes:
- I'm not crazy about the database column name 'alt'. The project where I originally hacked this in I used 'description', but I wasn't too happy with that either.
- As soon as I added anything to the image form, the image request specs failed saying they [were unable to locate the iframe](https://gist.github.com/1399023). Removing the calls to `within_frame` allow the specs to pass and they appear to work the same, they are just a bit less organized.
- I didn't add a translation of "Alt Text" to any of the locale files except English. I believe without that present, other languages will just have "Alt" displayed. I thought that was better than having me spend the time to add badly machine translated versions to all the other locales.
- There is no integration with the translations table for the alt text, which might be a desirable feature. I have no experience with that feature or using Refinery with multiple languages and I wasn't sure what the best approach was or how much more work it would be.

Thoughts?
