### PR TITLE
Fix wymeditor opacity bug

### DIFF
--- a/core/app/assets/stylesheets/wymeditor/skins/refinery/skin.css.scss
+++ b/core/app/assets/stylesheets/wymeditor/skins/refinery/skin.css.scss
@@ -524,7 +524,3 @@ a.wym_wymeditor_link {
 .wym_skin_refinery .wym_status.wym_section {
   display: none;
 }
-
-.wym_skin_refinery {
-  opacity: 0;
-}


### PR DESCRIPTION
Wymeditor, when not overridden, has opacity set to 0. This means it is invisible in the admin edit page screen.
Removing this specific portion of CSS fixes this with no other obvious impacts
