### PR TITLE
Removed unused 'store_current_location!' method.

### DIFF
--- a/pages/lib/refinery/pages/instance_methods.rb
+++ b/pages/lib/refinery/pages/instance_methods.rb
@@ -32,12 +32,7 @@ module Refinery
         render_without_presenters(*args)
       end
 
-    private
-      def store_current_location!
-        return super if admin?
 
-        session[:website_return_to] = refinery.url_for(@page.url) if @page && @page.persisted?
-      end
 
     end
   end


### PR DESCRIPTION
All tests still pass.

Removed

``` ruby

private
      def store_current_location!
        return super if admin?

        session[:website_return_to] = refinery.url_for(@page.url) if @page && @page.persisted?
      end

```
