### PR TITLE
Fix include of refinery/admin.js in admin layout

### DIFF
--- a/core/app/views/refinery/admin/_javascripts.html.erb
+++ b/core/app/views/refinery/admin/_javascripts.html.erb
@@ -1,4 +1,4 @@
-<%= javascript_include_tag 'admin' -%>
+<%= javascript_include_tag 'refinery/admin' -%>
 <%= javascript_include_tag 'refinery/refinery' -%>
 <%= javascript_include_tag 'refinery/wymeditor', "wymeditor/lang/#{::I18n.locale}", "wymeditor/skins/refinery/skin" %>
 <%= yield :after_javascript_libraries -%>


### PR DESCRIPTION
It looks like the admin layout means to include core/app/assets/refinery/admin.js (as per ac09b8e), but gets the path wrong. I was just working on a site and noticed that the asset 404'd.
