### PR TITLE
Shorten all authentication helpers

### DIFF
--- a/authentication/app/controllers/refinery/passwords_controller.rb
+++ b/authentication/app/controllers/refinery/passwords_controller.rb
@@ -36,7 +36,7 @@ module Refinery
         # Call devise reset function.
         user.send(:generate_reset_password_token!)
         UserMailer.reset_notification(user, request).deliver
-        redirect_to refinery.new_refinery_user_session_path,
+        redirect_to refinery.login_path,
                     :notice => t('email_reset_sent', :scope => 'refinery.users.forgot')
       else
         flash.now[:error] = if (email = params[:refinery_user][:email]).blank?

--- a/authentication/app/controllers/refinery/users_controller.rb
+++ b/authentication/app/controllers/refinery/users_controller.rb
@@ -31,7 +31,7 @@ module Refinery
       if refinery_user?
         redirect_to refinery.admin_users_path
       elsif refinery_users_exist?
-        redirect_to refinery.new_refinery_user_session_path
+        redirect_to refinery.login_path
       end
     end
 

--- a/authentication/app/views/refinery/passwords/edit.html.erb
+++ b/authentication/app/views/refinery/passwords/edit.html.erb
@@ -20,7 +20,7 @@
   <%= render '/refinery/admin/form_actions', :f => f,
              :continue_editing => false,
              :submit_button_text => t('reset_password', :scope => 'refinery.users.reset'),
-             :cancel_url => refinery.new_refinery_user_session_path,
+             :cancel_url => refinery.login_path,
              :cancel_title => nil,
              :hide_delete => true -%>
 <% end -%>

--- a/authentication/app/views/refinery/users/new.html.erb
+++ b/authentication/app/views/refinery/users/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for :header, t('there_are_no_users', :scope => 'refinery.welcome') %>
 
-<%= form_for :user, :url => refinery.refinery_user_registration_path do |f| -%>
+<%= form_for :user, :url => refinery.signup_path do |f| -%>
 
   <%= render '/refinery/admin/error_messages', :object => @user, :include_object_name => true %>
 

--- a/authentication/config/routes.rb
+++ b/authentication/config/routes.rb
@@ -12,10 +12,10 @@ Refinery::Core::Engine.routes.draw do
 
     # Override Devise's other routes for convenience methods.
     devise_scope :refinery_user do
-      get '/refinery/login', :to => "sessions#new", :as => :new_refinery_user_session
-      get '/refinery/logout', :to => "sessions#destroy", :as => :destroy_refinery_user_session
-      get '/refinery/users/register' => 'users#new', :as => :new_refinery_user_registration
-      post '/refinery/users/register' => 'users#create', :as => :refinery_user_registration
+      get '/refinery/login', :to => "sessions#new", :as => :login
+      get '/refinery/logout', :to => "sessions#destroy", :as => :logout
+      get '/refinery/users/register' => 'users#new', :as => :signup
+      post '/refinery/users/register' => 'users#create', :as => :signup
     end
   rescue RuntimeError => exc
     if exc.message =~ /ORM/

--- a/authentication/spec/requests/refinery/passwords_spec.rb
+++ b/authentication/spec/requests/refinery/passwords_spec.rb
@@ -6,7 +6,7 @@ module Refinery
       let!(:user) { FactoryGirl.create(:refinery_user, :email => "refinery@refinerycms.com") }
 
       it "asks user to specify email address" do
-        visit refinery.new_refinery_user_session_path
+        visit refinery.login_path
         click_link "I forgot my password"
         page.should have_content("Please enter the email address for your account.")
       end

--- a/authentication/spec/requests/refinery/sessions_spec.rb
+++ b/authentication/spec/requests/refinery/sessions_spec.rb
@@ -6,7 +6,7 @@ module Refinery
       FactoryGirl.create(:refinery_user, :username => "ugisozols",
                               :password => "123456",
                               :password_confirmation => "123456")
-      visit refinery.new_refinery_user_session_path
+      visit refinery.login_path
     end
 
     it "shows login form" do

--- a/core/app/views/refinery/_site_bar.html.erb
+++ b/core/app/views/refinery/_site_bar.html.erb
@@ -19,7 +19,7 @@
         </span>
 
         <%= link_to t('.log_out', site_bar_translate_locale_args),
-                    refinery.destroy_refinery_user_session_path, :id => 'logout' %>
+                    refinery.logout_path, :id => 'logout' %>
       </div>
     </div>
   </div>

--- a/core/lib/refinery/application_controller.rb
+++ b/core/lib/refinery/application_controller.rb
@@ -84,7 +84,7 @@ module Refinery
 
     def refinery_user_required?
       if just_installed? and controller_name != 'users'
-        redirect_to refinery.new_refinery_user_registration_path
+        redirect_to refinery.signup_path
       end
     end
 


### PR DESCRIPTION
Previously, authentication helpers were long and tedious to type out: `new_refinery_user_session_path_the_quest_for_a_longer_method_name_part_two`. It is unnecessary for them to be this long. `login_path` will do just fine, because the engine is now isolated. There's three new helpers: `login_*`, `logout_*` and `signup_*`.

I don't know how you deal with deprecation of the old ones, so I've just gone ahead and changed them now.
