### PR TITLE
#1084 Paste deactivates cancel button

### DIFF
--- a/core/app/assets/javascripts/wymeditor/jquery.refinery.wymeditor.js
+++ b/core/app/assets/javascripts/wymeditor/jquery.refinery.wymeditor.js
@@ -1774,7 +1774,7 @@ WYMeditor.INIT_DIALOG = function(wym, selected, isIframe) {
 
   var selected = selected || wym.selected();
   var dialog = $("#"+wym._options.dialogId);
-  var doc = $((isIframe ? dialog.find('iframe').contents() : document));
+  var doc = $(dialog.find('iframe').contents());
   var dialogType = dialog.find('#wym_dialog_type').val();
   if (wym._selected_image) {
     var replaceable = $(wym._selected_image);


### PR DESCRIPTION
Case: The user selects an action in which a dialog is shown that
does not contain an iFrame (Paste from Word / Add Table).

Resolution: Keep the cancel button from receiving the close_dialog
event
