### PR TITLE
Remove extra javascript content blocks.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 ## 2.1.0 [unreleased]
 
+* Removed :before_javascript_libraries, :after_javascript_libraries, and :javascript_libraries content blocks. [#1842](https://github.com/resolve/refinerycms/pull/1842). [Rob Yurkowski](https://github.com/robyurkowski)
 * Refactored wysiwyg fields into a partial. [#1796](https://github.com/resolve/refinerycms/pull/1796). [Rob Yurkowski](https://github.com/robyurkowski)
 * Shortened all authentication helpers. [#1719](https://github.com/resolve/refinerycms/pull/1719). [Ryan Bigg](https://github.com/radar)
 * Added canonical page id to body to allow CSS selectors to target specific pages instead of including special CSS files. [#1700](https://github.com/resolve/refinerycms/pull/1700) & [#1828](https://github.com/resolve/refinerycms/pull/1828). [Philip Arndt](https://github.com/parndt) & [Graham Wagener](https://github.com/gwagener/)

--- a/core/app/views/refinery/_javascripts.html.erb
+++ b/core/app/views/refinery/_javascripts.html.erb
@@ -1,11 +1,24 @@
-<%= yield :before_javascript_libraries -%>
-<%= yield :javascript_libraries %>
-<%= yield :after_javascript_libraries %>
+<% if content_for :before_javascript_libraries %>
+  <% Refinery.deprecate "content_for :before_javascript_libraries", :when => '2.2', :replacement => "content_for :javascripts" %>
+  <% content_for :javascripts, yield(:before_javascript_libraries) %>
+<% end %>
+
+<% if content_for :javascript_libraries %>
+  <% Refinery.deprecate "content_for :javascript_libraries", :when => '2.2', :replacement => "content_for :javascripts" %>
+  <% content_for :javascripts, yield(:javascript_libraries) %>
+<% end %>
+
+<% if content_for :after_javascript_libraries %>
+  <% Refinery.deprecate "content_for :after_javascript_libraries", :when => '2.2', :replacement => "content_for :javascripts" %>
+  <% content_for :javascripts, yield(:after_javascript_libraries) %>
+<% end %>
+
+
+<%= javascript_include_tag 'application' %>
+<%= yield :javascripts -%>
 <% if request.env['HTTP_USER_AGENT'] =~ /MSIE/ %>
   <!--[if lt IE 7 ]>
     <%= javascript_include_tag 'dd_belatedpng' %>
     <script> DD_belatedPNG.fix('img, .png_bg'); //fix any <img> or .png_bg background-images </script>
   <![endif]-->
 <% end %>
-<%= javascript_include_tag 'application' %>
-<%= yield :javascripts -%>


### PR DESCRIPTION
In concert with #1841, this removes the extra sections of Javascript that aren't necessary anymore with the asset pipeline.

It should be debated whether the `:javascripts` content block has use anymore; I think that it still does, but I'm definitely open to arguments.
