### PR TITLE
WIP: Dragonfly image thumbs

### DIFF
--- a/images/app/models/refinery/thumb.rb
+++ b/images/app/models/refinery/thumb.rb
@@ -1,0 +1,6 @@
+module Refinery
+  class Images::Thumb < Refinery::Core::BaseModel
+    validates_uniqueness_of :job, :uid
+    attr_accessible :job, :uid
+  end
+end

--- a/images/db/migrate/20120807075800_create_refinerycms_thumbs_schema.rb
+++ b/images/db/migrate/20120807075800_create_refinerycms_thumbs_schema.rb
@@ -1,0 +1,9 @@
+class CreateRefinerycmsThumbsSchema < ActiveRecord::Migration
+  def change
+    create_table :refinery_thumbs do |t|
+      t.string   :uid
+      t.string   :job
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
# Dragonfly image thumbs
## The issue:

When hosting Refinery sites on Heroku a storage provider like Amazon AWS has to be used. Currently images are handled in the following manner:
1.  Images are uploaded through Heroku worker to Amazon (or equivalent)
2.  Images references are stored in database table 'refinery_images'. They reference the original file in their original geometry.
3.  When an images is requested using image_fu or equivalent a Heroku url is used for serving images. ie `/system/images/BAhbB1sHOgZmSSImMjAxMi8wOC8wMy8xMS81MS8yMy80MTYvdGl0bGUuanBnBjoGRVRbCDoGcDoKdGh1bWJJIg0yNjh4MTc4IwY7BkY/title.jpg`
4.  Dragonfly will at this point fetch the image from S3, resize it in the app process (your heroku dyno) and serve the image to the user.

This is slow. For every image served dyno's get tied up in serving the images. This defeats the purpose of a CDN. When serving lots of images it will also cause you to need more dyno's then necessary. Images should an can be served directly from their host.
We've posted about this issue before on the [mailing list](https://groups.google.com/forum/?fromgroups#!topic/refinery-cms/RzhP6ZLBYhc)
## Our solution:
1.  Images are uploaded through Heroku worker to Amazon (or equivalent)
2.  Images references are stored in database table 'refinery_images'. They reference the original file in their original geometry.
3.  When an images is requested using image_fu or equivalent a modified version of the job to create the thumbnail is dispatched.
   This job does 2 things:
   1. checks for existence of the thumb in the database
   2. if it exists it will serve the image straight from the asset host, if it doesn't exist it will create the thumb, serve it from the tmp directory and store the thumb back on S3. On sub-sequential servings the image will be served straight from the asset host. 
### What we did:
- Created database schema & model to keep track of existing thumbs (Refinery::Images::Thumb).
- Modified Dragonfly configuration to serve images directly from the remote url if they are already created. First time they are still served trough the app server.
## Issues:
1.  Currently Dragonfly throws an error when it tries to retrieve an image which does not exist before fixing it. This probably should be fixed.
2.  When inserting newly uploaded, never before served, images in the WYSIWYG editor they still use the straight URL. We should look into a fix for this.
## Todo:
1.  Look into better caching
2.  Allow the CDN url to be used instead of the Store url. In current situation when using AWS the AWS bucket url is used, we should allow the use of cloudfront.
3.  Write some tests
## Credits:

Idea: http://blog.crowdint.com/2011/12/07/serving-remote-content-with-dragonfly.html
Implementation: @bartj3 & @johanb

/cc @parndt & @ugisozols we'd love some feedback on this. 
