### PR TITLE
Remove invalid rel attribute from <img> tag

### DIFF
--- a/core/app/assets/javascripts/wymeditor/functions.js.erb
+++ b/core/app/assets/javascripts/wymeditor/functions.js.erb
@@ -112,7 +112,6 @@ WYMeditor.INIT_DIALOG = function(wym, selected, isIframe) {
         .attr(WYMeditor.SRC, url)
         .attr(WYMeditor.TITLE, form.find(wym._options.titleSelector).val())
         .attr(WYMeditor.ALT, form.find(wym._options.altSelector).val())
-        .attr(WYMeditor.REL, form.find(wym._options.sizeSelector).val())
         .load(function(e){
           $(this).attr({
             'width': $(this).width()


### PR DESCRIPTION
Hi,
Can we please remove the `rel` attribute from `<img>` tags as it produces invalid html.

Currently it produces html like:

``` html
<img src="/system/images/BAhbB1sHOgZmSSItMjAxMi8xMS8xMi8wOV81N18wN182MzZfQXZhdGFyX3NtYWxsLmpwZwY6BkVUWwg6BnA6CnRodW1iSSINMjI1eDI1NT4GOwZG/Avatar-small.jpg" title="Avatar Small" alt="Avatar Small" rel="225x255" width="225" height="150" />
```

This is invalid html according http://validator.w3.org/, see our page at http://validator.w3.org/check?uri=http%3A%2F%2Fbeta.n%20atlib.govt.nz

According to http://dev.w3.org/html5/spec-author-view/the-img-element.html#the-img-element the only valid attributes are the  [global attributes](http://dev.w3.org/html5/spec/single-page.html#global-attributes) and:
- alt
- src
- crossorigin
- usemap
- ismap
- width
- height

Tested this locally and it works fine, specs are passing with no changes. I wasn't sure what I needed to do to in terms of testing as I had just removed an attribute, but if you could point me in the right direction I could add them if necessary.

Dave
