### PR TITLE
Add missing assets.precompile declarations

### DIFF
--- a/core/lib/refinery/core/engine.rb
+++ b/core/lib/refinery/core/engine.rb
@@ -98,6 +98,10 @@ module Refinery
       # set the manifests and assets to be precompiled
       initializer "refinery.assets.precompile", :group => :all do |app|
         app.config.assets.precompile += [
+          "home.css",
+          "formatting.css",
+          "theme.css",
+          "admin.js",
           "refinery/*",
           "refinery/icons/*",
           "wymeditor/lang/*",


### PR DESCRIPTION
The files are included by default yet are missing from `config.assets.precompile` array.
