### PR TITLE
Removes i18n-js in favour of erb includes.

### DIFF
--- a/core/app/assets/javascripts/i18n-messages.js
+++ b/core/app/assets/javascripts/i18n-messages.js
@@ -1,2 +1,0 @@
-var I18n = I18n || {};
-I18n.translations = {};

--- a/core/app/assets/javascripts/refinery/boot_wym.js.erb
+++ b/core/app/assets/javascripts/refinery/boot_wym.js.erb
@@ -1,7 +1,3 @@
-if (typeof(I18n) != 'undefined') {
-  I18n.locale = "<%= I18n.locale %>";
-}
-
 onOpenDialog = function(dialog) {
   (dialog = $('.ui-dialog')).find('.ui-dialog-titlebar').corner('1px top');
   if(!$.browser.msie){
@@ -228,7 +224,7 @@ var wymeditor_boot_options = $.extend({
       );
     }
   }
-  , lang: ((typeof(I18n) != 'undefined' && I18n.locale != null) ? I18n.locale : 'en')
+  , lang: '<%= ::Refinery::i18n_enabled? ? ::Refinery::I18n.current_locale : 'en' %>'
 }, custom_wymeditor_boot_options);
 
 WYMeditor.editor.prototype.loadIframe = function(iframe) {

--- a/core/app/assets/javascripts/refinery/modal_dialogs.js.erb
+++ b/core/app/assets/javascripts/refinery/modal_dialogs.js.erb
@@ -90,7 +90,7 @@ init_submit_continue = function(){
   if ((continue_editing_button = $('#continue_editing')).length > 0 && continue_editing_button.attr('rel') != 'no-prompt') {
     $('#editor_switch a').click(function(e) {
       if ($('form[data-changes-made]').length > 0) {
-        if (!confirm(I18n.t('js.admin.confirm_changes'))) {
+        if (!confirm('<%= j ::I18n.t('js.admin.confirm_changes') %>')) {
           e.preventDefault();
         }
       }

--- a/core/app/assets/javascripts/refinery/refinery.js.erb
+++ b/core/app/assets/javascripts/refinery/refinery.js.erb
@@ -3,7 +3,6 @@
  *= require jquery_ujs
  *= require jquery-ui
  *= require ../modernizr-min
-<% require_asset 'i18n' if defined?(Refinery::I18n::Engine) %>
  *= require ../jquery/jquery.corner
  *= require ../jquery/jquery.textTruncate
  *= require ../jquery/jquery.html5-placeholder-shim

--- a/core/app/assets/javascripts/refinery/submit_continue.js.coffee.erb
+++ b/core/app/assets/javascripts/refinery/submit_continue.js.coffee.erb
@@ -5,4 +5,4 @@
   
   if (continue_editing_button = $("#continue_editing")).length > 0 and continue_editing_button.attr("rel") != "no-prompt"
     $("#editor_switch a").click (e) ->
-      e.preventDefault()  unless confirm(I18n.t("js.admin.confirm_changes"))  if $("form[data-changes-made]").length > 0
+      e.preventDefault()  unless confirm("<%= ::I18n.t("js.admin.confirm_changes") %>")  if $("form[data-changes-made]").length > 0


### PR DESCRIPTION
This should address #1197. An additional change to refinerycms-i18n needs to happen to remove its dependency on i18n-js.
