### PR TITLE
Fix condition in Refinery::Page#with_globalize

### DIFF
--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -124,7 +124,7 @@ module Refinery
 
       # Wrap up the logic of finding the pages based on the translations table.
       def with_globalize(conditions = {})
-        conditions = {:locale => ::Globalize.locale}.merge(conditions)
+        conditions = {:locale => ::Globalize.locale.to_s}.merge(conditions)
         globalized_conditions = {}
         conditions.keys.each do |key|
           if (translated_attribute_names.map(&:to_s) | %w(locale)).include?(key.to_s)


### PR DESCRIPTION
`Globalize.locale` returns a symbol, which is assumed to be a DB column when used as a `where` condition value.
So `where(:locale => Globalize.locale)` becomes `refinery_pages.locale = refinery_pages.en`.
Converting the symbol to a string fixes this.
