### PR TITLE
conflict with model named Node

### DIFF
--- a/core/lib/refinery/crud.rb
+++ b/core/lib/refinery/crud.rb
@@ -276,8 +276,8 @@ module Refinery
               render :nothing => true
             end
 
-            def update_child_positions(node, #{singular_name})
-              node['children']['0'].each do |_, child|
+            def update_child_positions(_node, #{singular_name})
+              _node['children']['0'].each do |_, child|
                 child_id = child['id'].split(/#{singular_name}\_?/)
                 child_#{singular_name} = #{class_name}.where(:id => child_id).first
                 child_#{singular_name}.move_to_child_of(#{singular_name})


### PR DESCRIPTION
We have a model named Node. crud.rb stumbles over this model, because the the two variables passed to update_child_positions would both be named the same. Therefore we have renamed the node variable to _node as it is only used inside of the function. 

We changed this in branch master (2.0.0) as well as in 1-0-stable. We currently use 1.0.9
