### PR TITLE
for some reason clearfix could not be overridden in the css

### DIFF
--- a/core/app/views/refinery/_menu.html.erb
+++ b/core/app/views/refinery/_menu.html.erb
@@ -3,7 +3,7 @@
   # ::Refinery::Menu is smart enough to remember all of the items in the original collection.
   if (roots = local_assigns[:roots] || (collection ||= @menu_pages).roots).present?
     dom_id ||= 'menu'
-    css = [(css || 'menu'), 'clearfix'].flatten.join(' ')
+    css = [(css || 'menu clearfix')].flatten.join(' ')
     hide_children = Refinery::Core.menu_hide_children if hide_children.nil?
 -%>
 <nav id='<%= dom_id %>' class='<%= css %>'>


### PR DESCRIPTION
I'm not sure what the reasoning is, but there is no way to override the class clearfix in the menu css.  This makes adding other controls next to the menu rather difficult.  The change I made preserves the behavior unless someone has used the locals css so most people should see no change.
