### PR TITLE
More descriptive generated engine migration name

### DIFF
--- a/core/lib/generators/refinery/engine/templates/db/migrate/1_create_namespace_plural_name.rb
+++ b/core/lib/generators/refinery/engine/templates/db/migrate/1_create_namespace_plural_name.rb
@@ -1,4 +1,4 @@
-class Create<%= class_name.pluralize %> < ActiveRecord::Migration
+class Create<%= namespacing %><%= class_name.pluralize %> < ActiveRecord::Migration
 
   def up
     create_table :refinery_<%= "#{namespacing.underscore}_" if table_name != namespacing.underscore.pluralize -%><%= table_name %> do |t|


### PR DESCRIPTION
example: 

```
Copied migration 20120202041042_create_office_tables.refinery_awesome.rb from refinery_awesome
```
