### PR TITLE
Fix for unescaped regexp based on user input

### DIFF
--- a/core/lib/refinery/application_controller.rb
+++ b/core/lib/refinery/application_controller.rb
@@ -56,7 +56,7 @@ module Refinery
       end
 
       def home_page?
-        main_app.root_path =~ /^#{request.path}\/?/
+        main_app.root_path =~ /^#{Regexp.escape(request.path)}\/?/
       end
 
       def just_installed?


### PR DESCRIPTION
Had a nice exception email this morning:

A ActionView::Template::Error occurred in pages#show:

  unmatched ): /^\/w00tw00t.at.blackhats.romanian.anti-sec:)\/?/
  vendor/bundle/ruby/1.8/gems/refinerycms-core-1.0.9/lib/refinery/application_controller.rb:64:in `home_page?'

Clearly that request should return a 404 not a 500.

I'm afraid I haven't tested the fix yet but it's trivial enough that I can't see how it could break anything (famous last words!).
