### PR TITLE
Check to ensure render_with_templates? is defined when executing 404 page

### DIFF
--- a/pages/lib/refinery/pages/instance_methods.rb
+++ b/pages/lib/refinery/pages/instance_methods.rb
@@ -10,7 +10,11 @@ module Refinery
       def error_404(exception=nil)
         if (@page = ::Refinery::Page.where(:menu_match => "^/404$").includes(:parts).first).present?
           # render the application's custom 404 page with layout and meta.
-          render_with_templates?(:status => 404)
+          if self.respond_to? :render_with_templates?
+            render_with_templates? :status => 404
+          else
+            render :template => '/refinery/pages/show', :formats => [:html], :status => 404
+          end
           return false
         else
           super

--- a/testing/refinerycms-testing.gemspec
+++ b/testing/refinerycms-testing.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'database_cleaner',        '~> 0.7.1'
   s.add_dependency 'factory_girl_rails',      '~> 1.7.0'
   s.add_dependency 'rack-test',               '~> 0.6.0'
-  s.add_dependency 'rspec-rails',             '~> 2.10.0'
+  s.add_dependency 'rspec-rails',             '~> 2.11'
   s.add_dependency 'capybara',                '~> 1.1.0'
 end


### PR DESCRIPTION
Fixes #1795. When the error_404 method is called outside of the scope of the PagesController, as it can be, since extensions also are extended, too, the render_with_templates? call will throw a NoMethodError. This might also be rewritten as a redirect to the 404 page, which I think might be a better choice in the long run, but needs to be discussed.
