### PR TITLE
Encoding in core.erb.rb

### DIFF
--- a/core/lib/generators/refinery/core/templates/config/initializers/refinery/core.rb.erb
+++ b/core/lib/generators/refinery/core/templates/config/initializers/refinery/core.rb.erb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 Refinery::Core.configure do |config|
   # When true will rescue all not found errors and display a friendly error page
   config.rescue_not_found = Rails.env.production?


### PR DESCRIPTION
Added encoding: utf-8 in core.rb.erb to allow i18n characters in config.site_name
