### PR TITLE
Images: Allow configurable whitelisted mime types

### DIFF
--- a/images/app/models/refinery/image.rb
+++ b/images/app/models/refinery/image.rb
@@ -6,7 +6,7 @@ module Refinery
 
     validates :image, :presence  => true
     validates_with ImageSizeValidator
-    validates_property :mime_type, :of => :image, :in => %w(image/jpeg image/png image/gif image/tiff),
+    validates_property :mime_type, :of => :image, :in => ::Refinery::Images.whitelisted_mime_types,
                        :message => :incorrect_format
 
     # Docs for acts_as_indexed http://github.com/dougal/acts_as_indexed

--- a/images/lib/generators/refinery/images/templates/config/initializers/refinery/images.rb.erb
+++ b/images/lib/generators/refinery/images/templates/config/initializers/refinery/images.rb.erb
@@ -14,6 +14,9 @@ Refinery::Images.configure do |config|
 
   # Configure image sizes
   # config.user_image_sizes = <%= Refinery::Images.user_image_sizes.inspect %>
+  
+  # Configure white-listed mime types for validation
+  # config.whitelisted_mime_types = <%= Refinery::Images.whitelisted_mime_types.inspect %>
 
   # Configure image view options
   # config.image_views = <%= Refinery::Images.image_views.inspect %>

--- a/images/lib/refinery/images/configuration.rb
+++ b/images/lib/refinery/images/configuration.rb
@@ -7,7 +7,8 @@ module Refinery
                     :pages_per_dialog_that_have_size_options, :user_image_sizes,
                     :image_views, :preferred_image_view, :datastore_root_path,
                     :s3_backend, :s3_bucket_name, :s3_region,
-                    :s3_access_key_id, :s3_secret_access_key, :trust_file_extensions
+                    :s3_access_key_id, :s3_secret_access_key, :trust_file_extensions,
+                    :whitelisted_mime_types
 
     self.dragonfly_insert_before = 'ActionDispatch::Callbacks'
     self.dragonfly_secret = Refinery::Core.dragonfly_secret
@@ -24,6 +25,14 @@ module Refinery
       :medium => '225x255>',
       :large => '450x450>'
     }
+
+    self.whitelisted_mime_types = [
+      'image/jpeg',
+      'image/png',
+      'image/gif',
+      'image/tiff'
+    ]
+
     self.image_views = [:grid, :list]
     self.preferred_image_view = :grid
 


### PR DESCRIPTION
You should be able to allow additional mimetypes inside of images (bmp is missing, for example).
