### PR TITLE
avoid charset errors when precompiling assets with translated strings

### DIFF
--- a/core/app/assets/javascripts/refinery/modal_dialogs.js.erb
+++ b/core/app/assets/javascripts/refinery/modal_dialogs.js.erb
@@ -1,3 +1,4 @@
+<%# encoding: utf-8 %>
 init_modal_dialogs = function(){
   $('a[href*="dialog=true"]').not('#dialog_container a').each(function(i, anchor) {
     $(anchor).data({

--- a/core/app/assets/javascripts/refinery/submit_continue.js.coffee.erb
+++ b/core/app/assets/javascripts/refinery/submit_continue.js.coffee.erb
@@ -1,3 +1,4 @@
+<%# encoding: utf-8 %>
 @init_submit_continue = ->
   $("#submit_continue_button").click submit_and_continue
   $("form").change (e) ->


### PR DESCRIPTION
If translation .yml files have UTF-8 characters, asset precompilation will fail because some javascript files contain ::I18n.t. Adding <%# encoding: utf-8 %> to the top of those files solves the problem.

For example:

```
RAILS_ENV=production bundle exec rake assets:precompile/Users/drifter/.rvm/rubies/ruby-1.9.3-p194/bin/ruby /Users/drifter/.rvm/gems/ruby-1.9.3-p194@global/bin/rake assets:precompile:all RAILS_ENV=production RAILS_GROUPS=assets
rake aborted!
"\xC3" on US-ASCII
  (in /Users/drifter/.rvm/gems/ruby-1.9.3-p194/gems/refinerycms-core-2.0.5/app/assets/javascripts/refinery/submit_continue.js.coffee.erb)
```
