### PR TITLE
fix for #2130, NoMethodError with dalli >2.0

### DIFF
--- a/pages/lib/refinery/pages/caching.rb
+++ b/pages/lib/refinery/pages/caching.rb
@@ -27,9 +27,9 @@ module Refinery
       def clear_caching!
         begin
           cache.delete_matched(/.*pages.*/)
-        rescue NotImplementedError
-          cache.clear
+        rescue NoMethodError, NotImplementedError
           warn "**** [REFINERY] The cache store you are using is not compatible with Rails.cache#delete_matched - clearing entire cache instead ***"
+          cache.clear
         end
       end
 


### PR DESCRIPTION
dalli now raises NoMethodError on delete_matched
fixes #2130
