### PR TITLE
remove source from block_tags, and don't add wymeditor_whiltelist_tags to block_tags

### DIFF
--- a/core/app/assets/javascripts/wymeditor/classes.js.erb
+++ b/core/app/assets/javascripts/wymeditor/classes.js.erb
@@ -1122,8 +1122,8 @@ WYMeditor.XhtmlSaxListener = function()
     "thead", "title", "tr", "tt", "ul", "var", "extends", "meter",
     "section", "article", "aside", "details", "header", "footer",
     "nav", "dialog", "figure", "figcaption", "address", "hgroup",
-    "mark", "time", "canvas", "audio", "video", "source", "output",
-    "progress", "ruby", "rt", "rp", "summary", "command"<%= ", #{Refinery::Core.wymeditor_whitelist_tags.keys.map{|k| %Q{"#{k}"}}.join(', ')}" if Refinery::Core.wymeditor_whitelist_tags.any? %>];
+    "mark", "time", "canvas", "audio", "video", "output",
+    "progress", "ruby", "rt", "rp", "summary", "command"];
 
 
     // Defines self-closing tags.

--- a/core/app/assets/javascripts/wymeditor/setup.js.erb
+++ b/core/app/assets/javascripts/wymeditor/setup.js.erb
@@ -186,8 +186,8 @@ $.extend(WYMeditor, {
      "li", "tbody", "td", "tfoot", "th", "thead", "tr", "meter",
      "section", "article", "aside", "details", "header", "footer",
      "nav", "dialog", "figure", "figcaption", "address", "hgroup",
-     "mark", "time", "canvas", "audio", "video", "source", "output",
-     "progress", "ruby", "rt", "rp", "summary", "command"<%= ", #{Refinery::Core.wymeditor_whitelist_tags.keys.map{|k| %Q{"#{k}"}}.join(', ')}" if Refinery::Core.wymeditor_whitelist_tags.any? %>),
+     "mark", "time", "canvas", "audio", "video", "output",
+     "progress", "ruby", "rt", "rp", "summary", "command"),
 
     KEY : {
       BACKSPACE: 8,


### PR DESCRIPTION
Source is not a block tag, is inline, but it was added to block_tags and inline_tags

Also, refinerycms-videojs (https://github.com/adexin-team/refinerycms-videojs) adds source and video to wymeditor_whitelist_tags in order to set available attributes, and that adds source as block tag too. Having source as block and inline tags breaks html, because change &lt;/video&gt; with &lt;/source&gt;

https://github.com/adexin-team/refinerycms-videojs/blob/master/config/initializers/refinery/core.rb#L4
