### PR TITLE
Adding the ability to use arbitrary Google Analytics parameters

### DIFF
--- a/core/app/views/refinery/_google_analytics.html.erb
+++ b/core/app/views/refinery/_google_analytics.html.erb
@@ -1,7 +1,22 @@
-<% page_code = Refinery::Core.google_analytics_page_code.to_s.strip %>
-<% unless local_request? or refinery_user? or page_code =~ /^(UA-xxxxxx-x)?$/ -%>
+<%
+google_config = Refinery::Core.google_analytics_page_code
+
+analytics_params = {}
+
+if google_config
+  if google_config.class == String
+    analytics_params[:setAccount] = google_config
+  elsif google_config.class == Hash
+    analytics_params = google_config
+  end
+end
+
+gaq_string = analytics_params.map{ |k,v| "['_#{k}','#{v.to_s.strip}']" }.join(',')
+
+%>
+<% unless local_request? or refinery_user? or analytics_params[:setAccount].to_s =~ /^(UA-xxxxxx-x)?$/ -%>
 <!-- asynchronous google analytics: mathiasbynens.be/notes/async-analytics-snippet -->
-<script>var _gaq=[['_setAccount','<%= page_code %>'],['_trackPageview'],['_trackPageLoadTime']];(function(d,t){
+<script>var _gaq=[<%= raw gaq_string -%>,['_trackPageview'],['_trackPageLoadTime']];(function(d,t){
 var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
 g.async=1;g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)
 }(document,'script'))</script>


### PR DESCRIPTION
We needed to add the domainName parameter to our Google Analytics setup and thought others might need to, too. Now instead of taking just a string as that parameter, it can instead take a hash which it will destructure into the string format expected in the Javascript for GA.

We didn't want to rename the parameter or add another parameter name, though that is probably the right way to do it; if you think that's worth our time, please add a note and we can add that in to an updated pull request.

We wrote a test for this, but we couldn't figure out a way to stub local_request? or refinery_user? in our test; we monkeypatched the methods onto Object to ensure that they would get called. Ideas on how to do this would be most welcome, and we can submit that too.

Thanks!
