### PR TITLE
Add check to extension generator which checks if extension specified by --extension option actually exist. 

### DIFF
--- a/core/lib/refinery/extension_generation.rb
+++ b/core/lib/refinery/extension_generation.rb
@@ -180,9 +180,7 @@ module Refinery
     end
 
     def exit_with_message!(message)
-      puts ""
-      puts message
-      puts ""
+      STDERR.puts "\n#{message}\n\n"
       exit 1
     end
 
@@ -314,6 +312,11 @@ module Refinery
       if attributes.empty? && self.behavior != :revoke
         exit_with_message! "You must specify a name and at least one field." \
                            "\nFor help, run: #{generator_command}"
+      end
+
+      if options[:extension].present? && !extension_pathname.directory?
+        exit_with_message! "You can't use '--extension #{options[:extension]}' option because" \
+                           " extension with name #{options[:extension]} doesn't exist."
       end
     end
 

--- a/core/spec/lib/generators/refinery/engine/engine_generator_multiple_resources_spec.rb
+++ b/core/spec/lib/generators/refinery/engine/engine_generator_multiple_resources_spec.rb
@@ -34,6 +34,12 @@ module Refinery
         }
       end
 
+      it "appends existing seeds file" do
+         File.open("#{destination_root}/vendor/extensions/rspec_product_tests/db/seeds.rb") do |file|
+           file.grep(%r{/rspec_product_tests|/rspec_item_tests}).count.should eq(2)
+         end
+       end
+
       it "appends routes to the routes file" do
         File.open("#{destination_root}/vendor/extensions/rspec_product_tests/config/routes.rb") do |file|
           file.grep(%r{rspec_item_tests}).count.should eq(2)

--- a/core/spec/lib/generators/refinery/engine/engine_generator_sanity_check_spec.rb
+++ b/core/spec/lib/generators/refinery/engine/engine_generator_sanity_check_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+require 'generator_spec/test_case'
+require 'generators/refinery/engine/engine_generator'
+
+module Refinery
+  describe EngineGenerator do
+    include GeneratorSpec::TestCase
+
+    it "exits when reserved word is used for extnesion name" do
+      clash_keywords = YAML.load_file(File.expand_path("../../../../../../lib/generators/refinery/clash_keywords.yml", __FILE__))
+      clash_keywords.each do |word|
+        lambda {
+          STDERR.should_receive(:puts).with("\nPlease choose a different name. The generated code would fail for class '#{word}' as it conflicts with a reserved keyword.\n\n")
+          run_generator [word, "title:string"]
+        }.should raise_error(SystemExit)
+      end
+    end
+
+    it "exits when plural word is used for extension name" do
+      lambda {
+        STDERR.should_receive(:puts).with("\nPlease specify the singular name 'apple' instead of 'apples'.\n\n")
+        run_generator %w{ apples title:string }
+      }.should raise_error(SystemExit)
+    end
+
+    it "exits when uncountable word is used for extension name" do
+      lambda {
+        STDERR.should_receive(:puts).with("\nThe extension name you specified will not work as the singular name is equal to the plural name.\n\n")
+        run_generator %w{ money title:string }
+      }.should raise_error(SystemExit)
+    end
+
+    it "exits when no attribute provided" do
+      lambda {
+        STDERR.should_receive(:puts).with("\nYou must specify a name and at least one field.\nFor help, run: rails generate refinery:engine\n\n")
+        run_generator %w{ car }
+      }.should raise_error(SystemExit)
+    end
+
+    it "exits when '--extension' option is used but there is no extension by provided name" do
+      lambda { 
+        STDERR.should_receive(:puts).with("\nYou can't use '--extension nonexistent' option because extension with name nonexistent doesn't exist.\n\n")
+        run_generator %w{ car title:string --extension nonexistent }
+      }.should raise_error(SystemExit)
+    end
+  end
+end

--- a/core/spec/lib/generators/refinery/engine/engine_generator_spec.rb
+++ b/core/spec/lib/generators/refinery/engine/engine_generator_spec.rb
@@ -81,18 +81,6 @@ module Refinery
       }
     end
 
-    context "when generating extension inside existing extensions dir" do
-      before do
-        run_generator %w{ rspec_item_test title:string --extension rspec_product_tests --skip }
-      end
-
-      it "appends existing seeds file" do
-        File.open("#{destination_root}/vendor/extensions/rspec_product_tests/db/seeds.rb") do |file|
-          file.grep(%r{/rspec_product_tests|/rspec_item_tests}).count.should eq(2)
-        end
-      end
-    end
-
     describe "attr_accessible" do
       it "adds attributes to the list" do
         File.open("#{destination_root}/vendor/extensions/rspec_product_tests/app/models/refinery/rspec_product_tests/rspec_product_test.rb") do |file|


### PR DESCRIPTION
#1967

~~Unfortunately I wasn't able to figure out a good way to capture messages so that's why I'm only testing for SystemExit.~~

I tried using:

``` ruby
output = `rails g refinery:engine name ...`
output.should eq("message ...")
```

 but it increases spec time quite a lot.
