### PR TITLE
Replace shell call with FileUtils.rm_rf

### DIFF
--- a/testing/lib/refinery/tasks/testing.rake
+++ b/testing/lib/refinery/tasks/testing.rake
@@ -38,7 +38,7 @@ namespace :refinery do
 
     desc "Remove the dummy app used for testing"
     task :clean_dummy_app do
-      system "rm -Rdf #{File.join(Refinery::Testing::Railtie.target_engine_path, 'spec/dummy')}"
+      FileUtils.rm_rf File.join(Refinery::Testing::Railtie.target_engine_path, 'spec/dummy')
     end
 
     namespace :engine do


### PR DESCRIPTION
- Gnu rm [doesn't have the -d flag](http://linux.die.net/man/1/rm).
- Avoid the overhead of `system`.
- Shelling-out to rm probably wouldn't work at all on windows.
