### PR TITLE
Remove application_helper.rb from refinery/core

### DIFF
--- a/core/app/controllers/refinery/admin_controller.rb
+++ b/core/app/controllers/refinery/admin_controller.rb
@@ -3,6 +3,7 @@
 module Refinery
   class AdminController < ::ActionController::Base
     include ::Refinery::ApplicationController
+    helper ApplicationHelper
     helper Refinery::Core::Engine.helpers
     include Refinery::Admin::BaseController
 

--- a/core/app/helpers/application_helper.rb
+++ b/core/app/helpers/application_helper.rb
@@ -1,5 +1,0 @@
-# Methods added to this helper will be available to all templates in the application.
-
-module ::ApplicationHelper
-
-end

--- a/core/spec/lib/refinery/core_spec.rb
+++ b/core/spec/lib/refinery/core_spec.rb
@@ -173,4 +173,12 @@ describe Refinery do
       end
     end
   end
+
+  describe Refinery::Core::Engine do
+    describe "#helpers" do
+      it "should not include ApplicationHelper" do
+        Refinery::Core::Engine.helpers.ancestors.map(&:name).should_not include("ApplicationHelper")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Otherwise it gets cached in `Refinery::Core::Engine.helpers` and is not reloaded in development mode.
