### PR TITLE
Fix condition in Refinery::Page#with_globalize

### DIFF
--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -106,7 +106,7 @@ module Refinery
 
       # Finds pages by their slug.  See by_title
       def by_slug(slug, conditions={})
-        locales = Refinery.i18n_enabled? ? Refinery::I18n.frontend_locales : ::I18n.locale
+        locales = Refinery.i18n_enabled? ? Refinery::I18n.frontend_locales : ::I18n.locale.to_s
         with_globalize({ :locale => locales, :slug => slug }.merge(conditions))
       end
 


### PR DESCRIPTION
(similar issue as in #1831)

`I18n.locale` returns a symbol, which is assumed to be a DB column when used as a where condition value.
So `where(:locale => I18n.locale)` becomes `refinery_pages.locale = refinery_pages.en`.
Converting the symbol to a string fixes this.
