### PR TITLE
Stop notices from PostgreSQL appearing when DB setup tasks are run

### DIFF
--- a/core/lib/generators/refinery/cms/templates/config/database.yml.postgresql
+++ b/core/lib/generators/refinery/cms/templates/config/database.yml.postgresql
@@ -19,6 +19,7 @@ development:
   pool: 5
   username: postgres
   password: postgres
+  min_messages: warning
 
   # Connect on a TCP socket. Omitted by default since the client uses a
   # domain socket that doesn't need configuration. Windows does not have
@@ -45,6 +46,7 @@ test:
   pool: 5
   username: postgres
   password: postgres
+  min_messages: warning
 
 production:
   adapter: postgresql
@@ -53,3 +55,4 @@ production:
   pool: 5
   username: postgres
   password: postgres
+  min_messages: warning

--- a/core/lib/generators/refinery/dummy/templates/rails/database.yml
+++ b/core/lib/generators/refinery/dummy/templates/rails/database.yml
@@ -14,6 +14,7 @@ login: &login
   pool: 5
   username: postgres
   password: postgres
+  min_messages: warning
 <% else %>
   adapter: sqlite3
   pool: 5


### PR DESCRIPTION
This stops messages such as this from appearing when database setup
tasks are run:

NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index
"refinery_resources_pkey" for table "refinery_resources"

I saw these clogging up the build messages here: http://travis-ci.org/#!/resolve/refinerycms/jobs/720667. Thought I would fix it.

:heart:
