### PR TITLE
When uploading images directly from /refinery/images/new redirect back t...

### DIFF
--- a/images/app/assets/javascript/refinery/images.js.coffee.erb
+++ b/images/app/assets/javascript/refinery/images.js.coffee.erb
@@ -19,7 +19,6 @@ class Images
 
   cache_dom: ->
     @error_list = $("#error_list")
-    @success_list = $("#flash")
     @error_explanation = $("#errorExplanation")
     @upload_progress = $("#upload_progress")
 
@@ -44,14 +43,15 @@ class Images
   after_upload_all: ->
     $(".save-loader").hide()
     @upload_progress.hide()
-    @success_list.show()
     if @errors.length > 0
       @render_errors()
     else
       if getParameterByName("modal") == "true"
         window.parent.document.getElementById("dialog_frame").contentDocument.location.reload(true);
-      else
+      else if getParameterByName("dialog") == "true"
         window.parent.location.reload(true)
+      else
+        window.location = "<%= Refinery::Core::Engine.routes.url_helpers.admin_images_path %>"
 
   validate: (file) ->
     max_file_size = <%= Refinery::Images.max_image_size %>

--- a/images/app/controllers/refinery/admin/images_controller.rb
+++ b/images/app/controllers/refinery/admin/images_controller.rb
@@ -55,12 +55,10 @@ module Refinery
         unless params[:insert]
           if @images.all?(&:valid?)
             flash.notice = t('uploaded_successfully', :scope => 'refinery.admin.images.form')
-            if from_dialog?
-              @dialog_successful = true
-              render :nothing => true, :layout => true
-            else
-              redirect_to refinery.admin_images_path
-            end
+            
+            @dialog_successful = true if from_dialog?
+
+            render :nothing => true, :layout => true
           else
             self.new # important for dialogs
             render :action => 'new'


### PR DESCRIPTION
...o /refinery/images.

I changed the code because when I tried to upload images using direct path `/refinery/images/new` it would reload the same window and not redirect back to `/refinery/images`.

I wasn't sure about introducing refinery url helper in js so maybe we should approach this differently.
