### PR TITLE
fix js syntax error in jquery.refinery.wymeditor.js introduced earlier at 86f9ee7a

### DIFF
--- a/core/app/assets/javascripts/wymeditor/jquery.refinery.wymeditor.js
+++ b/core/app/assets/javascripts/wymeditor/jquery.refinery.wymeditor.js
@@ -4475,7 +4475,7 @@ WYMeditor.WymClassExplorer.prototype._exec = function(cmd,param) {
 
 WYMeditor.WymClassExplorer.prototype.selected = function() {
     var caretPos = this._iframe.contentWindow.document.caretPos;
-    if(caretPos != null && caretPos.parentElement != undefined)
+    if(caretPos != null && caretPos.parentElement != undefined) {
         return(caretPos.parentElement());
     }
 };


### PR DESCRIPTION
add the missing the opening curly brace
