### PR TITLE
Add actual support for turning the welcome page off or on

### DIFF
--- a/core/lib/refinery/application_controller.rb
+++ b/core/lib/refinery/application_controller.rb
@@ -65,6 +65,10 @@ module Refinery
 
   protected
 
+    def show_welcome_page?
+      !!Refinery::Core.show_welcome_page
+    end
+
     def force_ssl?
       redirect_to :protocol => 'https' if !request.ssl? && Refinery::Core.force_ssl
     end
@@ -83,7 +87,7 @@ module Refinery
     end
 
     def refinery_user_required?
-      if just_installed? and controller_name != 'users'
+      if just_installed? and show_welcome_page? and controller_name != 'users'
         redirect_to refinery.new_refinery_user_registration_path
       end
     end

--- a/core/lib/refinery/core/configuration.rb
+++ b/core/lib/refinery/core/configuration.rb
@@ -7,7 +7,7 @@ module Refinery
                     :menu_hide_children, :menu_css, :dragonfly_secret, :ie6_upgrade_message_enabled,
                     :show_internet_explorer_upgrade_message, :wymeditor_whitelist_tags,
                     :javascripts, :stylesheets, :s3_bucket_name, :s3_region, :s3_access_key_id,
-                    :s3_secret_access_key, :force_ssl
+                    :s3_secret_access_key, :force_ssl, :show_welcome_page
 
     self.rescue_not_found = false
     self.s3_backend = false
@@ -28,6 +28,7 @@ module Refinery
     self.s3_access_key_id = ENV['S3_KEY']
     self.s3_secret_access_key = ENV['S3_SECRET']
     self.force_ssl = false
+    self.show_welcome_page = true
 
     def config.register_javascript(name)
       self.javascripts << name

--- a/doc/guides/5 - Using Refinery as an Engine/2 - With an existing Rails 3.1 + Devise app.textile
+++ b/doc/guides/5 - Using Refinery as an Engine/2 - With an existing Rails 3.1 + Devise app.textile
@@ -385,6 +385,8 @@ ruby> exit
 </shell>
 
 We need to also avoid the show_welcome page in test mode or our ExistingApp existing integration tests will suddenly stop working.
+
+One way to accomplish this is to monkey patch the show_welcome_page? method:
 +app/controllers/application_controller+
 <ruby>
 class ApplicationController < ActionController::Base
@@ -394,6 +396,17 @@ class ApplicationController < ActionController::Base
     #database will successfully run.
     false
   end
+  ...
+end
+</ruby>
+
+But this is the old and busted way of doing things. Let's get with the new hotness:
+
++config/initializers/refinery/core.rb+
+<ruby>
+Refinery::Core.configure do |config|
+  ...
+  config.show_welcome_page = false
   ...
 end
 </ruby>


### PR DESCRIPTION
The guides suggest if you're using an existing application with devise you can add the `show_welcome_page?` method to your application controller and tell it to return `false` it will keep the welcome page from showing. Needless to say, this wasn't a thing. I've made this a thing. It's now a core refinery setting.
