### PR TITLE
Use Page#url to view page live from pages admin

### DIFF
--- a/pages/app/views/refinery/admin/pages/_page.html.erb
+++ b/pages/app/views/refinery/admin/pages/_page.html.erb
@@ -21,7 +21,7 @@
 
     <span class='actions'>
       <%= link_to refinery_icon_tag('application_go.png'),
-                  refinery.page_path(page.uncached_nested_url),
+                  page.url,
                   :target => "_blank",
                   :title => t('.view_live_html') %>
       <%= link_to refinery_icon_tag('page_add.png'),

--- a/pages/spec/requests/refinery/admin/pages_spec.rb
+++ b/pages/spec/requests/refinery/admin/pages_spec.rb
@@ -132,7 +132,7 @@ module Refinery
           page.body.should =~ /Add a new child page/
           page.body.should =~ %r{/refinery/pages/new\?parent_id=}
           page.body.should =~ /View this page live/
-          page.body.should =~ %r{/pages/my-first-page}
+          page.body.should =~ %r{href="/my-first-page"}
 
           Refinery::Page.count.should == 1
         end


### PR DESCRIPTION
(Applies https://github.com/resolve/refinerycms/pull/1715 to 2-0-stable)

"View this page live" links to Page#url, which
is more reflective of how pages will be referenced
and fixes issue with pages with the same slug
under different parent nodes.

Closes GH-1714
