### PR TITLE
Add class "selected" to menu link when using i18n and redirecting

### DIFF
--- a/core/app/helpers/refinery/menu_helper.rb
+++ b/core/app/helpers/refinery/menu_helper.rb
@@ -53,7 +53,7 @@ module Refinery
       # Find the first url that is a string.
       url = [page.url]
       url << ['', page.url[:path]].compact.flatten.join('/') if page.url.respond_to?(:keys)
-      url = url.detect{|u| u.is_a?(String)}
+      url = url.last.match(%r{^/#{::I18n.locale.to_s}(/.*)}) ? $1 : url.detect{|u| u.is_a?(String)}
 
       # Now use all possible vectors to try to find a valid match,
       # finally passing to rails' "current_page?" method.


### PR DESCRIPTION
When I using i18n and add page with redirect to non refinery resource i see no class 'selected' in menu link when follow it.
in `[path, URI.decode(path)]` we have something like `["/contacts", "/contacts"]`
in `url` `"/ru/contacts"`
think this fix can be useful.
