### PR TITLE
Use Pathname#rmtree to delete the test directory.

### DIFF
--- a/testing/lib/refinery/tasks/testing.rake
+++ b/testing/lib/refinery/tasks/testing.rake
@@ -43,7 +43,7 @@ namespace :refinery do
 
     desc "Remove the dummy app used for testing"
     task :clean_dummy_app do
-      Refinery::Testing::Railtie.target_engine_path.join('spec', 'dummy').rmdir
+      Refinery::Testing::Railtie.target_engine_path.join('spec', 'dummy').rmtree
     end
 
     namespace :engine do


### PR DESCRIPTION
Without this, running `rake refinery:testing:clean_dummy_app` fails with this error:

```
rake aborted!
Directory not empty - /home/pete/projects/refinerycms/spec/dummy
```
