### PR TITLE
We shouldn't require users or SSL on the frontend.

### DIFF
--- a/authentication/spec/requests/refinery/sessions_spec.rb
+++ b/authentication/spec/requests/refinery/sessions_spec.rb
@@ -8,8 +8,8 @@ module Refinery
 
     before do
       FactoryGirl.create(:refinery_user, :username => "ugisozols",
-                              :password => "123456",
-                              :password_confirmation => "123456")
+                                         :password => "123456",
+                                         :password_confirmation => "123456")
 
       visit refinery.login_path
     end

--- a/core/lib/refinery/admin/base_controller.rb
+++ b/core/lib/refinery/admin/base_controller.rb
@@ -9,6 +9,9 @@ module Refinery
       included do
         layout :layout?
 
+        send :before_filter, :require_refinery_users!
+        send :before_filter, :force_ssl!
+
         before_filter :authenticate_refinery_user!, :restrict_plugins, :restrict_controller
         after_filter :store_location?, :only => [:index] # for redirect_back_or_default
 
@@ -25,6 +28,10 @@ module Refinery
 
     protected
 
+      def force_ssl!
+        redirect_to :protocol => 'https' if Refinery::Core.force_ssl && !request.ssl?
+      end
+
       def group_by_date(records)
         new_records = []
 
@@ -35,6 +42,10 @@ module Refinery
         end
 
         new_records
+      end
+
+      def require_refinery_users!
+        redirect_to refinery.signup_path if just_installed? && controller_name != 'users'
       end
 
       def restrict_plugins

--- a/core/lib/refinery/application_controller.rb
+++ b/core/lib/refinery/application_controller.rb
@@ -15,10 +15,6 @@ module Refinery
 
       send :include, Refinery::Crud # basic create, read, update and delete methods
 
-      send :before_filter, :refinery_user_required?, :if => :admin?
-
-      send :before_filter, :force_ssl?, :if => :admin?
-
       if Refinery::Core.rescue_not_found
         send :rescue_from, ActiveRecord::RecordNotFound,
                            ::AbstractController::ActionNotFound,
@@ -62,10 +58,6 @@ module Refinery
 
   protected
 
-    def force_ssl?
-      redirect_to :protocol => 'https' if !request.ssl? && Refinery::Core.force_ssl
-    end
-
     # use a different model for the meta information.
     def present(model)
       @meta = presenter_for(model).new(model)
@@ -77,12 +69,6 @@ module Refinery
       "#{model.class.name}Presenter".constantize
     rescue NameError
       default
-    end
-
-    def refinery_user_required?
-      if just_installed? && controller_name != 'users'
-        redirect_to refinery.signup_path
-      end
     end
   end
 end

--- a/core/spec/controllers/refinery/admin/dummy_controller_spec.rb
+++ b/core/spec/controllers/refinery/admin/dummy_controller_spec.rb
@@ -31,6 +31,26 @@ module Refinery
             get :index
           end
         end
+
+        describe "force_ssl!" do
+          before do
+            controller.stub(:require_refinery_users!).and_return(false)
+          end
+
+          it "is false so standard HTTP is used" do
+            Refinery::Core.stub(:force_ssl).and_return(false)
+            controller.should_not_receive(:redirect_to).with(:protocol => 'https')
+
+            get :index
+          end
+
+          it "is true so HTTPS is used" do
+            Refinery::Core.stub(:force_ssl).and_return(true)
+            controller.should_receive(:redirect_to).with(:protocol => 'https')
+
+            get :index
+          end
+        end
       end
     end
   end

--- a/core/spec/lib/refinery/application_controller_spec.rb
+++ b/core/spec/lib/refinery/application_controller_spec.rb
@@ -48,38 +48,6 @@ module Refinery
       end
     end
 
-    describe "force_ssl" do
-      before do
-        controller.stub(:admin?).and_return(true)
-        controller.stub(:refinery_user_required?).and_return(false)
-      end
-
-      it "is false so standard HTTP is used" do
-        Refinery::Core.stub(:force_ssl).and_return(false)
-
-        get :index
-
-        response.should_not be_redirect
-      end
-
-      it "is true so HTTPS is used" do
-        Refinery::Core.stub(:force_ssl).and_return(true)
-
-        get :index
-
-        response.should be_redirect
-      end
-
-      it "is true but HTTPS is not used because admin? is false" do
-        controller.stub(:admin?).and_return(false)
-        Refinery::Core.stub(:force_ssl).and_return(true)
-
-        get :index
-
-        response.should_not be_redirect
-      end
-    end
-
     describe "#presenter_for" do
       it "returns BasePresenter for nil" do
         controller.send(:presenter_for, nil).should eq(BasePresenter)

--- a/testing/lib/refinery/testing/controller_macros/authentication.rb
+++ b/testing/lib/refinery/testing/controller_macros/authentication.rb
@@ -33,7 +33,7 @@ module Refinery
           end
 
           before do
-            controller.should_receive(:refinery_user_required?).and_return false
+            controller.should_receive(:require_refinery_users!).and_return false
             controller.should_receive(:authenticate_refinery_user!).and_return true
             controller.should_receive(:restrict_plugins).and_return true
             controller.should_receive(:allow_controller?).and_return controller_permission


### PR DESCRIPTION
- Renamed force_ssl? to force_ssl! and moved it to Admin::BaseController.
- Renamed refinery_user_required? to require_refinery_users! and moved it to Admin::BaseController.
