### PR TITLE
Remove the to_param from user now that we have a slug, because they'll conflict

### DIFF
--- a/authentication/app/models/refinery/user.rb
+++ b/authentication/app/models/refinery/user.rb
@@ -91,9 +91,5 @@ module Refinery
       username.to_s
     end
 
-    def to_param
-      to_s.parameterize
-    end
-
   end
 end


### PR DESCRIPTION
Basically, to_param wreaks havoc on friendly_id.
