### PR TITLE
Adds regression test for preview after save-and-continue

### DIFF
--- a/pages/spec/requests/refinery/admin/pages_spec.rb
+++ b/pages/spec/requests/refinery/admin/pages_spec.rb
@@ -185,6 +185,20 @@ module Refinery
             Page.by_title("Some changes I'm unsure what they will look like").should be_empty
           end
 
+          # Regression test for previewing after save-and_continue
+          it 'will show the preview in a new window after save-and-continue', :js do
+            visit refinery.admin_pages_path
+
+            find('a[tooltip^=Edit]').click
+            fill_in "Title", :with => "Save this"
+            click_button "Save & continue editing"
+            page.should have_content("'Save this' was successfully updated")
+            
+            click_button "Preview"
+
+            # this test SHOULD fail but it does not. It does when run manually
+            new_window_should_have_content("Save this")
+          end
         end
 
         context 'a brand new page' do


### PR DESCRIPTION
An error happens when `Preview` is clicked after the title is change and save with `Save and continue editing`

```
ActiveRecord::RecordNotFound in Refinery::PagesController#preview
Couldn't find Refinery::PagePart with ID=4 for Refinery::Page with ID=
```

**DO NOT MERGE**
A spec is included that was supposed to show the bug in action BUT, as described to @parndt in irc, this test passes when run in the spec but fails when the steps outlined in the spec is done manually.
