### PR TITLE
Fixed 'Stack level too deep' error in pages

### DIFF
--- a/pages/lib/refinery/pages/instance_methods.rb
+++ b/pages/lib/refinery/pages/instance_methods.rb
@@ -4,7 +4,6 @@ module Refinery
 
       def self.included(base)
         base.send :helper_method, :refinery_menu_pages
-        base.send :alias_method_chain, :render, :presenters
       end
 
       def error_404(exception=nil)
@@ -27,9 +26,9 @@ module Refinery
       end
 
     protected
-      def render_with_presenters(*args)
-        present(@page) unless admin? or @meta.present?
-        render_without_presenters(*args)
+      def render(*args)
+        present(@page) unless admin? || @meta.present?
+        super
       end
 
     private


### PR DESCRIPTION
I've integrated RefineryCMS to my existing big application, but it won't work and raises 'Stack level too deep'. After several hours of debugging I found that problem was in using `alias_method_chain` in pages mixin for `ApplicationController`. So I've simple refactor this code to use `super` instead of `alias_method_chain`. By the way `alias_method_chain` is not welcome practice and there is no reason to use it there. Now all works fine. Hope guys you will apply this patch soon.
