### PR TITLE
Engine generator fix

### DIFF
--- a/core/lib/generators/refinery/engine/templates/app/views/refinery/namespace/admin/plural_name/_singular_name.html.erb
+++ b/core/lib/generators/refinery/engine/templates/app/views/refinery/namespace/admin/plural_name/_singular_name.html.erb
@@ -1,11 +1,12 @@
+<% title_attribute = (title = attributes.detect { |a| a.type.to_s == "string" }).present? ? title.name : title %>
 <li class='clearfix record <%%= cycle("on", "on-hover") %>' id="<%%= dom_id(<%= singular_name %>) -%>">
   <span class='title'>
-    <%%= <%= singular_name %><% if (title = attributes.detect { |a| a.type.to_s == "string" }).present? -%>.<%= title.name %><% else %>.title<%end %> %>
+    <%%= <%= singular_name %>.<%= title_attribute %> %>
 <% if localized? %>
     <%% if Refinery.i18n_enabled? and Refinery::I18n.frontend_locales.many? %>
       <span class='preview'>
         <%% <%= singular_name %>.translations.each do |translation| %>
-          <%% if translation.title.present? %>
+          <%% if translation.<%= title_attribute %>.present? %>
             <%%= link_to refinery_icon_tag("flags/#{translation.locale}.png", :size => '16x11'),
                          refinery.edit_<%= namespacing.underscore %>_admin_<%= singular_name %>_path(<%= singular_name %>, :switch_locale => translation.locale),
                          :class => 'locale' %>
@@ -26,7 +27,7 @@
     <%%= link_to refinery_icon_tag("delete.png"), refinery.<%= namespacing.underscore %>_admin_<%= singular_name %>_path(<%= singular_name %>),
         :class => "cancel confirm-delete",
         :title => t('.delete'),
-        :confirm => t('message', :scope => 'refinery.admin.delete', :title => <%= singular_name %><% if (title = attributes.detect { |a| a.type.to_s == "string" }).present? %>.<%= title.name %><% else %>.title<% end %>),
+        :confirm => t('message', :scope => 'refinery.admin.delete', :title => <%= singular_name %>.<%= title_attribute %>),
         :method => :delete %>
   </span>
 </li>


### PR DESCRIPTION
I fixed then engine generation of a view that had an hardcoded "title" attribute in it.

Was generated before (line 8):

``` erb
<% if translation.title.present? %>
```

Now:

``` erb
<% if translation.[my_attribute].present? %>
```

ie: 

``` erb
<% if translation.job_title.present? %>
```

I also removed some code duplication to keep that DRY.
