### PR TITLE
Include the Devise controller macros when extending Refinery's.

### DIFF
--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -1,5 +1,0 @@
-require 'devise'
-
-RSpec.configure do |config|
-  config.include Devise::TestHelpers, :type => :controller
-end

--- a/testing/lib/refinery/testing/controller_macros/authentication.rb
+++ b/testing/lib/refinery/testing/controller_macros/authentication.rb
@@ -2,6 +2,10 @@ module Refinery
   module Testing
     module ControllerMacros
       module Authentication
+        def self.extended(base)
+          base.send(:include, Devise::TestHelpers)
+        end
+
         def login_user
           before(:each) do
             @user = FactoryGirl.create(:user)


### PR DESCRIPTION
Refinery's controller macros have an implicit dependency on Devise's . Make that dependency explicit by including that module when Rspec controller specs are extended with Refinery's controller macros.
