### PR TITLE
remove rails-dev-tweaks from edge Rails template

### DIFF
--- a/templates/refinery/edge.rb
+++ b/templates/refinery/edge.rb
@@ -8,10 +8,6 @@ gem 'refinerycms', :git => 'git://github.com/resolve/refinerycms.git'
 #    gem 'refinerycms-testing', '~> 2.0'
 #  end
 
-group :development do
-  gem 'rails-dev-tweaks', '~> 0.5.2'
-end
-
 # USER DEFINED
 
 # Add i18n support (optional, you can remove this if you really want to but it is advised to keep it).


### PR DESCRIPTION
It is breaking Rails 3.2 compatibility with this template.
