### PR TITLE
Remove global hash of Menu instances.

### DIFF
--- a/core/lib/refinery/menu.rb
+++ b/core/lib/refinery/menu.rb
@@ -1,30 +1,14 @@
 module Refinery
-
-  # Create a little something to store the instances of the menu.
-  class << self
-    attr_accessor :menus
-    def menus
-      @@menus ||= HashWithIndifferentAccess.new
-    end
-  end
-
   class Menu
 
     def initialize(objects = nil)
       objects.each do |item|
         item = item.to_refinery_menu_item if item.respond_to?(:to_refinery_menu_item)
-        items << MenuItem.new(item.merge(:menu_id => id))
+        items << MenuItem.new(item.merge(:menu => self))
       end if objects
-
-      ::Refinery.menus[self.id] = self
     end
 
-    attr_accessor :items, :id
-
-    def id
-      require 'securerandom' unless defined?(::SecureRandom)
-      @id ||= ::SecureRandom.hex(8)
-    end
+    attr_accessor :items
 
     def items
       @items ||= []

--- a/core/lib/refinery/menu_item.rb
+++ b/core/lib/refinery/menu_item.rb
@@ -3,7 +3,7 @@ module Refinery
 
     class << self
       def attributes
-        [:title, :parent_id, :lft, :rgt, :depth, :url, :menu_id, :menu_match]
+        [:title, :parent_id, :lft, :rgt, :depth, :url, :menu, :menu_match]
       end
 
       def apply_attributes!
@@ -75,10 +75,6 @@ module Refinery
       end
 
       hash.inspect
-    end
-
-    def menu
-      ::Refinery.menus[menu_id]
     end
 
     def parent


### PR DESCRIPTION
Inside Refinery::Menu's constructor, it was adding each new instance to a global hash. This was used so that MenuItem instances could refer to the Menu they belonged to, but it made it so all Menu and MenuItem instances would never fall out of scope and be garbage collected.

Earlier today I pasted this code in #1341 to demonstrate the problem:

```
rails r 'i = 0 ; loop { Refinery::Menu.new(Refinery::Page.fast_menu) ; p [:menus, Refinery.menus.size, :mem, `ps -o rss= -p #{$$}`.to_i] if (i += 1) % 1000 == 0 }'
```
