### PR TITLE
Bug with resources when mounting refinery engine using namespace

### DIFF
--- a/authentication/spec/models/refinery/user_spec.rb
+++ b/authentication/spec/models/refinery/user_spec.rb
@@ -201,7 +201,7 @@ module Refinery
       it "adds registered plugins" do
         first_user.plugins.collect(&:name).should eq(
           ["refinery_settings", "refinery_users", "refinery_dashboard",
-            "refinery_images", "refinery_pages", "refinery_files"]
+            "refinery_images", "refinery_files", "refinery_pages"]
         )
       end
 

--- a/lib/refinery/all.rb
+++ b/lib/refinery/all.rb
@@ -1,3 +1,3 @@
-%w(core authentication dashboard images pages resources).each do |engine|
+%w(core authentication dashboard images resources pages).each do |engine|
   require "refinerycms-#{engine}"
 end

--- a/resources/spec/requests/refinery/admin/resources_spec.rb
+++ b/resources/spec/requests/refinery/admin/resources_spec.rb
@@ -76,6 +76,29 @@ module Refinery
 
           page.should have_content("http://www.refineryhq.com/")
         end
+
+        context 'when the engine is mounted with a named space' do
+          before do
+            Rails.application.routes.draw do
+              mount Refinery::Core::Engine, :at => "/about"
+            end
+          end
+
+          after do
+            Rails.application.routes.draw do
+              mount Refinery::Core::Engine, :at => "/"
+            end
+          end
+
+          it "succeeds" do
+            visit refinery.admin_resources_path
+
+            click_link "Download this file"
+
+            page.should have_content("http://www.refineryhq.com/")
+          end
+
+        end
       end
     end
   end


### PR DESCRIPTION
We found a bug when mounting the app under a namespace where resources will 404 after uploading them.  We also noticed that this wasn't happening for any of the images that we uploaded, and so we made the connection of moving the resources engine before the pages engine when loading the gem.
