### PR TITLE
Update readme links

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,6 @@ More information at [http://refinerycms.com](http://refinerycms.com)
 
 * __[Install Refinery CMS](http://refinerycms.com/download)__
 * [Install Refinery CMS on Heroku](http://refinerycms.com/guides/how-to-install-refinery-on-heroku)
-* [Run the Refinery CMS test suite](http://refinerycms.com/guides/how-to-test-refinery)
 * [Contribute to Refinery CMS](http://refinerycms.com/guides/contributing-to-refinery)
 
 ## Getting Started


### PR DESCRIPTION
Removing obsolete testing link (what happened to that guide anyway?  I need it  :(  ) and update the link to the list of extensions to refer to the website, as the wiki doesn't have a list of extensions any more.
