### PR TITLE
use ".many?" instead of ".count > 1" for collection

### DIFF
--- a/core/lib/generators/refinery/engine/templates/app/views/refinery/namespace/admin/plural_name/_actions.html.erb
+++ b/core/lib/generators/refinery/engine/templates/app/views/refinery/namespace/admin/plural_name/_actions.html.erb
@@ -8,7 +8,7 @@
     <%%= link_to t('.create_new'), refinery.new_<%= namespacing.underscore %>_admin_<%= singular_name %>_path,
                  :class => "add_icon" %>
   </li>
-<%% if !searching? && ::Refinery::<%= namespacing %>::Admin::<%= class_name.pluralize %>Controller.sortable? && ::Refinery::<%= namespacing %>::<%= class_name %>.count > 1 %>
+<%% if !searching? && ::Refinery::<%= namespacing %>::Admin::<%= class_name.pluralize %>Controller.sortable? && ::Refinery::<%= namespacing %>::<%= class_name %>.many? %>
   <li>
     <%%= link_to t('.reorder', :what => "<%= singular_name.titleize.pluralize %>"),
                  refinery.<%= namespacing.underscore %>_admin_<%= plural_name %><%= "_index" if plural_name == singular_name%>_path,


### PR DESCRIPTION
super minor, per https://github.com/refinery/refinerycms/commit/02c74dad15a7af380037e29820e27e208dccae1f#commitcomment-2450022
(so as to be consistent. `ack \.many\?` shows plenty)
