### PR TITLE
Make multiple resource uploads pass on form parameters, which should be ...

### DIFF
--- a/resources/app/models/refinery/resource.rb
+++ b/resources/app/models/refinery/resource.rb
@@ -43,7 +43,7 @@ module Refinery
           resources << create(params)
         else
           params[:file].each do |resource|
-            resources << create(:file => resource)
+            resources << create({:file => resource}.merge(params.except(:file)))
           end
         end
 

--- a/resources/spec/models/refinery/resource_spec.rb
+++ b/resources/spec/models/refinery/resource_spec.rb
@@ -70,6 +70,13 @@ module Refinery
           r.should be_an_instance_of(Resource)
         end
       end
+
+      specify "each returned array item should be passed form parameters" do
+        params = {:file => [file, file, file], :fake_param => 'blah'}
+
+        Resource.should_receive(:create).exactly(3).times.with({:file => file, :fake_param => 'blah'})
+        Resource.create_resources(params)
+      end
     end
 
     describe "validations" do


### PR DESCRIPTION
...expected behaviour.

In the situation where you add a field to Resources, upon create, you're unable to save any of those additional attributes because we only pass on the file attribute at the moment when the user is uploading multiple files. Of course, the user is always uploading multiple files, because the default html5ish behaviour is to send an array anyway. This corrects the existing create method and allows the user to submit multiple attributes to be saved.
