### PR TITLE
Remove drop_dummy_app_database rake task.

### DIFF
--- a/testing/lib/refinery/tasks/testing.rake
+++ b/testing/lib/refinery/tasks/testing.rake
@@ -17,12 +17,9 @@ namespace :refinery do
 
       Refinery::DummyGenerator.start params
 
-      # Ensure the database is not there from a previous run.
-      Rake::Task['refinery:testing:drop_dummy_app_database'].invoke
-
       Refinery::CmsGenerator.start %w[--quiet --fresh-installation]
 
-      Dir.chdir Refinery::Testing::Railtie.target_extension_path
+      Dir.chdir dummy_app_path 
     end
 
     # This task is a hook to allow extensions to pass configuration
@@ -44,12 +41,6 @@ namespace :refinery do
     task :clean_dummy_app do
       Rake::Task['refinery:testing:drop_dummy_app_database'].invoke
       dummy_app_path.rmtree if dummy_app_path.exist?
-    end
-
-    desc "Remove the dummy app's database."
-    task :drop_dummy_app_database do
-      load 'rails/tasks/engine.rake'
-      Rake::Task['app:db:drop'].invoke
     end
 
     task :init_test_database do


### PR DESCRIPTION
The reason why I removed this task is that before running dummy setup we check to see if dummy app even exists so this task won't run multiple times therefor I can't imagine situation when there's an existing db (please do correct me if I'm wrong).

I alos changed Dir.chdir call to go to dummy_app_path because some rake tasks just won't work from root path.
