### PR TITLE
Compute public path in link_to dialog (1-0-stable)

### DIFF
--- a/pages/app/views/admin/pages_dialogs/_page_link.html.erb
+++ b/pages/app/views/admin/pages_dialogs/_page_link.html.erb
@@ -1,7 +1,7 @@
 <% linked = (url_for(page_link.url) == params[:current_link]) if params[:current_link].present? -%>
 <% link_args = defined?(link_to_arguments) ? link_to_arguments : {} %>
 <li class='clearfix<%= " child#{child}" if child %><%= " linked" if linked%>' id="<%= dom_id(page_link) -%>">
-  <%= link_to page_link.title_with_meta.html_safe, page_link.url,
+  <%= link_to page_link.title_with_meta.html_safe, compute_public_path(url_for(page_link.url), ''),
               { :title => t('.link_to_this_page'),
               :rel => page_link.title,
               :class => 'page_link' }.merge(link_args) %>

--- a/pages/app/views/admin/pages_dialogs/link_to.html.erb
+++ b/pages/app/views/admin/pages_dialogs/link_to.html.erb
@@ -95,7 +95,7 @@
             <% @resources.each do |resource| -%>
               <% resource_linked = (resource.url == params[:current_link]) unless params[:current_link].blank? %>
               <li<%= " class='linked'" if resource_linked %>>
-                <%= link_to "#{resource.title}.#{resource.ext}", resource.url,
+                <%= link_to "#{resource.title}.#{resource.ext}", compute_public_path(resource.url, ''),
                             :title => t('link_to_this_resource', :scope => 'admin.pages_dialogs.link_to.your_resource'),
                             :rel => resource.title,
                             :class => "page_link #{resource.ext}" %>


### PR DESCRIPTION
I'm developing a newsletter engine for refinerycms and links must be added with host and protocol instead of only path. Images url were fixed with a similar pull request, but I forgot to add it to files and page links.

It will only add host and protocol if action_controller.asset_host is defined
