### PR TITLE
reset i18n locale to default after seeding core pages

### DIFF
--- a/pages/db/seeds.rb
+++ b/pages/db/seeds.rb
@@ -49,3 +49,5 @@ Refinery::I18n.frontend_locales.each do |lang|
     Refinery::Page.by_title(title).each { |page| page.update_attributes(:slug => slug) }
   end
 end
+
+I18n.locale = ::Refinery::I18n.default_locale


### PR DESCRIPTION
Without this, current locale is in refinery setted to last locale and that cause other seeds (blog, inquiries...) creating their pages only under last (unexpected) locale.
