### PR TITLE
Implement Page.rebuild! so that invalid url cache is cleared on re-sort

### DIFF
--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -186,6 +186,20 @@ module Refinery
           return true # so that other callbacks process.
         end
       end
+
+      def rebuild!
+        all.each do |page|
+          invalidate_child_cached_urls(page)
+        end
+      end
+
+      def invalidate_child_cached_urls(page)
+        page.send(:invalidate_cached_urls)
+
+        page.children.each do |child|
+          invalidate_child_cached_urls(child)
+        end
+      end
     end
 
     # The canonical page for this particular page.


### PR DESCRIPTION
All tests passing on my end, and confirmed this fixed the problem I was having

When re-sorting pages, the URL in the front-end was not updating to the correct path

Now it does with this .rebuild! class method
