### PR TITLE
fix locale redirects for nested pages

### DIFF
--- a/pages/app/controllers/refinery/pages_controller.rb
+++ b/pages/app/controllers/refinery/pages_controller.rb
@@ -28,7 +28,7 @@ module Refinery
         elsif page.link_url.present?
           redirect_to page.link_url
         else
-          if requested_friendly_id != page.friendly_id
+          if should_redirect_to_friendly_url?
             redirect_to refinery.url_for(page.url), :status => 301
           else
             render_with_templates?
@@ -51,6 +51,10 @@ module Refinery
 
     def should_skip_to_first_child?
       page.skip_to_first_child && first_live_child
+    end
+
+    def should_redirect_to_friendly_url?
+      requested_friendly_id != page.friendly_id || params[:path].present? && params[:path].match(page.root.slug).nil?
     end
 
     def current_user_can_view_page?


### PR DESCRIPTION
hello, 
this fix situation when current nested page has equal slug in all languages but parent (root) page has diferent for some languages.
I also add one failing test for problem when we have default locale `:en` and we visit `/en/(home|news)` .  We should be redirected to `/(news)?` but we not ./
