### PR TITLE
Remove everything that was relalted to meta_keywords.

### DIFF
--- a/core/app/views/refinery/_head.html.erb
+++ b/core/app/views/refinery/_head.html.erb
@@ -3,7 +3,6 @@
   <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" /><![endif]-->
   <title><%= browser_title(yield(:title)) %></title>
   <%= raw %(<meta name="description" content="#{@meta.meta_description}" />) if @meta.meta_description.present? -%>
-  <%= raw %(<meta name="keywords" content="#{@meta.meta_keywords}">) if @meta.meta_keywords.present? -%>
   <%= raw %(<link rel="canonical" content="#{@canonical}" />) if @canonical.present? -%>
   <%= csrf_meta_tags if Refinery::Core.authenticity_token_on_frontend -%>
   <%= yield :meta %>

--- a/core/lib/refinery/base_presenter.rb
+++ b/core/lib/refinery/base_presenter.rb
@@ -5,8 +5,7 @@ module Refinery
       :title              => proc { |p| (p.model.class.name.titleize if p.model.present?) },
       :path               => proc { |p| p.title },
       :browser_title      => nil,
-      :meta_description   => nil,
-      :meta_keywords      => nil
+      :meta_description   => nil
     }
 
     attr_reader :model

--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -14,7 +14,7 @@ module Refinery
 
     class Translation
       is_seo_meta
-      attr_accessible :browser_title, :meta_description, :meta_keywords, :locale
+      attr_accessible :browser_title, :meta_description, :locale
     end
 
     attr_accessible :title
@@ -23,7 +23,7 @@ module Refinery
     seo_fields = ::SeoMeta.attributes.keys.map{|a| [a, :"#{a}="]}.flatten
     delegate(*(seo_fields << {:to => :translation}))
 
-    attr_accessible :id, :deletable, :link_url, :menu_match, :meta_keywords,
+    attr_accessible :id, :deletable, :link_url, :menu_match,
                     :skip_to_first_child, :position, :show_in_menu, :draft,
                     :parts_attributes, :browser_title, :meta_description,
                     :parent_id, :menu_title, :page_id, :layout_template,
@@ -44,7 +44,7 @@ module Refinery
                 :scope => :parent
 
     # Docs for acts_as_indexed http://github.com/dougal/acts_as_indexed
-    acts_as_indexed :fields => [:title, :meta_keywords, :meta_description,
+    acts_as_indexed :fields => [:title, :meta_description,
                                 :menu_title, :browser_title, :all_page_part_content]
 
     has_many :parts,

--- a/pages/spec/models/refinery/page_spec.rb
+++ b/pages/spec/models/refinery/page_spec.rb
@@ -326,10 +326,6 @@ module Refinery
 
     context 'meta data' do
       context 'responds to' do
-        it 'meta_keywords' do
-          page.respond_to?(:meta_keywords)
-        end
-
         it 'meta_description' do
           page.respond_to?(:meta_description)
         end
@@ -340,11 +336,6 @@ module Refinery
       end
 
       context 'allows us to assign to' do
-        it 'meta_keywords' do
-          page.meta_keywords = 'Some, great, keywords'
-          page.meta_keywords.should == 'Some, great, keywords'
-        end
-
         it 'meta_description' do
           page.meta_description = 'This is my description of the page for search results.'
           page.meta_description.should == 'This is my description of the page for search results.'
@@ -357,14 +348,6 @@ module Refinery
       end
 
       context 'allows us to update' do
-        it 'meta_keywords' do
-          page.meta_keywords = 'Some, great, keywords'
-          page.save
-
-          page.reload
-          page.meta_keywords.should == 'Some, great, keywords'
-        end
-
         it 'meta_description' do
           page.meta_description = 'This is my description of the page for search results.'
           page.save


### PR DESCRIPTION
seo_meta gem droped meta_keywords support in version 1.4.0.

If this gets merged then #2052 also needs to be merged.
