### PR TITLE
Updated getting started guide to add link to Using Refinery with an Existant Rails App

### DIFF
--- a/doc/guides/1 - Getting Started/2 - Getting Started.textile
+++ b/doc/guides/1 - Getting Started/2 - Getting Started.textile
@@ -69,6 +69,8 @@ h3. Creating a new Refinery project
 
 If you follow this guide, you'll create a Refinery site called <tt>rickrockstar</tt> that will have a custom design and an events extension to allow Rick to tell his fans when his next gig is.
 
+If you already have a Rails application and want to add Refinery to it, please follow "Using Refinery with an Existing Rails App Guide":/guides/with-an-existing-rails-app and continue this guide by the next section "4. Hello, Refinery!":#hello-refinery
+
 Before you can start building this site, you need to make sure that you have Refinery itself installed.
 
 h4. Installing Refinery


### PR DESCRIPTION
If feel like this link is useful because I think people look into the getting started guide event if they already have a Rails application and want to try Refinery with it. The first time I went there, I assume that instead of using refinerycms command line, I can just add the gem to my Gemfile but I missed out that I need to run the generator.

I let you close the pull request if you do not agree with me.

Related to #1670
