### PR TITLE
refactoring quotes and add .html_safe where is necessary

### DIFF
--- a/images/app/views/refinery/admin/images/_actions.html.erb
+++ b/images/app/views/refinery/admin/images/_actions.html.erb
@@ -3,13 +3,13 @@
     <%= render '/refinery/admin/search', :url => refinery.admin_images_path %>
   </li>
   <li>
-    <%= link_to t('.create_new_image'), refinery.new_admin_image_path(:dialog => true), :class => "add_icon" %>
+    <%= link_to t('.create_new_image'), refinery.new_admin_image_path(:dialog => true), :class => 'add_icon' %>
   </li>
   <% other_image_views.each do |image_view| %>
     <li>
       <%= link_to t('switch_to', :scope => 'refinery.admin.images.index.view', :view_name => t("#{image_view}", :scope => 'refinery.admin.images.index.view')),
                   refinery.admin_images_path(:view => image_view, :page => params[:page]),
-                  :class => "reorder_icon"  %>
+                  :class => 'reorder_icon'  %>
     </li>
   <% end %>
 </ul>

--- a/images/app/views/refinery/admin/images/_existing_image.html.erb
+++ b/images/app/views/refinery/admin/images/_existing_image.html.erb
@@ -1,11 +1,11 @@
-<div id='existing_image_area' class='dialog_area' <%= "style='display:none;'" if @image.errors.any? %>>
+<div id="existing_image_area" class="dialog_area" <%= 'style="display:none;"'.html_safe if @image.errors.any? %>>
   <%= render '/refinery/admin/search', :url => refinery.insert_admin_images_path(params.dup.except('image')) %>
-  <input type='hidden' name='selected_image' id='selected_image' />
-  <div id='existing_image_area_content' class='clearfix'>
+  <input type="hidden" name="selected_image" id="selected_image" />
+  <div id="existing_image_area_content" class="clearfix">
 <% if @images.any? %>
     <ul>
       <% @images.each do |image| -%>
