### PR TITLE
Update to "Using Refinery with Rails 3.1 and Devise"

### DIFF
--- a/doc/guides/5 - Using Refinery as an Engine/2 - With an existing Rails 3.1 + Devise app.textile
+++ b/doc/guides/5 - Using Refinery as an Engine/2 - With an existing Rails 3.1 + Devise app.textile
@@ -203,6 +203,9 @@ Now that we have a baseline example working ExistingApp using Devise, it's time 
     gem 'refinerycms-resources'
   end
 
+  # Add i18n support.
+  gem 'refinerycms-i18n', '~> 2.1.0.dev', :git => 'git://github.com/refinery/refinerycms-i18n.git'
+
   group :development, :test do
     gem 'refinerycms-testing',  :git => 'git://github.com/refinery/refinerycms.git'
   end


### PR DESCRIPTION
I've added the refinerycms-i18n gem to the gems that need to be added to your Gemfile.
This solves the error

```
Could not find gem 'refinerycms-i18n (~> 2.1.0.dev) ruby', which is required by gem 'refinerycms-testing (>= 0) ruby', in any of the sources.
```

that you got when following the guide
