### PR TITLE
Refactored CLI override command to use Thor.

### DIFF
--- a/core/lib/refinery/cli.rb
+++ b/core/lib/refinery/cli.rb
@@ -4,6 +4,14 @@ module Refinery
   class CLI < Thor
     include Thor::Actions
 
+    no_tasks do
+      def source_paths
+        Refinery::Plugins.registered.pathnames.map{|p|
+          %w(app vendor).map{|dir| p.join(dir, @override_kind[:dir])}
+        }.flatten.uniq
+      end
+    end
+
     OVERRIDES = {
       :view => {
         :glob => '*.{erb,builder}',
@@ -99,32 +107,33 @@ module Refinery
     private
 
     def _override(kind, which)
-      override_kind = OVERRIDES[kind]
-      pattern = "{refinery#{File::SEPARATOR},}#{which.split("/").join(File::SEPARATOR)}#{override_kind[:glob]}"
-      looking_for = ["app", "vendor"].inject([]) do |memo, location|
-        Refinery::Plugins.registered.pathnames.each do |p|
-          memo << p.join(location, override_kind[:dir], pattern).to_s
-        end
-        memo
-      end
+      @override_kind = OVERRIDES[kind]
 
-      # copy in the matches
-      if (matches = looking_for.map{|d| Dir[d]}.flatten.compact.uniq).any?
+      matcher = [
+        "{refinery#{File::SEPARATOR},}",
+        which.split('/').join(File::SEPARATOR),
+        @override_kind[:glob]
+      ].flatten.join
+
+      if (matches = find_relative_matches(matcher)).present?
         matches.each do |match|
-          location = match[/app|vendor/]
-          dir = match.split("/#{location}/#{override_kind[:dir]}/").last.split('/')
-          file = dir.pop # get rid of the file.
-          dir = dir.join(File::SEPARATOR) # join directory back together
-
-          destination_dir = Rails.root.join(location, override_kind[:dir], dir)
-          FileUtils.mkdir_p(destination_dir)
-          FileUtils.cp match, (destination = File.join(destination_dir, file))
-
-          puts "Copied #{override_kind[:desc]} file to #{destination.gsub("#{Rails.root.to_s}#{File::SEPARATOR}", '')}"
+          copy_file match, Rails.root.join('app', @override_kind[:dir], match)
         end
       else
-        puts "Couldn't match any #{override_kind[:desc]} files in any extensions like #{which}"
+        puts "Couldn't match any #{@override_kind[:desc]} files in any extensions like #{which}"
       end
+    end
+
+    def find_matches(pattern)
+      Set.new source_paths.map {|path| Dir[path.join(pattern)] }.flatten
+    end
+
+    def find_relative_matches(pattern)
+      find_matches(pattern).map {|match| strip_source_paths(match) }
+    end
+
+    def strip_source_paths(match)
+      match.gsub Regexp.new(source_paths.join('\/?|')), ''
     end
   end
 end

--- a/core/spec/lib/refinery/cli_spec.rb
+++ b/core/spec/lib/refinery/cli_spec.rb
@@ -55,7 +55,9 @@ describe "CLI" do
 
         msg = capture(:stdout) { rake["refinery:override"].invoke }
 
-        msg.should include(spec_success_message)
+        Array(spec_success_message).each do |message_fragment|
+          msg.should include(message_fragment)
+        end
         File.exists?(Rails.root.join(copied_file_location)).should be_true
       end
     end
@@ -65,7 +67,7 @@ describe "CLI" do
     it_behaves_like "refinery:override" do
       let(:env) { "view" }
       let(:not_found_message) { "Couldn't match any view template files in any extensions like non-existent\n" }
-      let(:spec_success_message) { "Copied view template file to app/views/refinery/#{file_name}\n" }
+      let(:spec_success_message) { %W(create app/views/refinery/#{file_name}) }
       let(:file_location) { File.expand_path("../../../../app/views/refinery", __FILE__) }
       let(:env_file_location) { "refinery/#{file_name.sub(%r{\..+}, "")}" }
       let(:copied_file_location) { "app/views/refinery/#{file_name}" }
@@ -76,7 +78,7 @@ describe "CLI" do
     it_behaves_like "refinery:override" do
       let(:env) { "controller" }
       let(:not_found_message) { "Couldn't match any controller files in any extensions like non-existent\n" }
-      let(:spec_success_message) { "Copied controller file to app/controllers/refinery/#{file_name}\n" }
+      let(:spec_success_message) { %W(create app/controllers/refinery/#{file_name}) }
       let(:file_location) { File.expand_path("../../../../app/controllers/refinery", __FILE__) }
       let(:env_file_location) { "refinery/#{file_name.sub(%r{\..+}, "")}" }
       let(:copied_file_location) { "app/controllers/refinery/#{file_name}" }
@@ -87,7 +89,7 @@ describe "CLI" do
     it_behaves_like "refinery:override" do
       let(:env) { "model" }
       let(:not_found_message) { "Couldn't match any model files in any extensions like non-existent\n" }
-      let(:spec_success_message) { "Copied model file to app/models/refinery/core/#{file_name}\n" }
+      let(:spec_success_message) { %W(create app/models/refinery/core/#{file_name}) }
       let(:file_location) { File.expand_path("../../../../app/models/refinery/core", __FILE__) }
       let(:env_file_location) { "refinery/core/#{file_name.sub(%r{\..+}, "")}" }
       let(:copied_file_location) { "app/models/refinery/core/#{file_name}" }
@@ -98,7 +100,7 @@ describe "CLI" do
     it_behaves_like "refinery:override" do
       let(:env) { "javascript" }
       let(:not_found_message) { "Couldn't match any javascript files in any extensions like non-existent\n" }
-      let(:spec_success_message) { "Copied javascript file to app/assets/javascripts/refinery/#{file_name}\n" }
+      let(:spec_success_message) { %W(create app/assets/javascripts/refinery/#{file_name}) }
       let(:file_location) { File.expand_path("../../../../app/assets/javascripts/refinery", __FILE__) }
       let(:env_file_location) { "refinery/#{file_name.sub(%r{\..+}, "")}" }
       let(:copied_file_location) { "app/assets/javascripts/refinery/#{file_name}" }
@@ -109,7 +111,7 @@ describe "CLI" do
     it_behaves_like "refinery:override" do
       let(:env) { "stylesheet" }
       let(:not_found_message) { "Couldn't match any stylesheet files in any extensions like non-existent\n" }
-      let(:spec_success_message) { "Copied stylesheet file to app/assets/stylesheets/refinery/#{file_name}\n" }
+      let(:spec_success_message) { %W(create app/assets/stylesheets/refinery/#{file_name}) }
       let(:file_location) { File.expand_path("../../../../app/assets/stylesheets/refinery", __FILE__) }
       let(:env_file_location) { "refinery/#{file_name.sub(%r{\..+}, "")}" }
       let(:copied_file_location) { "app/assets/stylesheets/refinery/#{file_name}" }


### PR DESCRIPTION
WARNING: The tests FAIL

This is because cli_spec.rb is testing the output of the `rake` command. I think this is silly.

If we're testing the CLI we should be testing the CLI class, not the `rake` command.

Permission to refactor [these specs](https://github.com/refinery/refinerycms/blob/a94c627d453609390fd39d5ed81bcf9598dc55d9/core/spec/lib/refinery/cli_spec.rb) to test the class instead?

Here's how you'd call it:

``` ruby
Refinery::CLI.new.override({"view" => "_content_page"})
```

Seems better to me. 

@robyurkowski @ugisozols Please give me your feedback.
