### PR TITLE
Rack::Cache should be a soft dependency

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
 * Added Hungarian translations. [#2010](https://github.com/refinery/refinerycms/pull/2010). [minktom](https://github.com/minktom)
 * Extracted search header logic into partial. [#1974](https://github.com/refinery/refinerycms/pull/1974). [Uģis Ozols](https://github.com/ugisozols)
 * Images can only be updated when the image being uplaoded has the same filename as the original image. [#1866](https://github.com/refinery/refinerycms/pull/1866). [Philip Arndt](https://github.com/parndt) & [Uģis Ozols](https://github.com/ugisozols)
+* Rack::Cache should be a soft dependency per rails/rails#7838. Fixes Dragonfly caching when Rack::Cache is present. [#1736](https://github.com/refinery/refinerycms/issues/1736). [Alexander Wenzowski](https://github.com/wenzowski)
 
 * [See full list](https://github.com/refinery/refinerycms/compare/2-0-stable...master)
 

--- a/images/lib/refinery/images/dragonfly.rb
+++ b/images/lib/refinery/images/dragonfly.rb
@@ -8,6 +8,7 @@ module Refinery
         def setup!
           app_images = ::Dragonfly[:refinery_images]
           app_images.configure_with(:imagemagick)
+          app_images.configure_with(:rails)
 
           app_images.define_macro(::Refinery::Image, :image_accessor)
 
@@ -36,16 +37,14 @@ module Refinery
           end
         end
 
+        ##
+        # Injects Dragonfly::Middleware for Refinery::Images into the stack
         def attach!(app)
-          ### Extend active record ###
-          app.config.middleware.insert_before Refinery::Images.dragonfly_insert_before,
-                                              'Dragonfly::Middleware', :refinery_images
-
-          app.config.middleware.insert_before 'Dragonfly::Middleware', 'Rack::Cache', {
-            :verbose     => Refinery::Core.verbose_rack_cache,
-            :metastore   => "file:#{Rails.root.join('tmp', 'dragonfly', 'cache', 'meta')}",
-            :entitystore => "file:#{Rails.root.join('tmp', 'dragonfly', 'cache', 'body')}"
-          }
+          if ::Rails.application.config.action_controller.perform_caching
+            app.config.middleware.insert_after 'Rack::Cache', 'Dragonfly::Middleware', :refinery_images
+          else
+            app.config.middleware.use 'Dragonfly::Middleware', :refinery_images
+          end
         end
       end
 

--- a/images/refinerycms-images.gemspec
+++ b/images/refinerycms-images.gemspec
@@ -19,8 +19,7 @@ Gem::Specification.new do |s|
   s.files             = `git ls-files`.split("\n")
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
-  s.add_dependency 'dragonfly',        '~> 0.9.8'
-  s.add_dependency 'rack-cache',       '>= 0.5.3'
+  s.add_dependency 'dragonfly',        '~> 0.9.12'
   s.add_dependency 'acts_as_indexed',  '~> 0.7.7'
   s.add_dependency 'refinerycms-core', version
 end

--- a/resources/refinerycms-resources.gemspec
+++ b/resources/refinerycms-resources.gemspec
@@ -19,8 +19,7 @@ Gem::Specification.new do |s|
   s.files             = `git ls-files`.split("\n")
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
-  s.add_dependency 'dragonfly',        '~> 0.9.8'
-  s.add_dependency 'rack-cache',       '>= 0.5.3'
+  s.add_dependency 'dragonfly',        '~> 0.9.12'
   s.add_dependency 'acts_as_indexed',  '~> 0.7.7'
   s.add_dependency 'refinerycms-core', version
 end


### PR DESCRIPTION
fix for #1736 assumes `::Rails.application.config.action_controller.perform_caching` reliably indicates `Rack::Cache` presence in middleware stack.
