### PR TITLE
Reformat regexp that broke vim's syntax highlighting.

### DIFF
--- a/core/lib/refinery/application_controller.rb
+++ b/core/lib/refinery/application_controller.rb
@@ -48,7 +48,7 @@ module Refinery
     end
 
     def home_page?
-      refinery.root_path =~ /^#{Regexp.escape(request.path.sub("//", "/"))}\/?/
+      refinery.root_path =~ %r{^#{Regexp.escape(request.path.sub("//", "/"))}}
     end
 
     def just_installed?

--- a/core/spec/lib/refinery/application_controller_spec.rb
+++ b/core/spec/lib/refinery/application_controller_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
-describe "Refinery::ApplicationController" do
-  describe "DummyController", :type => :controller do
+module Refinery
+  describe ApplicationController, :type => :controller do
     controller do
       include ::Refinery::ApplicationController
 
@@ -23,9 +23,20 @@ describe "Refinery::ApplicationController" do
         controller.home_page?.should be_true
       end
 
+      it "matches localised root url with trailing slash" do
+        controller.refinery.stub(:root_path).and_return("/en/")
+        request.stub(:path).and_return("/en/")
+        controller.home_page?.should be_true
+      end
+
       it "escapes regexp" do
         request.stub(:path).and_return("\/huh)")
         expect { controller.home_page? }.to_not raise_error(RegexpError)
+      end
+
+      it "returns false for non root url" do
+        request.stub(:path).and_return("/foo/")
+        controller.should_not be_home_page
       end
     end
 


### PR DESCRIPTION
This regexp broken vim syntax highlighting. Probably more likely a bug in the vim syntax highlighter than ruby, but I changed it anyways.

Also, it doesn't look like home_page? is used anywhere in refinery. Should it be removed for 2.1.x?
