### PR TITLE
Ajax reordering crashs when default_url_options[:host] is not setted at action controller in production mode.

### DIFF
--- a/core/app/views/refinery/admin/_make_sortable.html.erb
+++ b/core/app/views/refinery/admin/_make_sortable.html.erb
@@ -7,7 +7,7 @@
 <% content_for :javascripts do %>
   <script>
     $(document).ready(function(){
-      list_reorder.update_url     = '<%= update_url ||= refinery.url_for(:action => "update_positions") %>';
+      list_reorder.update_url     = '<%= update_url ||= refinery.url_for(:action => "update_positions", :only_path => true) %>';
       list_reorder.sortable_list  = $('#<%= list_id ||= "sortable_list" %>, .sortable_list');
       list_reorder.tree           = <%= tree %>;
       list_reorder.init();


### PR DESCRIPTION
Fix a bug when default_url_options[:host] is not setted at action controller in production mode.

And I couldn't see any need for host in an ajax request.
