### PR TITLE
Added 'placeholder' attribute to the 'input' tag

### DIFF
--- a/core/app/assets/javascripts/wymeditor/validators.js.erb
+++ b/core/app/assets/javascripts/wymeditor/validators.js.erb
@@ -338,8 +338,9 @@ WYMeditor.XhtmlValidator = {
         "readonly":/^(readonly)$/,
         "size":/^(\d)+$/,
         "3":"src",
-        "type":/^(button|checkbox|file|hidden|image|password|radio|reset|submit|text|tel|search|url|email|datetime|date|month|week|time|datetime-local|number|range|color|placeholder)$/,
-        "4":"value"
+        "type":/^(button|checkbox|file|hidden|image|password|radio|reset|submit|text|tel|search|url|email|datetime|date|month|week|time|datetime-local|number|range|color)$/,
+        "4":"value",
+        "5":"placeholder"
       },
       "inside":"form"
     },


### PR DESCRIPTION
Fix for issue #1870

Made following changes to the validation section of the `input` tag:
  - Added the missing `placeholder` attribute.
  - Removed `placeholder` as one of the possible values for the `type` tag.  Refer to the spec(http://www.w3.org/TR/html5/the-input-element.html#attr-input-type) for more details.
