### PR TITLE
add launchy to refinerycms-testing gemspec

### DIFF
--- a/testing/refinerycms-testing.gemspec
+++ b/testing/refinerycms-testing.gemspec
@@ -25,4 +25,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'rack-test',               '~> 0.6.0'
   s.add_dependency 'rspec-rails',             '~> 2.10.0'
   s.add_dependency 'capybara',                '~> 1.1.0'
+
+  s.add_development_dependency 'launchy'
 end


### PR DESCRIPTION
It is necessary in order to use capybarara's `save_and_open_page` method.
