### PR TITLE
Remove template that appears leftover from namespacing updates.

### DIFF
--- a/pages/app/views/admin/pages/_sortable_list.html.erb
+++ b/pages/app/views/admin/pages/_sortable_list.html.erb
@@ -1,8 +1,0 @@
-<ul class='sortable_list'>
-  <%= render :partial => 'page',
-             :collection => @pages.select{|p| p.parent_id.nil?},
-             :locals => {
-               :collection => @pages
-             }  %>
-</ul>
-<%= render '/refinery/admin/sortable_list', :continue_reordering => !!local_assigns[:continue_reordering] %>


### PR DESCRIPTION
Getting to know the Refinery source better, and noticed what appears to be a leftover file from before namespacing.  Not 100% sure if this is unused or done intentionally.  After removing it the specs still pass, and it appears that if it were to actually be used there would be a missing template error trying to render the page partial that doesnt exist.
