### PR TITLE
Found an issue with Refinery::I18n

### DIFF
--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -100,7 +100,11 @@ module Refinery
 
       # Finds a page using its slug.  See by_title
       def by_slug(slug)
-        with_globalize(:locale => Refinery::I18n.frontend_locales, :slug => slug)
+        if defined?(::Refinery::I18n)
+          with_globalize(:locale => Refinery::I18n.frontend_locales, :slug => slug)
+        else
+          with_globalize(:locale => ::I18n.locale, :slug => slug)
+        end
       end
 
       # Shows all pages with :show_in_menu set to true, but it also


### PR DESCRIPTION
I was getting this issue when I tried to go anywhere but the home page, "Uninitialized Constant ::Refinery::I18n."

I dug in and found out that it caused by an issue in by_slug that assumed Refinery::I18n was defined (which in my case, it wasn't), so I'm fixing that issue.
