### PR TITLE
Fix presenter finding logic.

### DIFF
--- a/core/lib/refinery/application_controller.rb
+++ b/core/lib/refinery/application_controller.rb
@@ -71,12 +71,15 @@ module Refinery
 
     # use a different model for the meta information.
     def present(model)
-      presenter = if model && model.class.present? && defined?("#{model.class}Presenter")
-        "#{model.class.name}Presenter".constantize
-      else
-        BasePresenter
-      end
-      @meta = presenter.new(model)
+      @meta = presenter_for(model).new(model)
+    end
+
+    def presenter_for(model, default=BasePresenter)
+      return default if model.nil?
+
+      "#{model.class.name}Presenter".constantize
+    rescue NameError
+      default
     end
 
     def refinery_user_required?

--- a/core/spec/lib/refinery/application_controller_spec.rb
+++ b/core/spec/lib/refinery/application_controller_spec.rb
@@ -68,5 +68,20 @@ describe "Refinery::ApplicationController" do
         end
       end
     end
+
+    describe "#presenter_for" do
+      it "returns BasePresenter for nil" do
+        controller.send(:presenter_for, nil).should eq(BasePresenter)
+      end
+
+      it "returns BasePresenter when the instance's class does not have a presenter" do
+        controller.send(:presenter_for, Object.new).should eq(BasePresenter)
+      end
+
+      it "returns the class's presenter when the instance's class has a presenter" do
+        model = Refinery::Page.new
+        controller.send(:presenter_for, model).should eq(Refinery::PagePresenter)
+      end
+    end
   end
 end


### PR DESCRIPTION
It looks like this has been broken for anything other than nil or Refinery::Page since 34bd3578cdcb. This should be backported to 2-0-stable since, for example, blog is broken again 2-0-stable currently.
