### PR TITLE
Fixed routes for model names with two or more words.

### DIFF
--- a/core/lib/refinery/core.rb
+++ b/core/lib/refinery/core.rb
@@ -151,7 +151,7 @@ module Refinery
     #   Refinery.route_for_model(Refinery::Blog::Post) => "blog_admin_post_path"
     #   Refinery.route_for_model(Refinery::Blog::Post, true) => "blog_admin_posts_path"
     def route_for_model(klass, plural = false)
-      parts = klass.to_s.downcase.split("::").delete_if { |p| p.blank? }
+      parts = klass.to_s.underscore.split('/').delete_if { |p| p.blank? }
 
       resource_name = plural ? parts[-1].pluralize : parts[-1]
 


### PR DESCRIPTION
The Dashboard view was working for models with names like `::Refinery::Page`, but not for models with names like `::Refinery::PageSettings`. With these ones, it throws this error:

<pre><code>NoMethodError in Refinery/admin/dashboard#index 
undefined method 'edit_pagesettings_admin_pagesetting_path' for #<ActionDispatch::Routing::RoutesProxy:0x000000073855c0>
</code></pre>


The fix for the `Refinery.route_for_model` method, makes it return `edit_page_settings_admin_page_setting_path` instead of `edit_pagesettings_admin_pagesetting_path`.
