### PR TITLE
rescue NoMethodError for dalli>2.x

### DIFF
--- a/pages/app/models/page.rb
+++ b/pages/app/models/page.rb
@@ -297,7 +297,7 @@ class Page < ActiveRecord::Base
     def expire_page_caching
       begin
         Rails.cache.delete_matched(/.*pages.*/)
-      rescue NotImplementedError
+      rescue NoMethodError, NotImplementedError
         Rails.cache.clear
         warn "**** [REFINERY] The cache store you are using is not compatible with Rails.cache#delete_matched - clearing entire cache instead ***"
       end


### PR DESCRIPTION
same fix against 1-0-stable
fixes #2130
