### PR TITLE
Revert "Allow transactional database strategy with Selenium."

### DIFF
--- a/core/spec/support/database_cleaner.rb
+++ b/core/spec/support/database_cleaner.rb
@@ -12,20 +12,10 @@ RSpec.configure do |config|
   config.after(:each) do
     DatabaseCleaner.clean
   end
-end
 
-# Allows transactional DatabaseCleaner strategy with Selenium.
-module ActiveRecord
-  class Base
-    mattr_accessor :shared_connection
-    @@shared_connection = nil
-
-    def self.connection
-      @@shared_connection || retrieve_connection
-    end
+  config.around(:each, :js) do |example|
+    DatabaseCleaner.strategy = :truncation
+    example.call
+    DatabaseCleaner.strategy = :transaction
   end
 end
-
-# Forces all threads to share the same connection. This works on
-# Capybara because it starts the web server in a thread.
-ActiveRecord::Base.shared_connection = ActiveRecord::Base.connection


### PR DESCRIPTION
This reverts commit 0572d3a04e39ff5633a5f507315359363612cd80.

Main reason behind this is spec fails like [this](http://travis-ci.org/#!/resolve/refinerycms/jobs/1925517/L166). I did read https://github.com/brianmario/mysql2/issues/99 and tried https://gist.github.com/3049152 but without any luck.

Regarding no_rails_spec_helper - do we even use it?
