### PR TITLE
Hex encode recipient into mailto links

### DIFF
--- a/core/app/assets/javascripts/refinery/admin.js.erb
+++ b/core/app/assets/javascripts/refinery/admin.js.erb
@@ -457,7 +457,7 @@ var link_dialog = {
     $('#email_address_text, #email_default_subject_text, #email_default_body_text').change(function(e){
       var default_subject = $('#email_default_subject_text').val(),
           default_body = $('#email_default_body_text').val(),
-          mailto = "mailto:" + $('#email_address_text').val(),
+          recipient = $('#email_address_text').val();
           modifier = "?",
           additional = "";
 
@@ -471,7 +471,11 @@ var link_dialog = {
         modifier = "&";
       }
 
-      link_dialog.update_parent(mailto + additional, mailto.replace('mailto:', ''));
+      var hex_recipient = '';
+      for (var i = 0; i < recipient.length; i++) {
+        hex_recipient += '%' + recipient.charCodeAt(i).toString(16);
+      }
+      link_dialog.update_parent("mailto:" + hex_recipient + additional, recipient);
     });
   },
 


### PR DESCRIPTION
I've had a bash at this, see what you think.

It hex encodes the email address using Js from the dialog into wymmeditor.

Subsequent requests simply add the encoded version as a query parameter, so it's automatically decoded and re-displayed as plain text : )

I've left the anchor's title attribute populated with the email address, maybe it would be better to simply strip that out? I have no idea how these spam bots work and I am probably wrongly assuming they wont scan that.
