### PR TITLE
Update seo_meta to 1.4.0

### DIFF
--- a/pages/refinerycms-pages.gemspec
+++ b/pages/refinerycms-pages.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'friendly_id',                 '~> 4.0.4'
   s.add_dependency 'globalize3',                  '~> 0.2.0'
   s.add_dependency 'awesome_nested_set',          '~> 2.1.3'
-  s.add_dependency 'seo_meta',                    '~> 1.3.0'
+  s.add_dependency 'seo_meta',                    '~> 1.4.0'
   s.add_dependency 'refinerycms-core',            version
   s.add_dependency 'babosa',                      '!= 0.3.6'
 end


### PR DESCRIPTION
Should upgrade this gem to 1.4.0, minor changes only, but deprecated Keywords fields which is great since its a 2001 era thing!
