### PR TITLE
Fixed activity selection for plugins with multiple activities

### DIFF
--- a/core/lib/refinery/plugin.rb
+++ b/core/lib/refinery/plugin.rb
@@ -38,6 +38,10 @@ module Refinery
       self.plugin_activity ||= []
     end
 
+    def activity_by_class_name(class_name)
+      self.activity.select{ |a| a.class_name == class_name.to_s.camelize } 
+    end
+
     # Stores information that can be used to retrieve the latest activities of this plugin
     def activity=(activities)
       [activities].flatten.each { |activity| add_activity(activity) }

--- a/core/spec/lib/refinery/plugin_spec.rb
+++ b/core/spec/lib/refinery/plugin_spec.rb
@@ -153,5 +153,16 @@ module Refinery
       end
     end
 
+    describe '#activity_by_class_name' do
+      before { plugin.activity = [ { :class_name => "X::Y::Z" }, { :class_name => "X::Y::ZZ" }] }
+
+      context 'when the plugin have diferents activities' do
+        it 'returns the correct activity' do
+          plugin.activity_by_class_name("X::Y::Z").first.should == plugin.activity.first
+          plugin.activity_by_class_name("X::Y::ZZ").first.should == plugin.activity.last
+        end
+      end
+    end
+
   end
 end

--- a/dashboard/app/helpers/refinery/admin/dashboard_helper.rb
+++ b/dashboard/app/helpers/refinery/admin/dashboard_helper.rb
@@ -4,7 +4,7 @@ module ::Refinery
 
       def activity_message_for(record)
         if (plugin = ::Refinery::Plugins.active.find_by_model(record.class)) &&
-           (activity = plugin.activity.first)
+           (activity = plugin.activity_by_class_name(record.class.name).first)
           # work out which action occured
           action = record.updated_at.eql?(record.created_at) ? 'created' : 'updated'
 


### PR DESCRIPTION
When you have multiple activities in a plugin, you always get the first
activity in the plugin and the partial of the second activity have
wrong data.
