### PR TITLE
fixed route for accessing a page's children when there is multiple levels of nesting

### DIFF
--- a/pages/app/views/refinery/admin/pages/_page.html.erb
+++ b/pages/app/views/refinery/admin/pages/_page.html.erb
@@ -43,7 +43,7 @@
                   :method => :delete if page.deletable? %>
     </span>
   </div>
-  <ul class='nested' data-ajax-content="<%= main_app.children_refinery_admin_page_path(page.uncached_nested_url) %>">
+  <ul class='nested' data-ajax-content="<%= main_app.refinery_admin_children_pages_path(page.uncached_nested_url) %>">
     <%= render(:partial => 'page', :collection => page.children) if Refinery::Pages.auto_expand_admin_tree %>
   </ul>
 </li>

--- a/pages/config/routes.rb
+++ b/pages/config/routes.rb
@@ -5,14 +5,12 @@ Rails.application.routes.draw do
 
     scope(:module => 'admin', :path => 'refinery', :as => 'refinery_admin') do
       get 'pages/*path/edit', :to => 'pages#edit'
+      get 'pages/*path/children', :to => 'pages#children', :as => 'children_pages'
       put 'pages/*path', :to => 'pages#update'
       delete 'pages/*path', :to => 'pages#destroy'
       resources :pages, :except => [:show] do
         collection do
           post :update_positions
-        end
-        member do
-          get :children
         end
       end
 

--- a/pages/spec/requests/refinery/admin/pages_spec.rb
+++ b/pages/spec/requests/refinery/admin/pages_spec.rb
@@ -53,9 +53,10 @@ module Refinery
 
         context "when sub pages exist" do
           before do
-            parent = FactoryGirl.create(:page, :title => "Our Company")
-            FactoryGirl.create(:page, :parent => parent, :title => 'Our Team')
-            FactoryGirl.create(:page, :parent => parent, :title => 'Our Locations')
+            @parent = FactoryGirl.create(:page, :title => "Our Company")
+            FactoryGirl.create(:page, :parent => @parent, :title => 'Our Team')
+            @locations = FactoryGirl.create(:page, :parent => @parent, :title => 'Our Locations')
+            FactoryGirl.create(:page, :parent => @locations, :title => 'New York')
           end
 
           context "with auto expand option turned off" do
@@ -79,6 +80,13 @@ module Refinery
 
               page.should have_content("Our Team")
               page.should have_content("Our Locations")
+            end
+
+            it "expands children when nested mutliple levels deep", :js => true do
+              find("#page_#{@parent.id} .toggle").click
+              find("#page_#{@locations.id} .toggle").click
+
+              page.should have_content("New York")
             end
           end
 


### PR DESCRIPTION
the Refinery::Admin::PagesController#children action did not have the correct route defined for handling children with multiple levels of nesting.

i.e. `/refinery/pages/corporation/children` worked ok
  but `/refinery/pages/corporation/locations/new-york/children` returned a 404

this commit redefines the pages/children route using route globbing and adds a test to make sure there are no regressions
