### PR TITLE
Properly emit an html opening tag for non-IE browsers.

### DIFF
--- a/core/app/views/refinery/_html_tag.html.erb
+++ b/core/app/views/refinery/_html_tag.html.erb
@@ -3,4 +3,4 @@
 <!--[if IE 7 ]>    <html lang="<%= ::I18n.locale %>" class="no-js ie7"> <![endif]-->
 <!--[if IE 8 ]>    <html lang="<%= ::I18n.locale %>" class="no-js ie8"> <![endif]-->
 <!--[if IE 9 ]>    <html lang="<%= ::I18n.locale %>" class="no-js ie9"> <![endif]-->
-<!--[if (gt IE 9)|!(IE)]> <html lang="<%= ::I18n.locale %>" class="no-js"> <![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!--> <html lang="<%= ::I18n.locale %>" class="no-js"> <!--<![endif]-->


### PR DESCRIPTION
Fix for issue #1435
