### PR TITLE
add first|last classes to menu list items

### DIFF
--- a/core/app/helpers/refinery/menu_helper.rb
+++ b/core/app/helpers/refinery/menu_helper.rb
@@ -21,6 +21,11 @@ module Refinery
 
       css = []
       css << 'selected' if selected_page_or_descendant_page_selected?(local_assigns[:menu_branch])
+      css << if menu_branch_counter == 0
+               'first'
+             elsif menu_branch_counter == options[:sibling_count]
+               'last'
+             end
       css
     end
 


### PR DESCRIPTION
so it seems `menu_branch_css` helper method lacks code for adding 'first' or 'last' class to corresponding menu list items while containing fetches for number of siblings

whether it should be added one piece or removed other respectively
