### PR TITLE
Fix for #1447

### DIFF
--- a/pages/lib/refinery/pages/instance_methods.rb
+++ b/pages/lib/refinery/pages/instance_methods.rb
@@ -4,6 +4,7 @@ module Refinery
 
       def self.included(base)
         base.send :helper_method, :refinery_menu_pages
+        base.send :alias_method_chain, :render, :presenters
       end
 
       def error_404(exception=nil)
@@ -22,9 +23,9 @@ module Refinery
       end
 
     protected
-      def render(*args)
+      def render_with_presenters(*args)
         present(@page) unless admin? or @meta.present?
-        super
+        render_without_presenters(*args)
       end
 
     private


### PR DESCRIPTION
The patch includes a fix for  #1447  (overriding render with Refinery::Pages::InstanceMethods#render breaks the respond_with :json or :xml functionality).
