### PR TITLE
Testing fixups

### DIFF
--- a/testing/lib/generators/refinery/testing/templates/Guardfile
+++ b/testing/lib/generators/refinery/testing/templates/Guardfile
@@ -1,0 +1,30 @@
+engines = Dir[File.expand_path('../vendor/engines/*', __FILE__)]
+
+guard 'spork', :wait => 60, :cucumber => false, :rspec_env => { 'RAILS_ENV' => 'test' } do
+  watch('config/application.rb')
+  watch('config/environment.rb')
+  watch(%r{^config/environments/.+\.rb$})
+  watch(%r{^config/initializers/.+\.rb$})
+  watch('spec/spec_helper.rb')
+  watch(%r{^spec/support/.+\.rb$})
+
+  engines.each do |engine|
+    watch(%r{^#{engine}/spec/support/.+\.rb$})
+  end
+end
+
+guard 'rspec', :version => 2, :spec_paths => engines.map{|e| "#{e}/spec"},
+  :cli => (File.read('.rspec').split("\n").join(' ') if File.exists?('.rspec')) do
+  engines.each do |engine|
+    watch(%r{^#{engine}/spec/.+_spec\.rb$})
+    watch(%r{^#{engine}/app/(.+)\.rb$})                           { |m| "#{engine}/spec/#{m[1]}_spec.rb" }
+    watch(%r{^#{engine}/lib/(.+)\.rb$})                           { |m| "#{engine}/spec/lib/#{m[1]}_spec.rb" }
+    watch(%r{^#{engine}/app/controllers/(.+)_(controller)\.rb$})  { |m| ["#{engine}/spec/routing/#{m[1]}_routing_spec.rb", "#{engine}/spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb", "#{engine}/spec/requests/#{m[1]}_spec.rb"] }
+    watch(%r{^#{engine}/spec/support/(.+)\.rb$})                  { "#{engine}/spec" }
+    watch("#{engine}/spec/spec_helper.rb")                        { "#{engine}/spec" }
+    watch("#{engine}/config/routes.rb")                           { "#{engine}/spec/routing" }
+    watch("#{engine}/app/controllers/application_controller.rb")  { "#{engine}/spec/controllers" }
+    # Capybara request specs
+    watch(%r{^#{engine}/app/views/(.+)/.*\.(erb|haml)$})          { |m| "#{engine}/spec/requests/#{m[1]}_spec.rb" }
+  end
+end

--- a/testing/lib/generators/refinery/testing/templates/spec/spec_helper.rb
+++ b/testing/lib/generators/refinery/testing/templates/spec/spec_helper.rb
@@ -1,0 +1,56 @@
+ENGINE_RAILS_ROOT = File.join(File.dirname(__FILE__), '../') unless defined?(ENGINE_RAILS_ROOT)
+
+def setup_environment
+  # Configure Rails Environment
+  ENV["RAILS_ENV"] ||= 'test'
+
+  require File.expand_path("../../config/environment", __FILE__)
+
+  require 'rspec/rails'
+  require 'capybara/rspec'
+
+  Rails.backtrace_cleaner.remove_silencers!
+
+  RSpec.configure do |config|
+    config.mock_with :rspec
+    config.treat_symbols_as_metadata_keys_with_true_values = true
+    config.filter_run :focus => true
+    config.run_all_when_everything_filtered = true
+  end
+
+  # set javascript driver for capybara
+  Capybara.javascript_driver = :webkit
+
+  # minimize password hashing stretches
+  Devise.stretches = 1
+end
+
+def each_run
+  FactoryGirl.reload
+
+  # Requires supporting files with custom matchers and macros, etc,
+  # in ./support/ and its subdirectories including factories.
+  ([ENGINE_RAILS_ROOT, Rails.root.to_s].uniq | ::Refinery::Plugins.registered.pathnames).map{|p|
+    Dir[File.join(p, 'spec', 'support', '**', '*.rb').to_s]
+  }.flatten.sort.each do |support_file|
+    require support_file
+  end
+end
+
+# If spork is available in the Gemfile it'll be used but we don't force it.
+unless (begin; require 'spork'; rescue LoadError; nil end).nil?
+  Spork.prefork do
+    # Loading more in this block will cause your tests to run faster. However,
+    # if you change any configuration or code from libraries loaded here, you'll
+    # need to restart spork for it take effect.
+    setup_environment
+  end
+
+  Spork.each_run do
+    # This code will be run each time you run your specs.
+    each_run
+  end
+else
+  setup_environment
+  each_run
+end

--- a/testing/lib/generators/refinery/testing/testing_generator.rb
+++ b/testing/lib/generators/refinery/testing/testing_generator.rb
@@ -1,0 +1,14 @@
+module Refinery
+  class TestingGenerator < Rails::Generators::Base
+    source_root File.expand_path('../templates', __FILE__)
+
+    def copy_guardfile
+      template "Guardfile"
+    end
+
+    def copy_spec_helper
+      directory "spec"
+    end
+
+  end
+end

--- a/testing/lib/refinery/testing.rb
+++ b/testing/lib/refinery/testing.rb
@@ -3,6 +3,8 @@ require 'rspec-rails'
 require 'factory_girl_rails'
 
 module Refinery
+  autoload :TestingGenerator, 'generators/refinery/testing/testing_generator'
+
   module Testing
     class << self
       def root


### PR DESCRIPTION
As discussed with @parndt in IRC:
- Require rspec-rails so that projects using refinerycms-testing get the `rake spec` task for free.
- Add a testing generator that copies a Guardfile and spec_helper.rb.

I haven't used generators much so there's a good chance I'm doing something stupid. What do you guys think?
