### PR TITLE
Use therubyracer in Gemfile when needed

### DIFF
--- a/templates/refinery/edge.rb
+++ b/templates/refinery/edge.rb
@@ -1,4 +1,7 @@
 require 'rbconfig'
+
+ExecJS::Runtimes.autodetect rescue gsub_file 'Gemfile', "# gem 'therubyracer'", "gem 'therubyracer'"
+
 append_file 'Gemfile' do
 "
 


### PR DESCRIPTION
Unclean implemetation of my idea.
#1406 #1412

For JRuby, `therubyrhino` is already used by rails.
For other Rubies, there is commented `therubyracer`. If you have another runtime installed in path (like node.js on Linux), you don't need another. If there is no `ExecJS` compatible JS runtime, `therubyracer` is used.
