### PR TITLE
Could not find a JavaScript runtime on edge project setup

### DIFF
--- a/templates/refinery/edge.rb
+++ b/templates/refinery/edge.rb
@@ -1,5 +1,6 @@
 append_file 'Gemfile' do
 "
+gem 'therubyracer'
 gem 'refinerycms', :git => 'git://github.com/resolve/refinerycms.git'
 
 #  group :development, :test do


### PR DESCRIPTION
When trying to use edge refinery with Rails 3.1.3 using your basic setup (http://refinerycms.com/edge-guides/getting-started-with-refinery) I ran into the following problem: 

``` shell
Using turn (0.8.3) 
Your bundle is complete! Use `bundle show [gemname]` to see where a bundled gem is installed.
        rake    db:create
rake aborted!
Could not find a JavaScript runtime. See https://github.com/sstephenson/execjs for a list of available runtimes.

(See full trace by running task with --trace)
    generate    refinery:cms
/home/peter/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/execjs-1.3.0/lib/execjs/runtimes.rb:50:in `autodetect': Could not find a JavaScript runtime. See https://github.com/sstephenson/execjs for a list of available runtimes. (ExecJS::RuntimeUnavailable)
    from /home/peter/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/execjs-1.3.0/lib/execjs.rb:5:in `<module:ExecJS>'
    from /home/peter/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/execjs-1.3.0/lib/execjs.rb:4:in `<top (required)>'
....
```

So I have added therubyracer to the Gemfile to resolve this
