### PR TITLE
Extensions were not watched properly by guard

### DIFF
--- a/testing/lib/generators/refinery/testing/templates/Guardfile
+++ b/testing/lib/generators/refinery/testing/templates/Guardfile
@@ -1,4 +1,4 @@
-extensions = Dir[File.expand_path('../vendor/extensions/*', __FILE__)]
+extensions = Dir[ 'vendor/extensions/*' ]
 
 guard 'spork', :wait => 60, :cucumber => false, :rspec_env => { 'RAILS_ENV' => 'test' } do
   watch('config/application.rb')


### PR DESCRIPTION
The extension file path was absolute instead of relative (fixes #1569)
