### PR TITLE
Updates docs to make sure Heroku config vars match Refinery ENV variables

### DIFF
--- a/doc/guides/7 - Hosting and Deployment/1 - Heroku.textile
+++ b/doc/guides/7 - Hosting and Deployment/1 - Heroku.textile
@@ -181,6 +181,8 @@ Next, tell Heroku about your new S3 bucket.
 heroku config:add S3_KEY=123key S3_SECRET=456secret S3_BUCKET=my_app_production
 </shell>
 
+WARNING. Make sure the config vars you add to Heroku match Refinery's environment variables: +S3_KEY+, +S3_SECRET+, and +S3_BUCKET+  
+
 If you have created your bucket in a region other than 'us-east-1' you need to
 add S3_REGION=s3region also.
 

--- a/doc/guides/7 - Hosting and Deployment/2 - Amazon S3 for Uploads.textile
+++ b/doc/guides/7 - Hosting and Deployment/2 - Amazon S3 for Uploads.textile
@@ -50,7 +50,7 @@ ENV['S3_SECRET']='fill_in_your_secret_key_here'
 ENV['S3_BUCKET']='fill_in_your_bucket_name_here'
 </ruby>
 
-(Note: For Heroku, you should use config vars to set your environment variables, using Heroku's command line utility. See "Heroku's config vars documentation":http://devcenter.heroku.com/articles/config-vars.)
+(Note: For Heroku, you should use "config vars to set your environment variables":http://refinerycms.com/guides/heroku)
 
 Another option, expecially if you experience Dragonfly::DataStorage::S3DataStore exceptions, is to configure 
 your Amazon S3 credential using the following syntax:


### PR DESCRIPTION
Re: Issue #1879 https://github.com/refinery/refinerycms/issues/1879#issuecomment-8926062
- adds warning to make sure Heroku config vars match Refinery env vars
- link to updated Heroku docs page from S3 doc page where appropriate
