### PR TITLE
fix #1959 bad RegExp for fullpage caching in doc

### DIFF
--- a/doc/guides/7 - Hosting and Deployment/3 - Full-Page Cache with Apache.textile
+++ b/doc/guides/7 - Hosting and Deployment/3 - Full-Page Cache with Apache.textile
@@ -28,7 +28,7 @@ RewriteEngine On
 RewriteRule ^$ home
 
 #checks cache directory for already cached pages
-RewriteCond %{REQUEST_URI} ^/(../)?[^/]*$
+RewriteCond %{REQUEST_URI} ^/[a-zA-Z0-9\-/]*$
 RewriteCond %{DOCUMENT_ROOT}/refinery/cache/pages%{REQUEST_URI}.html -f
 RewriteRule ^([^.]+)$ refinery/cache/pages/%{REQUEST_URI}.html [L]
 


### PR DESCRIPTION
Hi

More info in issue #1959 https://github.com/refinery/refinerycms/issues/1959

Martin
