### PR TITLE
Remove references to Thread[:globalize_locale].

### DIFF
--- a/core/lib/generators/refinery/engine/templates/app/views/refinery/namespace/admin/plural_name/_form.html.erb
+++ b/core/lib/generators/refinery/engine/templates/app/views/refinery/namespace/admin/plural_name/_form.html.erb
@@ -8,7 +8,7 @@
               :include_object_name => true %>
 <% if localized? %>
   <%%= render "locale_picker",
-              :current_locale => Thread.current[:globalize_locale] if Refinery.i18n_enabled? %>
+              :current_locale => Globalize.locale if Refinery.i18n_enabled? %>
 <% end %>
   <% attributes.each_with_index do |attribute, index| %>
 <% if attribute.field_type.to_s != 'text_area' -%>

--- a/pages/app/controllers/refinery/admin/pages_controller.rb
+++ b/pages/app/controllers/refinery/admin/pages_controller.rb
@@ -50,7 +50,7 @@ module Refinery
           # end
         else
           # Always display the tree of pages from the default frontend locale.
-          Thread.current[:globalize_locale] = params[:switch_locale].try(:to_sym) || Refinery::I18n.default_frontend_locale
+          Globalize.locale = params[:switch_locale].try(:to_sym) || Refinery::I18n.default_frontend_locale
         end
       end
 

--- a/pages/app/controllers/refinery/admin/pages_dialogs_controller.rb
+++ b/pages/app/controllers/refinery/admin/pages_dialogs_controller.rb
@@ -8,7 +8,7 @@ module ::Refinery
         # Get the switch_local variable to determine the locale we're currently editing
         # Set up Globalize with our current locale
         if ::Refinery.i18n_enabled?
-          Thread.current[:globalize_locale] = params[:switch_locale] || Refinery::I18n.default_locale
+          Globalize.locale = params[:switch_locale] || Refinery::I18n.default_locale
         end
 
         @pages = ::Refinery::Page.roots.paginate(:page => params[:page], :per_page => ::Refinery::Page.per_page(true))


### PR DESCRIPTION
`Thread[:globalize_locale]` is an implementation detail. Use the API instead of mucking around in the guts.
