### PR TITLE
Stub login in request specs.

### DIFF
--- a/core/spec/support/refinery.rb
+++ b/core/spec/support/refinery.rb
@@ -5,10 +5,15 @@ RSpec.configure do |config|
   config.include Refinery::Testing::ControllerMacros::Methods, :type => :controller
   config.extend Refinery::Testing::RequestMacros::Authentication, :type => :request
   config.include Refinery::Testing::UrlHelper
+  config.include Warden::Test::Helpers
 
   # set some config values so that image and resource factories don't fail to create
   config.before(:each) do
     Refinery::Images.max_image_size = 5242880
     Refinery::Resources.max_file_size = 52428800
+  end
+
+  config.after do
+    Warden.test_reset!
   end
 end

--- a/pages/spec/requests/refinery/admin/pages_spec.rb
+++ b/pages/spec/requests/refinery/admin/pages_spec.rb
@@ -261,13 +261,16 @@ module Refinery
           Refinery::I18n.stub(:frontend_locales).and_return([:en, :ru])
 
           # Create a home page in both locales (needed to test menus)
-          home_page = FactoryGirl.create(:page, :title => 'Home',
-                                                :link_url => '/',
-                                                :menu_match => "^/$")
-          Globalize.locale = :ru
-          home_page.title = 'Домашняя страница'
-          home_page.save
-          Globalize.locale = :en
+          home_page = Globalize.with_locale(:en) do
+            FactoryGirl.create(:page, :title => 'Home',
+                                      :link_url => '/',
+                                      :menu_match => "^/$")
+          end
+
+          Globalize.with_locale(:ru) do
+            home_page.title = 'Домашняя страница'
+            home_page.save
+          end
         end
 
         describe "add a page with title for default locale" do

--- a/testing/lib/refinery/testing/request_macros/authentication.rb
+++ b/testing/lib/refinery/testing/request_macros/authentication.rb
@@ -6,12 +6,7 @@ module Refinery
           let!(:logged_in_user) { Factory.create(factory) }
 
           before do
-            visit refinery.new_refinery_user_session_path
-
-            fill_in "Login", :with => logged_in_user.username
-            fill_in "Password", :with => logged_in_user.password
-
-            click_on "Sign in"
+            login_as logged_in_user, :scope => :refinery_user
           end
         end
 


### PR DESCRIPTION
Like we discussed in #1413 I removed the login page request in favor of using Warden's test helpers [as described here](https://github.com/plataformatec/devise/wiki/How-To:-Test-with-Capybara). This caused a few test failures to popup, all of them in the pages/spec/requests/refinery/admin/pages_spec.rb file. I was able to workaround one test failure with the changes I made to that file, but a few persisted. The code in that spec is not the cleanest and all of the failing specs belong to one describe block, so it's possible I missed something, but I'm done monkeying with it today.

For the record, the test failures I see are these:

```
rspec ./pages/spec/requests/refinery/admin/pages_spec.rb:552 # TranslatePages Pages Link-to Dialog adding page link with relative urls shows Russian pages if we're editing the Russian locale
rspec ./pages/spec/requests/refinery/admin/pages_spec.rb:559 # TranslatePages Pages Link-to Dialog adding page link with relative urls shows default to the default locale if no query string is added
rspec ./pages/spec/requests/refinery/admin/pages_spec.rb:569 # TranslatePages Pages Link-to Dialog adding page link with absolute urls shows Russian pages if we're editing the Russian locale
rspec ./pages/spec/requests/refinery/admin/pages_spec.rb:576 # TranslatePages Pages Link-to Dialog adding page link with absolute urls shows default to the default locale if no query string is added
```

BTW, with these changes the specs took about 13 seconds (8%) less wall clock time.
