### PR TITLE
Require refinerycms-settings gem

### DIFF
--- a/templates/refinery/edge.rb
+++ b/templates/refinery/edge.rb
@@ -3,6 +3,7 @@ append_file 'Gemfile' do
 "
 
 #{"gem 'therubyracer'" if RbConfig::CONFIG['target_os'] =~ /linux/i}
+gem 'refinerycms-settings', :git => 'git://github.com/parndt/refinerycms-settings.git'
 gem 'refinerycms', :git => 'git://github.com/resolve/refinerycms.git'
 
 #  group :development, :test do


### PR DESCRIPTION
Hi, 

My first ever pull request on github:  If you use any of the edge engines (e.g. blog) the new settings gem is required.  It may be useful if it's in the template Gemfile.

Cheers

Kyle
