### PR TITLE
Precompile path fix

### DIFF
--- a/core/lib/refinery/core/engine.rb
+++ b/core/lib/refinery/core/engine.rb
@@ -96,7 +96,7 @@ module Refinery
       end
 
       # set the manifests and assets to be precompiled
-      initializer "refinery.assets.precompile" do |app|
+      initializer "refinery.assets.precompile", :group => :all do |app|
         app.config.assets.precompile += [
           "refinery/*",
           "refinery/icons/*",


### PR DESCRIPTION
Rails' initializers need to have an explicit `:all` group (instead of the default `:default`) or else they are skipped during `rake assets:precompile`.

See [assets.rake#L95](https://github.com/rails/rails/blob/c3d50b35b0e03a68095ebb0d52d371d28c8aa436/actionpack/lib/sprockets/assets.rake#L95), [application.rb#L131](https://github.com/rails/rails/blob/90269802dbf690fbe8be0cd01e3b387a51f02b70/railties/lib/rails/application.rb#L131), [initializable.rb#L55](https://github.com/rails/rails/blob/90269802dbf690fbe8be0cd01e3b387a51f02b70/railties/lib/rails/initializable.rb#L55) and [initializable.rb#L26](https://github.com/rails/rails/blob/90269802dbf690fbe8be0cd01e3b387a51f02b70/railties/lib/rails/initializable.rb#L26).

This fixes asset precompilation on Heroku with `config.assets.initialize_on_precompile = false`.