-        <li<%= " class='selected'" if @image_id == image.id %>>
+        <li<%= ' class="selected"'.html_safe if @image_id == image.id %>>
           <%= image_fu(image, '106x106#c', {
                          :alt => image.title,
                          :title => image.title,
@@ -23,11 +23,11 @@
   <%= will_paginate @images, :params => params.dup %>
 
   <% unless @app_dialog or @images.empty? %>
-    <div id='existing_image_size_area' class='clearfix'>
-      <input type='hidden' name='selected_image_size' id='selected_image_size' />
+    <div id="existing_image_size_area" class="clearfix">
+      <input type="hidden" name="selected_image_size" id="selected_image_size" />
       <p>
         <input type="checkbox" id="wants_to_resize_image" name="wants_to_resize_image" value="1" checked="checked" />
-        <label for='wants_to_resize_image' class='stripped' style='font-weight: bold;'>
+        <label for="wants_to_resize_image" class="stripped" style="font-weight: bold;">
           <%= t('.resize_image') %>
         </label>
       </p>

--- a/images/app/views/refinery/admin/images/_form.html.erb
+++ b/images/app/views/refinery/admin/images/_form.html.erb
@@ -5,7 +5,7 @@
              :object => @image,
              :include_object_name => false %>
 
-  <div class='field'>
+  <div class="field">
     <% if action_name =~ /(edit)|(update)/ %>
       <p>
         <%= t('.use_current_image') %>
@@ -20,31 +20,31 @@
     <% end %>
   </div>
 
-  <div class='field'>
+  <div class="field">
     <label><%= t('.maximum_image_size', :bytes => number_to_human_size(Refinery::Images.max_image_size)) %></label>
   </div>
 
-  <input type='hidden' name='wymeditor' value='<%= params[:wymeditor] %>'>
+  <input type="hidden" name="wymeditor" value="<%= params[:wymeditor] %>">
 
   <%= render '/refinery/admin/form_actions', :f => f,
              :continue_editing => false,
-             :hide_cancel => (@app_dialog or action_name == "insert" or from_dialog?),
+             :hide_cancel => (@app_dialog or action_name == 'insert' or from_dialog?),
              :delete_title => t('delete', :scope => 'refinery.admin.images'),
              :delete_confirmation => t('message', :scope => 'refinery.admin.delete', :title => @image.image_name) -%>
 
   <% if @app_dialog %>
-    <input type='hidden' name='app_dialog' value='<%= @app_dialog %>' />
-    <input type='hidden' name='field' value='<%= @field %>' />
-    <input type='hidden' name='update_image' value='<%= @update_image %>' />
-    <input type='hidden' name='thumbnail' value='<%= @thumbnail %>' />
-    <input type='hidden' name='callback' value='<%= @callback %>' />
-    <input type='hidden' name='conditions' value='<%= @conditions %>' />
+    <input type="hidden" name="app_dialog" value="<%= @app_dialog %>" />
+    <input type="hidden" name="field" value="<%= @field %>" />
+    <input type="hidden" name="update_image" value="<%= @update_image %>" />
+    <input type="hidden" name="thumbnail" value="<%= @thumbnail %>" />
+    <input type="hidden" name="callback" value="<%= @callback %>" />
+    <input type="hidden" name="conditions" value="<%= @conditions %>" />
   <% end %>
 <% end %>
 
 <% if action_name =~ /(edit)|(update)/ %>
-  <div id='existing_image'>
+  <div id="existing_image">
     <label><%=t('.current_image') %></label>
-    <%= image_fu @thumbnail || @image, '225x255>', :class => "brown_border" %>
+    <%= image_fu @thumbnail || @image, '225x255>', :class => 'brown_border' %>
   </div>
 <% end %>

--- a/images/app/views/refinery/admin/images/_grid_view.html.erb
+++ b/images/app/views/refinery/admin/images/_grid_view.html.erb
@@ -1,17 +1,17 @@
 <ul id="image_grid" class="<%= ['clearfix', 'pagination_frame', pagination_css_class].compact.join(' ') %>">
   <% @images.each_with_index do |image, index| -%>
-    <li id="image_<%= image.id %>" class='image_<%= index % 5 %>'>
+    <li id="image_<%= image.id %>" class="image_<%= index % 5 %>">
       <%= image_fu image, '135x135#c', :title => image.title %>
-      <span class='actions'>
+      <span class="actions">
         <%= link_to refinery_icon_tag('eye.png'), image.url,
-                    :target => "_blank",
+                    :target => '_blank',
                     :title => t('.view_live_html') %>
         <%= link_to refinery_icon_tag('application_edit.png'),
                     refinery.edit_admin_image_path(image),
                     :title => t('edit', :scope => 'refinery.admin.images') %>
         <%= link_to refinery_icon_tag('delete.png'),
                     refinery.admin_image_path(image),
-                    :class => "cancel confirm-delete",
+                    :class => 'cancel confirm-delete',
                     :title => t('delete', :scope => 'refinery.admin.images'),
                     :data => {
                       :confirm => t('message', :scope => 'refinery.admin.delete', :title => image.title)

--- a/images/app/views/refinery/admin/images/_list_view_image.html.erb
+++ b/images/app/views/refinery/admin/images/_list_view_image.html.erb
@@ -1,17 +1,17 @@
-<li id="sortable_<%= list_view_image.id %>" class='clearfix record <%= cycle("on", "on-hover") %>'>
-  <span class='title'>
+<li id="sortable_<%= list_view_image.id %>" class="clearfix record <%= cycle('on', 'on-hover') %>">
+  <span class="title">
     <%= list_view_image.title %> <span class="preview">&nbsp;</span>
   </span>
-  <span class='actions'>
+  <span class="actions">
     <%= link_to refinery_icon_tag('eye.png'), list_view_image.url,
-                :target => "_blank",
-                :title => "#{image_fu list_view_image, '96x96#c', :size => '96x96'}" %>
+                :target => '_blank',
+                :title => image_fu(list_view_image, '96x96#c', :size => '96x96') %>
     <%= link_to refinery_icon_tag('application_edit.png'),
                 refinery.edit_admin_image_path(list_view_image),
                 :title => t('edit', :scope => 'refinery.admin.images') %>
     <%= link_to refinery_icon_tag('delete.png'),
                 refinery.admin_image_path(list_view_image),
-                :class => "cancel confirm-delete",
+                :class => 'cancel confirm-delete',
                 :title => t('delete', :scope => 'refinery.admin.images'),
                 :data => {
                   :confirm => t('message', :scope => 'refinery.admin.delete', :title => list_view_image.title)

--- a/images/app/views/refinery/admin/images/_records.html.erb
+++ b/images/app/views/refinery/admin/images/_records.html.erb
@@ -1,8 +1,8 @@
 <% if searching? %>
-  <%= link_to t('cancel_search', :scope => 'refinery.admin.search'), refinery.admin_images_path, :class => "cancel-search" %>
+  <%= link_to t('cancel_search', :scope => 'refinery.admin.search'), refinery.admin_images_path, :class => 'cancel-search' %>
   <h2><%= t('results_for_html', :scope => 'refinery.admin.search', :query => h(params[:search])).html_safe %></h2>
 <% end %>
-<div class='pagination_container'>
+<div class="pagination_container">
   <% if @images.any? %>
     <%= render 'images' %>
   <% else %>

--- a/images/app/views/refinery/admin/images/index.html.erb
+++ b/images/app/views/refinery/admin/images/index.html.erb
@@ -1,6 +1,6 @@
-<section id='records'>
+<section id="records">
   <%= render 'records' %>
 </section>
-<section id='actions'>
+<section id="actions">
   <%= render 'actions' %>
 </section>

--- a/images/app/views/refinery/admin/images/insert.html.erb
+++ b/images/app/views/refinery/admin/images/insert.html.erb
@@ -1,25 +1,25 @@
-<% user_can_modify_images = ::Refinery::Plugins.active.names.include?("refinery_images") %>
-<div id='dialog_menu_left'>
+<% user_can_modify_images = ::Refinery::Plugins.active.names.include?('refinery_images') %>
+<div id="dialog_menu_left">
   <% if (any_images = @images.any?) or searching? %>
-    <span id="existing_image_radio" class="radio<%= " selected_radio" if (no_errors = @image.errors.empty?) %>">
-      <input type='radio' name='image_type' value='existing_image' id='image_type_existing'<%= " checked='true'" if no_errors or searching? %> />
-      <label for='image_type_existing' class='stripped'><%= t('.existing_image') %></label>
+    <span id="existing_image_radio" class="radio<%= ' selected_radio' if (no_errors = @image.errors.empty?) %>">
+      <input type="radio" name="image_type" value="existing_image" id="image_type_existing"<%= ' checked="true"'.html_safe if no_errors or searching? %> />
+      <label for="image_type_existing" class="stripped"><%= t('.existing_image') %></label>
     </span>
   <% end %>
   <% if user_can_modify_images %>
-    <span id="upload_image_radio" class="radio<%= " selected_radio" if !no_errors and !any_images %>">
-      <input type='radio' name='image_type' value='upload_image' id='image_type_upload'<%= " checked='true'" if (!any_images or !no_errors) and !searching? %> />
-      <label for='image_type_upload' class='stripped'><%= t('.new_image') %></label>
+    <span id="upload_image_radio" class="radio<%= ' selected_radio' if !no_errors and !any_images %>">
+      <input type="radio" name="image_type" value="upload_image" id="image_type_upload"<%= ' checked="true"'.html_safe if (!any_images or !no_errors) and !searching? %> />
+      <label for="image_type_upload" class="stripped"><%= t('.new_image') %></label>
     </span>
   <% end %>
 </div>
 
-<div id='dialog_main'>
+<div id="dialog_main">
   <% if any_images or user_can_modify_images %>
     <%= render 'existing_image' if any_images or searching? %>
 
     <% if user_can_modify_images %>
-      <div id='upload_image_area' class='dialog_area'<%= " style='display:none;'" if any_images and (no_errors or searching?) %>>
+      <div id="upload_image_area" class="dialog_area"<%= ' style="display:none;"'.html_safe if any_images and (no_errors or searching?) %>>
         <%= render 'form', :insert => true %>
       </div>
     <% end %>
@@ -39,7 +39,7 @@
   <script>
     $(document).ready(function(){
       new ImageDialog({
-        callback: <%= @callback.present? ? "self.parent.#{h @callback}" : "null" %>,
+        callback: <%= @callback.present? ? "self.parent.#{h @callback}" : 'null' %>,
         multiple: <%= @multiple == 'true' %>
       }).create();
     });


### PR DESCRIPTION
hello, 
fix problem where some atributes are rendered like `class="&#39;selected&#39;"` which cause bugs on some systems, and also is it small step in way unify use of quotes
