### PR TITLE
Please don't touch the load path

### DIFF
--- a/refinerycms.gemspec
+++ b/refinerycms.gemspec
@@ -1,6 +1,5 @@
 # Encoding: UTF-8
-$:.push File.expand_path('../core/lib', __FILE__)
-require 'refinery/version'
+require File.expand_path('../core/lib/refinery/version', __FILE__)
 
 version = Refinery::Version.to_s
 


### PR DESCRIPTION
No need to touch the load path, even in a gemspec.

A la bundler's default gemspec template, just require the version file with an absolute path for the `Refinery::Version` constant. :-)

/cc @parndt
