### PR TITLE
Add a description for mounting Refinery's routes

### DIFF
--- a/templates/refinery/edge.rb
+++ b/templates/refinery/edge.rb
@@ -40,7 +40,16 @@ generate 'refinery:i18n'
 rake 'railties:install:migrations'
 rake 'db:migrate'
 
-inject_into_file 'config/routes.rb', "\n  mount Refinery::Core::Engine => '/'\n", :after => "Application.routes.draw do\n"
+mount = %Q{
+  #  # This line mounts Refinery's routes at the root of your application.
+  # This means, any requests to the root URL of your application will go to Refinery::PagesController#home.
+  # If you would like to change where this engine is mounted, simply change the :at option to something different.
+  #
+  # We ask that you don't use the :as option here, as Refinery relies on it being the default of "refinery"
+  mount Refinery::Core::Engine => '/'
+}
+
+inject_into_file 'config/routes.rb', mount, :after => "Application.routes.draw do\n"
 
 gsub_file 'config/application.rb', "require 'devise/orm/active_record'", ""
 


### PR DESCRIPTION
This commit adds a small comment above the mounting line for Refinery, explaining what it does and how to change it. Also asks users to not use the `:as` option, as it can break things.
