### PR TITLE
Disable sorting for the menu reorder buttons

### DIFF
--- a/core/app/assets/javascripts/refinery/sortable_menu.js.coffee
+++ b/core/app/assets/javascripts/refinery/sortable_menu.js.coffee
@@ -2,6 +2,7 @@
   $menu = $("#menu")
   return  if $menu.length == 0
   $menu.sortable(
+    items: "> *:not(#menu_reorder, #menu_reorder_done)"
     axis: "x"
     cursor: "crosshair"
     connectWith: ".nested"


### PR DESCRIPTION
Exclude #menu_reorder and #menu_reorder_done from the sortable items when reordering the menu menu.

![Screenshot](http://i.imgur.com/kqiZJ.png)
![Screenshot](http://i.imgur.com/LL0OM.png)
![Screenshot](http://i.imgur.com/X2k8N.png)
