### PR TITLE
Remove invalidate_cached_urls.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 * Fixed html stripping bug when editing pages. [#1891](https://github.com/refinery/refinerycms/issues/1891). [Uģis Ozols](https://github.com/ugisozols)
 * Fixed pagination in existing image/resource partial after uploading new image/resource. [#1970](https://github.com/refinery/refinerycms/issues/1970). [Uģis Ozols](https://github.com/ugisozols)
 * Added check to extension generator which checks if extension specified by --extension option actually exist. [#1967](https://github.com/refinery/refinerycms/issues/1967). [Uģis Ozols](https://github.com/ugisozols)
+* Removed everything that was related to `Refinery::Page#invalidate_cached_urls` because it was redundant and there already is a code that takes care of deleting cache. [#1998](https://github.com/refinery/refinerycms/pull/1998). [Uģis Ozols](https://github.com/ugisozols)
 * [See full list](https://github.com/refinery/refinerycms/compare/2.0.8...2.0.9)
 
 ## 2.0.8 [17 August 2012]


### PR DESCRIPTION
It's not needed because:
- cache is cleared by after_filter in admin pages controller
- when rebuild is called it runs #invalidate_cached_urls on every page
  and its children so in case user has many pages it causes a lot of
  queries which increases load time and sometimes even time out.

See #1954 for discussion.
