### PR TITLE
admin.js hardcodes empty custom_wymeditor_boot_options

### DIFF
--- a/core/app/assets/javascripts/admin.js
+++ b/core/app/assets/javascripts/admin.js
@@ -2,6 +2,5 @@
 // Just mirror the options specified in boot_wym.js with the new options here.
 // This will completely override anything specified in boot_wym.js for that key.
 // e.g. skin: 'something_else'
-var custom_wymeditor_boot_options = {
+if (typeof(custom_wymeditor_boot_options) == "undefined") { custom_wymeditor_boot_options = {}; }
 
-};


### PR DESCRIPTION
a problem with this approach can be found in issue https://github.com/resolve/refinerycms/issues/1162
