### PR TITLE
Fixes .../edit&switch_locale=en... bug with copywriting.

### DIFF
--- a/core/app/assets/javascripts/refinery/admin.js.erb
+++ b/core/app/assets/javascripts/refinery/admin.js.erb
@@ -68,11 +68,8 @@ init_modal_dialogs = function(){
       'dialog-width': parseInt($($(anchor).attr('href').match("width=([0-9]*)")).last().get(0), 10)||928
       , 'dialog-height': parseInt($($(anchor).attr('href').match("height=([0-9]*)")).last().get(0), 10)||473
       , 'dialog-title': ($(anchor).attr('title') || $(anchor).attr('name') || $(anchor).html() || null)
-    }).attr('href', $(anchor).attr('href').replace(/((\&(amp\;)?)|\?)dialog\=true/, '')
-                                          .replace(/((\&(amp\;)?)|\?)width\=\d+/, '')
-                                          .replace(/((\&(amp\;)?)|\?)height\=\d+/, '')
-                                          .replace(/(\?&(amp\;)?)/, '?')
-                                          .replace(/\?$/, ''))
+    }).attr('href', $(anchor).attr('href').replace(/(&(amp;)?|\?)(dialog=true|(width|height)=\d+)/g, '')
+                                          .replace(/(\/[^&\?]*)&(amp;)?/, '$1?'))
     .click(function(e){
       $anchor = $(this);
       iframe_src = (iframe_src = $anchor.attr('href'))

--- a/core/app/assets/javascripts/refinery/modal_dialogs.js.erb
+++ b/core/app/assets/javascripts/refinery/modal_dialogs.js.erb
@@ -5,11 +5,8 @@ init_modal_dialogs = function(){
       'dialog-width': parseInt($($(anchor).attr('href').match("width=([0-9]*)")).last().get(0), 10)||928
       , 'dialog-height': parseInt($($(anchor).attr('href').match("height=([0-9]*)")).last().get(0), 10)||473
       , 'dialog-title': ($(anchor).attr('title') || $(anchor).attr('name') || $(anchor).html() || null)
-    }).attr('href', $(anchor).attr('href').replace(/(\&(amp\;)?)?dialog\=true/, '')
-                                          .replace(/(\&(amp\;)?)?width\=\d+/, '')
-                                          .replace(/(\&(amp\;)?)?height\=\d+/, '')
-                                          .replace(/(\?&(amp\;)?)/, '?')
-                                          .replace(/\?$/, ''))
+    }).attr('href', $(anchor).attr('href').replace(/(&(amp;)?|\?)(dialog=true|(width|height)=\d+)/g, '')
+                                          .replace(/(\/[^&\?]*)&(amp;)?/, '$1?'))
     .click(function(e){
       $anchor = $(this);
       iframe_src = (iframe_src = $anchor.attr('href'))


### PR DESCRIPTION
The error that 8d0c1a7d63132ccdddedcecfbaa9b8fbdbd3c92f fixed was not caused by d0cef214a301e4fa4f0b9fcaa9f9fa9a338d10b4, but rather by 4d3488b373fb40474c84a35e3ae0dbb55e97cf18 (the fix for #1397).  Previously the first three replace lines had removed things after the ?, but not the ? itself.  Then the last two replace lines cleaned up any mess, either a trailing ? or ?&...  With the ? removed the last two replace lines did nothing and the result was .../edit&switch_locale=en...

In the 2-0-stable branch 8a457ddb4b821c9a66f81c8c2901db9c72c87066 reverted 8a457ddb4b821c9a66f81c8c2901db9c72c87066, but did not override the fix for #1397 so it didn't actually fix anything.

This change combines the first three lines into one and replaces the last two lines with a regex that replaces the offending & with a ? (but not any subsequent &s or anything if the url is already correct).

This also brings the fix for #1397 into https://github.com/resolve/refinerycms/blob/2-0-stable/core/app/assets/javascripts/refinery/modal_dialogs.js.erb.  I think d0cef214a301e4fa4f0b9fcaa9f9fa9a338d10b4 and 8a457ddb4b821c9a66f81c8c2901db9c72c87066 should be safe to re-submit.
