### PR TITLE
Tidy up refinery_page menu_match regex so it is easier to read.

### DIFF
--- a/pages/lib/refinery/pages/engine.rb
+++ b/pages/lib/refinery/pages/engine.rb
@@ -30,7 +30,7 @@ module Refinery
           plugin.name = 'refinery_pages'
           plugin.directory = 'pages'
           plugin.version = %q{2.0.0}
-          plugin.menu_match = /refinery\/page(_part)?s(_dialogs)?$/
+          plugin.menu_match = /refinery\/page(_part|s_dialog)?s$/
           plugin.url = app.routes.url_helpers.refinery_admin_pages_path
           plugin.activity = {
             :class_name => :'refinery/page',


### PR DESCRIPTION
This regex is easier to read IMHO, and it also won't match erroneously match "/refinery/page_parts_dialogs" either.
