### PR TITLE
Update regex to match multiline config.action_mailer.

### DIFF
--- a/core/lib/generators/refinery/cms/cms_generator.rb
+++ b/core/lib/generators/refinery/cms/cms_generator.rb
@@ -163,10 +163,20 @@ gem 'pg'
         # Refinery does not necessarily expect action_mailer to be available as
         # we may not always require it (currently only the authentication extension).
         # Rails, however, will optimistically place config entries for action_mailer.
-        insert_into_file env, "  if config.respond_to?(:action_mailer)\n  ",
-                              :before => %r{^\s*config\.action_mailer\..+([\w\W]*\})?}, :verbose => false
-        insert_into_file env, "\n  end",
-                              :after => %r{^\s*config\.action_mailer\..+([\w\W]*\})?}, :verbose => false
+        current_mailer_config = File.read(destination_path.join(env)).to_s.
+                                     match(%r{^\s.+?config\.action_mailer\..+([\w\W]*\})?}).
+                                     to_a.flatten.first
+
+        if current_mailer_config.present?
+          new_mailer_config = [
+            "  if config.respond_to?(:action_mailer)",
+            current_mailer_config.gsub(%r{\A\n+?}, ''). # remove extraneous newlines at the start
+                                  gsub(%r{^\ \ }) { |line| "  #{line}" }, # add indentation on each line
+            "  end"
+          ].join("\n")
+
+          gsub_file env, current_mailer_config, new_mailer_config, :verbose => false
+        end
 
         gsub_file env, "config.assets.compile = false", "config.assets.compile = true", :verbose => false
       end

--- a/core/spec/lib/generators/refinery/cms/cms_generator_spec.rb
+++ b/core/spec/lib/generators/refinery/cms/cms_generator_spec.rb
@@ -91,21 +91,11 @@ end
 Dummy::Application.configure do
   if config.respond_to?(:action_mailer)
     config.action_mailer.test = true
-  config.action_mailer.check = {
-    :test => true,
-    :check => true
-  }
+    config.action_mailer.check = {
+      :test => true,
+      :check => true
+    }
   end
-end
-          SPEC
-        end
-      end
-
-      it "leaves commented config.action_mailer alone" do
-        File.open("#{destination_root}/config/environments/test.rb") do |file|
-          file.read.should eq <<-SPEC
-Dummy::Application.configure do
-  # config.action_mailer.test = true
 end
           SPEC
         end


### PR DESCRIPTION
#1979

Updated regex can now properly match config.action_mailer settings like:

``` ruby
config.action_mailer.raise_delivery_errors = false
```

and multiline:

``` ruby
config.action_mailer.raise_delivery_errors = false
config.action_mailer.smtp_settings = {
    address: "test.com",
    port: 123,
    domain: "example.com"
}
```
