### PR TITLE
Don't require 'application_helper'

### DIFF
--- a/core/lib/refinery/admin/base_controller.rb
+++ b/core/lib/refinery/admin/base_controller.rb
@@ -1,5 +1,4 @@
 require 'action_controller'
-require 'application_helper'
 
 module Refinery
   module Admin


### PR DESCRIPTION
ApplicationHelper is an autoloadable constant, there is no need for an explicit `require`. This was causing me some `already initialized constant` warnings in my app.
