### PR TITLE
Removes to_sym mapping since params is a HashWithIndifferentAccess and concatenates it with initial condition.

### DIFF
--- a/core/lib/refinery/crud.rb
+++ b/core/lib/refinery/crud.rb
@@ -68,7 +68,7 @@ module Refinery
 
           def create
             # if the position field exists, set this object as last object, given the conditions of this class.
-            if #{class_name}.column_names.include?("position") && params[:#{singular_name}].keys.exclude?("position")
+            if #{class_name}.column_names.include?("position") && params[:#{singular_name}][:position].nil?
               params[:#{singular_name}].merge!({
                 :position => ((#{class_name}.maximum(:position, :conditions => #{options[:conditions].inspect})||-1) + 1)
               })


### PR DESCRIPTION
See https://github.com/resolve/refinerycms/commit/f734be1b37e93046a2e8447fde2069e9c7a7df87#commitcomment-941993 for more details.
