### PR TITLE
Fixes GH-1892 by properly updating the form action when the title is changed during save-and-continue

### DIFF
--- a/core/app/assets/javascripts/refinery/admin.js.erb
+++ b/core/app/assets/javascripts/refinery/admin.js.erb
@@ -194,6 +194,9 @@ submit_and_continue = function(e, redirect_to) {
         $('#continue_editing').val(false);
 
         init_flash_messages();
+
+        //updates the form action with new URL
+        $('form').attr('action', $('#new_action').attr('value'));
       }
     }, 'html'
   );

--- a/core/app/views/refinery/_message.html.erb
+++ b/core/app/views/refinery/_message.html.erb
@@ -1,3 +1,8 @@
+<% if local_assigns.has_key? :new_url %> 
+  <%# Need the new action URL if the title has been changed.
+      Will be used by the js to update the form action %>
+  <%= hidden_field_tag 'new_action', new_url %>  
+<% end -%>
 <% flash.each do |key, value| %>
 <div id='flash' class="flash flash_<%= key %>" style='visibility: hidden;' >
   <%= value %>

--- a/pages/app/controllers/refinery/admin/pages_controller.rb
+++ b/pages/app/controllers/refinery/admin/pages_controller.rb
@@ -27,6 +27,42 @@ module Refinery
         render :layout => false
       end
 
+      def update
+        if @page.update_attributes(params[:page])
+          flash.notice = t(
+            'refinery.crudify.updated',
+            :what => "'#{@page.title}'"
+          )
+
+          unless from_dialog?
+            unless params[:continue_editing] =~ /true|on|1/
+              redirect_back_or_default(refinery.admin_pages_path)
+            else
+              unless request.xhr?
+                redirect_to :back
+              else
+                render :partial => '/refinery/message',
+                  #pass the new update url in case the title was updated 
+                  :locals => {:new_url => refinery.admin_page_path(@page.uncached_nested_url) }
+              end
+            end
+          else
+            self.index
+            @dialog_successful = true
+            render :index
+          end
+        else
+          unless request.xhr?
+            render :action => 'edit'
+          else
+            render :partial => '/refinery/admin/error_messages', :locals => {
+              :object => @page,
+              :include_object_name => true
+            }
+          end
+        end
+      end
+
     protected
 
       def find_page

--- a/pages/spec/requests/refinery/admin/pages_spec.rb
+++ b/pages/spec/requests/refinery/admin/pages_spec.rb
@@ -143,19 +143,45 @@ module Refinery
       end
 
       describe "edit/update" do
-        before { Page.create :title => "Update me" }
-
-        it "updates page" do
+        before do
+          Page.create :title => "Update me"
+          
           visit refinery.admin_pages_path
-
           page.should have_content("Update me")
+        end
 
-          click_link "Edit this page"
+        context 'when saving and returning to index' do
+          it "updates page" do
+            click_link "Edit this page"
 
-          fill_in "Title", :with => "Updated"
-          click_button "Save"
+            fill_in "Title", :with => "Updated"
+            click_button "Save"
 
-          page.should have_content("'Updated' was successfully updated.")
+            page.should have_content("'Updated' was successfully updated.")
+          end
+        end
+
+        context 'when saving and continuing to edit' do
+          before :each do
+            find('a[tooltip^=Edit]').visible?
+            find('a[tooltip^=Edit]').click
+
+            fill_in "Title", :with => "Updated"
+            click_button "Save & continue editing"
+            find('#flash').visible?
+          end
+
+          it "updates page", :js do
+            page.should have_content("'Updated' was successfully updated.")
+          end
+          
+          # Regression test for https://github.com/refinery/refinerycms/issues/1892
+          context 'when saving to exit (a second time)' do
+            it 'updates page', :js do 
+              click_button "Save"
+              page.should have_content("'Updated' was successfully updated.")
+            end
+          end
         end
       end
 


### PR DESCRIPTION
Passes the  `admin_pages_path url` using the items current title back to the view using a hidden field tag.  The save-and-continue javascript then updates the form action with the new url.
Includes request spec for the first save-and-continue and regression test for the bug described in GH-1892.
