### PR TITLE
Add guard-spork '0.5.2' dependency to RefineryCMS-Testing

### DIFF
--- a/testing/refinerycms-testing.gemspec
+++ b/testing/refinerycms-testing.gemspec
@@ -31,5 +31,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'rspec-instafail'
   s.add_dependency 'capybara',                '~> 1.1.0'
   s.add_dependency 'guard-rspec',             '~> 0.6.0'
+  s.add_dependency 'guard-spork',             '~> 0.5.2'
   s.add_dependency 'refinerycms-core',        version
 end


### PR DESCRIPTION
Before adding this dependency, I got this error on a fresh Refinery 2.0 project:

ERROR: Could not load 'guard/spork' or find class Guard::Spork
ERROR: cannot load such file -- guard/spork
ERROR: Invalid Guardfile, original error is:
undefined method `new' for nil:NilClass
