### PR TITLE
fix pages when i18n is disabled

### DIFF
--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -189,7 +189,7 @@ module Refinery
     end
 
     def translated_to_default_locale?
-      persisted? && translations.where(:locale => Refinery::I18n.default_frontend_locale).any?
+      persisted? && (!Refinery.i18n_enabled? || translations.where(:locale => Refinery::I18n.default_frontend_locale).any?)
     end
 
     # The canonical page for this particular page.


### PR DESCRIPTION
I'm not using refinerycms-i18n in one project and listing pages fails.
I think it must be fixed on master too.
