### PR TITLE
Make clean_dummy_task a noop when dummy_app doesn't exist.

### DIFF
--- a/testing/lib/refinery/tasks/testing.rake
+++ b/testing/lib/refinery/tasks/testing.rake
@@ -43,7 +43,9 @@ namespace :refinery do
 
     desc "Remove the dummy app used for testing"
     task :clean_dummy_app do
-      Refinery::Testing::Railtie.target_engine_path.join('spec', 'dummy').rmtree
+      path = Refinery::Testing::Railtie.target_engine_path.join('spec', 'dummy')
+
+      path.rmtree if path.exist?
     end
 
     namespace :engine do


### PR DESCRIPTION
Before:

```
pete@balloon ~/projects/refinerycms $ rake refinery:testing:clean_dummy_app
pete@balloon ~/projects/refinerycms $ rake refinery:testing:clean_dummy_app     
rake aborted!                                                                   
No such file or directory - /home/pete/projects/refinerycms/spec/dummy          

Tasks: TOP => refinery:testing:clean_dummy_app                                  
(See full trace by running task with --trace) 
```

After:

```
pete@balloon ~/projects/refinerycms $ rake refinery:testing:clean_dummy_app refinery:testing:clean_dummy_app
pete@balloon ~/projects/refinerycms $ 

```
