### PR TITLE
@valid_template_whitelist is empty when using array of symbols as view_template_whitelist  option

### DIFF
--- a/pages/app/controllers/refinery/admin/pages_controller.rb
+++ b/pages/app/controllers/refinery/admin/pages_controller.rb
@@ -79,10 +79,10 @@ module Refinery
       end
 
       def load_valid_templates
-        @valid_layout_templates = Refinery::Pages.layout_template_whitelist &
+        @valid_layout_templates = Refinery::Pages.layout_template_whitelist.map(&:to_s) &
                                   Refinery::Pages.valid_templates('app', 'views', '{layouts,refinery/layouts}', '*html*')
 
-        @valid_view_templates = Refinery::Pages.view_template_whitelist &
+        @valid_view_templates = Refinery::Pages.view_template_whitelist.map(&:to_s) &
                                 Refinery::Pages.valid_templates('app', 'views', '{pages,refinery/pages}', '*html*')
       end
 


### PR DESCRIPTION
[This article](http://refinerycms.com/guides/using-custom-view-or-layout-templates) says that I can use an array containing either string or symbol as `view_template_whitelist`. To find out what view_templates can be found is used intersection `&` between `Refinery::Pages.view_template_whitelist` and `Refinery::Pages.valid_templates('app', 'views', '{pages,refinery/pages}', '*html*')`, the last one returns array of string and if you use & the result will return empty array.
Here is simple example to illustrate this:

``` ruby
[:simple, :array] & ['simple', 'array'] # => [] 
```
