### PR TITLE
Parent id nested set options

### DIFF
--- a/pages/app/helpers/refinery/admin/pages_helper.rb
+++ b/pages/app/helpers/refinery/admin/pages_helper.rb
@@ -1,6 +1,18 @@
 module Refinery
   module Admin
     module PagesHelper
+      def parent_id_nested_set_options(current_page)
+        all_pages = []
+        options = nested_set_options(::Refinery::Page, current_page) do |page|
+          all_pages << page
+          page
+        end
+        # page.title needs the :translations association, doing something like
+        # nested_set_options(::Refinery::Page.includes(:translations), page) doesn't work
+        ActiveRecord::Associations::Preloader.new(all_pages, :translations).run
+        options.map! {|page, id| ["#{'-' * page.level} #{page.title}", id]}
+        options
+      end
     end
   end
 end

--- a/pages/app/views/refinery/admin/pages/_form_advanced_options.html.erb
+++ b/pages/app/views/refinery/admin/pages/_form_advanced_options.html.erb
@@ -18,8 +18,7 @@
         <%= f.label :parent_id, t('.parent_page') %>
         <%= refinery_help_tag t('.parent_page_help') %>
       </span>
-      <%= f.select :parent_id, nested_set_options(::Refinery::Page, @page) {|i| "#{'-' * i.level} #{i.title}" },
-                   :include_blank => true %>
+      <%= f.select :parent_id, parent_id_nested_set_options(@page), :include_blank => true %>
     </div>
     <% if Refinery::Pages.use_layout_templates %>
     <div class='field'>


### PR DESCRIPTION
Manually preload :translations association to avoid the extra queries.
