### PR TITLE
Use namespace instead of extension resource plural name, which is often wrong in the case of nested resources.

### DIFF
--- a/core/lib/generators/refinery/engine/templates/lib/generators/refinery/extension_plural_name_generator.rb.erb
+++ b/core/lib/generators/refinery/engine/templates/lib/generators/refinery/extension_plural_name_generator.rb.erb
@@ -10,7 +10,7 @@ module Refinery
       append_file 'db/seeds.rb', :verbose => true do
         <<-EOH
 
-# Added by Refinery CMS <%= plural_name.titleize %> extension
+# Added by Refinery CMS <%= namespacing %> extension
 Refinery::<%= namespacing %>::Engine.load_seed
         EOH
       end


### PR DESCRIPTION
Fixes #2016.
