### PR TITLE
Linux needs a js runtime.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ group :development, :test do
       if RbConfig::CONFIG['target_os'] =~ /linux/i
         gem 'rb-inotify', '>= 0.5.1'
         gem 'libnotify',  '~> 0.1.3'
+        gem 'therubyracer', '~> 0.9.9'
       end
     end
   end


### PR DESCRIPTION
Without this, attempting to setup the dummy app for the refinery specs fails with the error:

```
Could not find a JavaScript runtime. See https://github.com/sstephenson/execjs for a list of available runtimes.
```
