### PR TITLE
Include application.js file by default on the front end.

### DIFF
--- a/core/app/views/refinery/_javascripts.html.erb
+++ b/core/app/views/refinery/_javascripts.html.erb
@@ -7,4 +7,5 @@
     <script> DD_belatedPNG.fix('img, .png_bg'); //fix any <img> or .png_bg background-images </script>
   <![endif]-->
 <% end %>
+<%= javascript_include_tag 'application' %>
 <%= yield :javascripts -%>


### PR DESCRIPTION
Rails includes the application.js file by default in new applications. This enables the asset pipeline to work correctly.  I think this feature should be included by the refinery front end as well.

Note that this will end up including jquery and jquery_ujs by default as they are the options specified in a new rails application.
