### PR TITLE
Rearranging Rubies to get Travis to run critical rubies 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ matrix:
     - rvm: rbx-18mode
     - rvm: rbx-19mode
 rvm:
-  - 1.8.7
   - 1.9.3
-  - jruby-18mode
+  - 1.8.7
   - jruby-19mode
-  - rbx-18mode
+  - jruby-18mode
   - rbx-19mode
+  - rbx-18mode


### PR DESCRIPTION
before allowed failure rubies.

If there's a wait in the queue, it's better to run the most important rubies first. 
