### PR TITLE
Update doc/guides/4 - Refinery Extensions/3 - Testing.textile

### DIFF
--- a/doc/guides/4 - Refinery Extensions/3 - Testing.textile
+++ b/doc/guides/4 - Refinery Extensions/3 - Testing.textile
@@ -34,10 +34,11 @@ Add the following lines to your extension's Rakefile
 ENGINE_PATH = File.dirname(__FILE__)
 APP_RAKEFILE = File.expand_path("../spec/dummy/Rakefile", __FILE__)
 
-load 'rails/tasks/extension.rake' if File.exists?(APP_RAKEFILE)
+load 'rails/tasks/engine.rake' if File.exists?(APP_RAKEFILE)
 
 require "refinerycms-testing"
 Refinery::Testing::Railtie.load_tasks
+Refinery::Testing::Railtie.load_dummy_tasks(ENGINE_PATH)
 </ruby>
 
 And run the dummy application generator:


### PR DESCRIPTION
the above changes were needed by me to get the dummy generator running under 2.0.3. I'm not 100% sure at what point the engine.rake/extension.rake switch was needed, but it was. 

And as of this commit
https://github.com/resolve/refinerycms/commit/9f215fc9b07c2c1e44064854781fb5e2c3e68921
it looks like we need `load_dummy_tasks` to get the, well, dummy tasks loaded.
