### PR TITLE
Include ContentPagesHelper in all controllers

### DIFF
--- a/pages/app/controllers/refinery/admin/pages_controller.rb
+++ b/pages/app/controllers/refinery/admin/pages_controller.rb
@@ -1,8 +1,6 @@
 module Refinery
   module Admin
     class PagesController < Refinery::AdminController
-      helper Pages::ContentPagesHelper
-
       cache_sweeper Refinery::PageSweeper
 
       crudify :'refinery/page',

--- a/pages/app/controllers/refinery/pages_controller.rb
+++ b/pages/app/controllers/refinery/pages_controller.rb
@@ -1,7 +1,5 @@
 module Refinery
   class PagesController < ::ApplicationController
-    helper Pages::ContentPagesHelper
-
     before_filter :find_page
 
     # Save whole Page after delivery

--- a/pages/lib/refinery/pages/engine.rb
+++ b/pages/lib/refinery/pages/engine.rb
@@ -16,6 +16,9 @@ module Refinery
       after_inclusion do
         ::ApplicationController.send :include, Refinery::Pages::InstanceMethods
         Refinery::AdminController.send :include, Refinery::Pages::Admin::InstanceMethods
+
+        ::ApplicationController.send :helper, Refinery::Pages::ContentPagesHelper
+        Refinery::AdminController.send :helper, Refinery::Pages::ContentPagesHelper
       end
 
       initializer "register refinery_pages plugin" do


### PR DESCRIPTION
Other engines currently use these helpers, in both the frontend and admin. Including them globally might not be the best solution, but it's the only practical one for this release. In the long term, it seems more sensible for the Blog engine (and so forth) to not use page objects at all.

Refinery core repos tests all passing with this change, but I'm afraid I haven't had time to install the blog engine into a sample app and try it. It wasn't working before though, so it can't be any worse. :/
