### PR TITLE
Fix singular_name for `Edit` test to match the Title Tooltip

### DIFF
--- a/core/lib/generators/refinery/engine/templates/spec/requests/refinery/admin/plural_name_spec.rb
+++ b/core/lib/generators/refinery/engine/templates/spec/requests/refinery/admin/plural_name_spec.rb
@@ -68,7 +68,7 @@ describe Refinery do
           visit refinery_admin_<%= plural_name %>_path
 
           within ".actions" do
-            click_link "Edit this <%= singular_name %>"
+            click_link "Edit this <%= singular_name.titleize.downcase %>"
           end
 
           fill_in "<%= title.name.titleize %>", :with => "A different <%= title.name %>"


### PR DESCRIPTION
- Tests were failing out of the box for engines with more than one word
  in the name
