### PR TITLE
Pull in any migrations when the generators run.

### DIFF
--- a/core/lib/generators/refinery/cms/cms_generator.rb
+++ b/core/lib/generators/refinery/cms/cms_generator.rb
@@ -202,6 +202,7 @@ gem 'pg'
     def run_additional_generators!
       generator_args = []
       generator_args << '--quiet' if self.options[:quiet]
+      generator_args << '--skip-migrations' if self.options[:skip_migrations]
       Refinery::CoreGenerator.start generator_args
       Refinery::AuthenticationGenerator.start generator_args if defined?(Refinery::AuthenticationGenerator)
       Refinery::ResourcesGenerator.start generator_args if defined?(Refinery::ResourcesGenerator)

--- a/images/lib/generators/refinery/images/images_generator.rb
+++ b/images/lib/generators/refinery/images/images_generator.rb
@@ -1,9 +1,12 @@
 module Refinery
   class ImagesGenerator < Rails::Generators::Base
+    class_option :skip_migrations, :type => :boolean, :default => false, :aliases => nil, :group => :runtime,
+                           :desc => "Skip over installing or running migrations."
+
     source_root File.expand_path('../templates', __FILE__)
 
     def rake_db
-      rake "refinery_images:install:migrations"
+      rake "refinery_images:install:migrations" unless self.options[:skip_migrations]
     end
 
     def generate_images_initializer

--- a/images/spec/lib/generators/refinery/images/images_generator_spec.rb
+++ b/images/spec/lib/generators/refinery/images/images_generator_spec.rb
@@ -9,7 +9,7 @@ module Refinery
 
     before do
       prepare_destination
-      run_generator
+      run_generator %w[--skip-migrations]
     end
 
     specify do

--- a/pages/lib/generators/refinery/pages/pages_generator.rb
+++ b/pages/lib/generators/refinery/pages/pages_generator.rb
@@ -1,9 +1,12 @@
 module Refinery
   class PagesGenerator < Rails::Generators::Base
+    class_option :skip_migrations, :type => :boolean, :default => false, :aliases => nil, :group => :runtime,
+                           :desc => "Skip over installing or running migrations."
+
     source_root File.expand_path('../templates', __FILE__)
 
     def rake_db
-      rake "refinery_pages:install:migrations"
+      rake "refinery_pages:install:migrations" unless self.options[:skip_migrations]
     end
 
     def generate_pages_initializer

--- a/pages/spec/lib/generators/refinery/pages/pages_generator_spec.rb
+++ b/pages/spec/lib/generators/refinery/pages/pages_generator_spec.rb
@@ -9,7 +9,7 @@ module Refinery
 
     before do
       prepare_destination
-      run_generator
+      run_generator %w[--skip-migrations]
     end
 
     specify do

--- a/resources/lib/generators/refinery/resources/resources_generator.rb
+++ b/resources/lib/generators/refinery/resources/resources_generator.rb
@@ -1,9 +1,12 @@
 module Refinery
   class ResourcesGenerator < Rails::Generators::Base
+    class_option :skip_migrations, :type => :boolean, :default => false, :aliases => nil, :group => :runtime,
+                           :desc => "Skip over installing or running migrations."
+
     source_root File.expand_path('../templates', __FILE__)
 
     def rake_db
-      rake "refinery_resources:install:migrations"
+      rake "refinery_resources:install:migrations" unless self.options[:skip_migrations]
     end
 
     def generate_resources_initializer

--- a/resources/spec/lib/generators/refinery/resources/resources_generator_spec.rb
+++ b/resources/spec/lib/generators/refinery/resources/resources_generator_spec.rb
@@ -9,7 +9,7 @@ module Refinery
 
     before do
       prepare_destination
-      run_generator
+      run_generator %w[--skip-migrations]
     end
 
     specify do


### PR DESCRIPTION
This makes it consistent with generated extensions.

This also makes it very slow to generate a dummy app or run the `refinery:cms` generator.
