### PR TITLE
correct link test if HTTP response is kind of Success or Redirection

### DIFF
--- a/pages/app/controllers/refinery/admin/pages_dialogs_controller.rb
+++ b/pages/app/controllers/refinery/admin/pages_dialogs_controller.rb
@@ -63,7 +63,7 @@ module Refinery
               end
 
               result = 'success' if [Net::HTTPSuccess, Net::HTTPRedirection].
-                                      include? Net::HTTP.get_response(url)
+                                      include? Net::HTTP.get_response(url).class.superclass
             end
           end
 


### PR DESCRIPTION
I swear it worked before! Until someone send my bugreport... .)

Explanation: 
If url is valid `Net::HTTP.get_response(url)` returns `Net::HTTPOK` class which is kind of `Net::HTTPSuccess` but fails in test `[Net::HTTPSuccess].include..`

In generally I thinking about refactoring all this method, because:
- On localhost I have problem test other url than on port 80.
- https  links (not tested)
- intranet links, other networks etc may been also problem and user can be confused with failing validation.

Couldn't be better put here only simple regexp?
