### PR TITLE
substiture jquery textTruncation with css text-overflow

### DIFF
--- a/core/app/assets/javascripts/refinery/interface.js.coffee.erb
+++ b/core/app/assets/javascripts/refinery/interface.js.coffee.erb
@@ -7,10 +7,6 @@
     $(".field > .wym_box").corner "5px tl"
     $(".wym_iframe iframe").corner "2px"
     $(".form-actions:not(\".form-actions-dialog\")").corner "5px"
-  $("#recent_activity li a, #recent_inquiries li a").each (i, a) ->
-    $(this).textTruncate
-      width: $(this).width()
-      tooltip: false
 
   $("textarea.wymeditor").each ->
     textarea = $(this)

--- a/core/app/assets/javascripts/refinery/refinery.js.erb
+++ b/core/app/assets/javascripts/refinery/refinery.js.erb
@@ -4,7 +4,6 @@
  *= require jquery-ui
  *= require ../modernizr-min
  *= require ../jquery/jquery.corner
- *= require ../jquery/jquery.textTruncate
  *= require ../jquery/jquery.html5-placeholder-shim
  *= require ../jquery/jquery.timers
  *= require ../jquery/jquery.jcarousel

--- a/core/app/assets/stylesheets/refinery/layout.css.scss
+++ b/core/app/assets/stylesheets/refinery/layout.css.scss
@@ -494,6 +494,13 @@ pre {
 #records > #recent_activity > ul li, #records > #recent_inquiries > ul li {
   max-height: 35px;
 }
+#recent_activity li a, #recent_inquiries li a {
+  overflow: hidden;
+  white-space: nowrap;
+  -o-text-overflow: ellipsis;
+  -ms-text-overflow: ellipsis;
+  text-overflow: ellipsis;
+}
 #content #records > ul li .actions a, #content #records .pagination_container > ul li .actions a {
   line-height: 29px;
 }


### PR DESCRIPTION
hello,
`text-overflow: ellipsis; white-space: nowrap;`
are supported in all modern browser thus we can use them rather than jquery plugin.
This makes refinery code cleaner, faster and smaller .) .
Also fix one issue on dashboard which about I wrote @parndt @ugisozols on email.
