### PR TITLE
Remove unneeded call to url helper

### DIFF
--- a/resources/app/views/refinery/admin/resources/_existing_resource.html.erb
+++ b/resources/app/views/refinery/admin/resources/_existing_resource.html.erb
@@ -22,7 +22,6 @@
   <%= render :partial => "/refinery/admin/form_actions",
              :locals => {
                :f => nil,
-               :cancel_url => refinery.admin_resources_path,
                :submit_button_text => t('.button_text'),
                :hide_cancel => true,
                :hide_delete => true


### PR DESCRIPTION
Since `:hide_cancel => true` is passed, the url doesn't need to be generated.
