### PR TITLE
Bug fixed in Firefox 11.

### DIFF
--- a/core/app/assets/javascripts/refinery/admin.js.erb
+++ b/core/app/assets/javascripts/refinery/admin.js.erb
@@ -91,9 +91,11 @@ init_modal_dialogs = function(){
       , height: height
       , open: onOpenDialog
       , close: onCloseDialog
+			, open: function(event, ui) {
+				iframe.attr('src', iframe_src);
+			}
     });
 
-    iframe.attr('src', iframe_src);
     e.preventDefault();
   });
 };


### PR DESCRIPTION
In the image picker popup, the content is blank until you move the popup.
