### PR TITLE
Content disposition for dragonfly

### DIFF
--- a/resources/lib/generators/refinery/resources/templates/config/initializers/refinery/resources.rb.erb
+++ b/resources/lib/generators/refinery/resources/templates/config/initializers/refinery/resources.rb.erb
@@ -22,5 +22,6 @@ Refinery::Resources.configure do |config|
   # config.dragonfly_secret = <%= Refinery::Resources.dragonfly_secret.inspect %>
   # config.dragonfly_url_format = <%= Refinery::Resources.dragonfly_url_format.inspect %>
   # config.datastore_root_path = <%= Refinery::Resources.datastore_root_path.inspect %>
+	# config.content_disposition = <%= Refinery::Resources.content_disposition.inspect %>
 
 end

--- a/resources/lib/refinery/resources/configuration.rb
+++ b/resources/lib/refinery/resources/configuration.rb
@@ -6,12 +6,13 @@ module Refinery
                     :max_file_size, :pages_per_dialog, :pages_per_admin_index,
                     :s3_backend, :s3_bucket_name, :s3_region,
                     :s3_access_key_id, :s3_secret_access_key,
-                    :datastore_root_path
+                    :datastore_root_path, :content_disposition
 
     self.dragonfly_insert_before = 'ActionDispatch::Callbacks'
     self.dragonfly_secret = Refinery::Core.dragonfly_secret
     self.dragonfly_url_format = '/system/resources/:job/:basename.:format'
-
+    
+    self.content_disposition = :attachment
     self.max_file_size = 52428800
     self.pages_per_dialog = 12
     self.pages_per_admin_index = 20

--- a/resources/lib/refinery/resources/dragonfly.rb
+++ b/resources/lib/refinery/resources/dragonfly.rb
@@ -11,7 +11,7 @@ module Refinery
           app_resources.define_macro(::Refinery::Resource, :resource_accessor)
 
           app_resources.analyser.register(::Dragonfly::Analysis::FileCommandAnalyser)
-          app_resources.content_disposition = :attachment
+          app_resources.content_disposition = Refinery::Resources.content_disposition
         end
 
         def configure!


### PR DESCRIPTION
Content disposition should be configurable, as you often want your files to be loaded inline instead of as a attachment.
