### PR TITLE
Initialized the @page variable in the before filter for preview action

### DIFF
--- a/pages/app/controllers/refinery/pages_controller.rb
+++ b/pages/app/controllers/refinery/pages_controller.rb
@@ -1,7 +1,8 @@
 module Refinery
   class PagesController < ::ApplicationController
     before_filter :find_page, :set_canonical, :except => [:preview]
-
+    before_filter :find_page_for_preview, :only => [:preview]
+    
     # Save whole Page after delivery
     after_filter { |c| c.write_cache? }
 
@@ -39,14 +40,6 @@ module Refinery
     end
 
     def preview
-      if page(fallback_to_404 = false)
-        # Preview existing pages
-        @page.attributes = params[:page]
-      elsif params[:page]
-        # Preview a non-persisted page
-        @page = Page.new(params[:page])
-      end
-
       render_with_templates?(:action => :show)
     end
 
@@ -72,6 +65,16 @@ module Refinery
       page.children.order('lft ASC').live.first
     end
 
+    def find_page_for_preview
+      if page(fallback_to_404 = false)
+        # Preview existing pages
+        @page.attributes = params[:page]
+      elsif params[:page]
+        # Preview a non-persisted page
+        @page = Page.new(params[:page])
+      end
+    end    
+    
     def find_page(fallback_to_404 = true)
       @page ||= case action_name
                 when "home"


### PR DESCRIPTION
The `@page` variable is getting initialized in the `preview` action rather than a `before` filter. This causes null pointer exceptions when a page controller decorator tries to access the `@page` variable for `preview` action.

Changed the code as per solution proposed in the Refinery group discussion: https://groups.google.com/forum/?fromgroups#!topic/refinery-cms/GO1u1JWymWo 
