### PR TITLE
Disable page caching when logged in to prevent caching the sitebar. 

### DIFF
--- a/pages/app/controllers/refinery/pages_controller.rb
+++ b/pages/app/controllers/refinery/pages_controller.rb
@@ -95,7 +95,7 @@ module Refinery
     end
 
     def write_cache?
-      if Refinery::Pages.cache_pages_full
+      if Refinery::Pages.cache_pages_full && !refinery_user?
         cache_page(response.body, File.join('', 'refinery', 'cache', 'pages', request.path.sub("//", "/")).to_s)
       end
     end


### PR DESCRIPTION
When `cache_pages_full` is enabled the page will be cached WITH the blue sitebar if you are logged in.

This commit should fix that.
