### PR TITLE
Make assets.debug config easier to change.

### DIFF
--- a/core/lib/generators/refinery/cms/cms_generator.rb
+++ b/core/lib/generators/refinery/cms/cms_generator.rb
@@ -32,6 +32,8 @@ module Refinery
 
       append_asset_pipeline!
 
+      set_assets_debugging_to_false!
+
       forced_overwriting?
 
       copy_files!
@@ -66,6 +68,15 @@ module Refinery
         gsub_file 'Gemfile', %q{gem 'sqlite3'}, %q{group :development, :test do
   gem 'sqlite3'
 end}  end
+    end
+
+    def set_assets_debugging_to_false!
+      if destination_path.join(env = "config/environments/development.rb").file?
+        gsub_file env, "config.assets.debug = true", "config.assets.debug = false"
+
+        insert_into_file env, "# Refinery is setting this config to false in order to speed up page load time\n  ",
+          :before => "config.assets.debug = false"
+      end
     end
 
     def append_gitignore!

--- a/core/lib/refinery/core/engine.rb
+++ b/core/lib/refinery/core/engine.rb
@@ -99,11 +99,6 @@ module Refinery
         ]
       end
 
-      # Disable asset debugging - it's a performance killer in dev mode
-      initializer "refinery.assets.pipeline" do |app|
-        app.config.assets.debug = false
-      end
-
       # active model fields which may contain sensitive data to filter
       initializer "refinery.params.filter" do |app|
         app.config.filter_parameters += [:password, :password_confirmation]


### PR DESCRIPTION
Previously Refinery CMS was setting config.assets.debug in its Core
initializer but since not all users want this behaviour it now sets
this config in development environemnt file. This makes it easier for
the user to change this config to whatever he prefers.
#1639
