### PR TITLE
Added canonical id to body tag

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 * Refactored wysiwyg fields into a partial. [#1796](https://github.com/resolve/refinerycms/pull/1796). [Rob Yurkowski](https://github.com/robyurkowski)
 * Shortened all authentication helpers. [#1719](https://github.com/resolve/refinerycms/pull/1719). [Ryan Bigg](https://github.com/radar)
+* Added canonical page id to body to allow CSS selectors to target specific pages instead of including special CSS files. [#1700](https://github.com/resolve/refinerycms/pull/1700) & [#1828](https://github.com/resolve/refinerycms/pull/1828). [Philip Arndy](https://github.com/parndt) & [Graham Wagener](https://github.com/gwagener/)
 
 * [See full list](https://github.com/resolve/refinerycms/compare/2-0-stable...master)
 

--- a/core/app/helpers/refinery/meta_helper.rb
+++ b/core/app/helpers/refinery/meta_helper.rb
@@ -48,5 +48,9 @@ module Refinery
       end
     end
 
+    def canonical_id(page)
+      "#{page.canonical_slug}-page" if page
+    end
+
   end
 end

--- a/core/app/views/layouts/application.html.erb
+++ b/core/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <%= render '/refinery/html_tag' %>
   <% site_bar = render('/refinery/site_bar', :head => true) -%>
   <%= render '/refinery/head' %>
-  <body>
+  <body id='<%= canonical_id @page %>'>
     <%= site_bar -%>
     <%= render '/refinery/ie6check' if request.env['HTTP_USER_AGENT'] =~ /MSIE/ -%>
     <div id="page_container">

--- a/core/app/views/refinery/_content_page.html.erb
+++ b/core/app/views/refinery/_content_page.html.erb
@@ -1,7 +1,5 @@
-<section id='<%= [@page.try(:canonical_slug), 'page'].compact.join('-') %>'>
-  <%= render_content_page(@page, {
-        :hide_sections => local_assigns[:hide_sections],
-        :can_use_fallback => !local_assigns[:show_empty_sections] && !local_assigns[:remove_automatic_sections]
-      }) %>
-  <%= render '/refinery/draft_page_message' unless @page.try(:live?) -%>
-</section>
+<%= render_content_page(@page, {
+      :hide_sections => local_assigns[:hide_sections],
+      :can_use_fallback => !local_assigns[:show_empty_sections] && !local_assigns[:remove_automatic_sections]
+    }) %>
+<%= render '/refinery/draft_page_message' unless @page.try(:live?) -%>

--- a/core/spec/helpers/refinery/meta_helper_spec.rb
+++ b/core/spec/helpers/refinery/meta_helper_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+module Refinery
+  describe MetaHelper do
+
+    describe '#canonical_id' do
+      context "when page doesn't exist" do
+        let(:page) { nil }
+
+        it 'returns nothing' do
+          helper.canonical_id(page).should be_nil
+        end
+      end
+
+      context 'when page exists' do
+        let(:page) { Page.new :slug => 'testing' }
+
+        it "returns the page's canonical slug with '-page' appended" do
+          helper.canonical_id(page).should == page.canonical_slug << '-page'
+        end
+      end
+    end
+
+  end
+end

--- a/core/spec/requests/refinery/application_layout_spec.rb
+++ b/core/spec/requests/refinery/application_layout_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+module Refinery
+  describe 'layout' do
+    refinery_login_with :refinery_user
+
+    let(:home_page) do
+      FactoryGirl.create :page, :title => 'Home', :link_url => '/'
+    end
+
+    describe 'body' do
+      it "id is the page's canonical id" do
+        visit home_page.url
+
+        page.should have_css 'body#home-page'
+      end
+    end
+  end
+end


### PR DESCRIPTION
This way it encompasses the header, page, and footer sections.  This also prevents the potential duplication of the `#page` id when `@page` is nil.
