### PR TITLE
Deprecation warnings using refinery when running rake

### DIFF
--- a/core/lib/refinery/application_controller.rb
+++ b/core/lib/refinery/application_controller.rb
@@ -24,7 +24,7 @@ module Refinery
 
       if Refinery::Core.rescue_not_found
         send :rescue_from, ActiveRecord::RecordNotFound,
-                           ActionController::UnknownAction,
+                           ::AbstractController::ActionNotFound,
                            ActionView::MissingTemplate,
                            :with => :error_404
       end


### PR DESCRIPTION
DEPRECATION WARNING: ActionController::UnknownAction is deprecated! Use ::AbstractController::ActionNotFound instead. (called from send at /home/.../bundler/gems/refinerycms-76ea94d07279/core/lib/refinery/application_controller.rb:26)

Simply changed as requested. 

Also done a grep for rest of project and nowhere else mentions it
