### PR TITLE
Custom Dragonfly Storage Backends

### DIFF
--- a/core/lib/generators/refinery/core/templates/config/initializers/refinery/core.rb.erb
+++ b/core/lib/generators/refinery/core/templates/config/initializers/refinery/core.rb.erb
@@ -10,6 +10,11 @@ Refinery::Core.configure do |config|
   # the default file system for storing resources and images
   config.s3_backend = !(ENV['S3_KEY'].nil? || ENV['S3_SECRET'].nil?)
 
+  # Use a custom Dragonfly storage backend instead of the default
+  # file system for storing resources and images
+  # config.custom_backend_class = <%= Refinery::Core.custom_backend_class.inspect %>
+  # config.custom_backend_opts = <%= Refinery::Core.custom_backend_opts.inspect %>
+
   # Whenever Refinery caches anything and can set a cache key, it will add
   # a prefix to the cache key containing the string you set here.
   # config.base_cache_key = <%= Refinery::Core.base_cache_key.inspect %>

--- a/core/lib/refinery/core/configuration.rb
+++ b/core/lib/refinery/core/configuration.rb
@@ -7,7 +7,8 @@ module Refinery
                     :dragonfly_secret,
                     :wymeditor_whitelist_tags, :javascripts, :stylesheets,
                     :s3_bucket_name, :s3_region, :s3_access_key_id,
-                    :s3_secret_access_key, :force_ssl, :backend_route
+                    :s3_secret_access_key, :force_ssl, :backend_route,
+                    :custom_backend_class, :custom_backend_opts
 
     self.rescue_not_found = false
     self.s3_backend = false
@@ -25,6 +26,8 @@ module Refinery
     self.s3_secret_access_key = ENV['S3_SECRET']
     self.force_ssl = false
     self.backend_route = "refinery"
+    self.custom_backend_class = ''
+    self.custom_backend_opts = {}
 
     def config.register_javascript(name)
       self.javascripts << name
@@ -41,6 +44,14 @@ module Refinery
 
       def clear_stylesheets!
         self.stylesheets = []
+      end
+
+      def custom_backend
+        config.custom_backend_class.present?
+      end
+
+      def custom_backend_class
+        custom_backend ? config.custom_backend_class.constantize : nil
       end
 
       def site_name

--- a/core/spec/lib/refinery/core/configuration_spec.rb
+++ b/core/spec/lib/refinery/core/configuration_spec.rb
@@ -32,6 +32,23 @@ module Refinery
           end
         end
       end
+
+      describe 'custom storage backend' do
+        it 'class should be nil by default' do
+          Refinery::Core.custom_backend_class.should == nil
+        end
+
+        context 'is set in core' do
+          before { class DummyBackend; end }
+          after { Refinery::Core.custom_backend_class = nil }
+          let(:backend) { DummyBackend.new }
+
+          it 'and is set to a class that exists' do
+            Refinery::Core.custom_backend_class = 'Refinery::Core::DummyBackend'
+            Refinery::Core.custom_backend_class.should == backend.class
+          end
+        end
+      end
     end
   end
 end

--- a/images/lib/generators/refinery/images/templates/config/initializers/refinery/images.rb.erb
+++ b/images/lib/generators/refinery/images/templates/config/initializers/refinery/images.rb.erb
@@ -43,4 +43,9 @@ Refinery::Images.configure do |config|
   # config.datastore_root_path = <%= Refinery::Images.datastore_root_path.inspect %>
   # config.trust_file_extensions = <%= Refinery::Images.trust_file_extensions.inspect %>
 
+  # Configure Dragonfly custom storage backend
+  # The custom_backend setting by default defers to the core setting for this but can be set just for images.
+  # config.custom_backend_class = <%= Refinery::Images.custom_backend_class.inspect %>
+  # config.custom_backend_opts = <%= Refinery::Images.custom_backend_opts.inspect %>
+
 end

--- a/images/lib/refinery/images/configuration.rb
+++ b/images/lib/refinery/images/configuration.rb
@@ -8,7 +8,8 @@ module Refinery
                     :image_views, :preferred_image_view, :datastore_root_path,
                     :s3_backend, :s3_bucket_name, :s3_region,
                     :s3_access_key_id, :s3_secret_access_key, :trust_file_extensions,
-                    :whitelisted_mime_types
+                    :whitelisted_mime_types,
+                    :custom_backend_class, :custom_backend_opts
 
     self.dragonfly_insert_before = 'ActionDispatch::Callbacks'
     self.dragonfly_secret = Refinery::Core.dragonfly_secret
@@ -57,6 +58,18 @@ module Refinery
 
       def s3_region
         config.s3_region.nil? ? Refinery::Core.s3_region : config.s3_region
+      end
+
+      def custom_backend
+        config.custom_backend_class.nil? ? Refinery::Core.custom_backend : config.custom_backend_class.present?
+      end
+
+      def custom_backend_class
+        config.custom_backend_class.nil? ? Refinery::Core.custom_backend_class : config.custom_backend_class.constantize
+      end
+
+      def custom_backend_opts
+        config.custom_backend_opts.nil? ? Refinery::Core.custom_backend_opts : config.custom_backend_opts
       end
 
     end

--- a/images/lib/refinery/images/dragonfly.rb
+++ b/images/lib/refinery/images/dragonfly.rb
@@ -35,6 +35,10 @@ module Refinery
               s3.region = Refinery::Images.s3_region if Refinery::Images.s3_region
             end
           end
+
+          if ::Refinery::Images.custom_backend
+            app_images.datastore = Refinery::Images.custom_backend_class.new(Refinery::Images.custom_backend_opts)
+          end
         end
 
         ##

--- a/resources/lib/generators/refinery/resources/templates/config/initializers/refinery/resources.rb.erb
+++ b/resources/lib/generators/refinery/resources/templates/config/initializers/refinery/resources.rb.erb
@@ -26,4 +26,9 @@ Refinery::Resources.configure do |config|
   # config.datastore_root_path = <%= Refinery::Resources.datastore_root_path.inspect %>
   # config.content_disposition = <%= Refinery::Resources.content_disposition.inspect %>
 
+  # Configure Dragonfly custom storage backend
+  # The custom_backend setting by default defers to the core setting for this but can be set just for resources.
+  # config.custom_backend_class = <%= Refinery::Resources.custom_backend_class.inspect %>
+  # config.custom_backend_opts = <%= Refinery::Resources.custom_backend_opts.inspect %>
+
 end

--- a/resources/lib/refinery/resources/configuration.rb
+++ b/resources/lib/refinery/resources/configuration.rb
@@ -6,7 +6,8 @@ module Refinery
                     :max_file_size, :pages_per_dialog, :pages_per_admin_index,
                     :s3_backend, :s3_bucket_name, :s3_region,
                     :s3_access_key_id, :s3_secret_access_key,
-                    :datastore_root_path, :content_disposition
+                    :datastore_root_path, :content_disposition,
+                    :custom_backend_class, :custom_backend_opts
 
     self.dragonfly_insert_before = 'ActionDispatch::Callbacks'
     self.dragonfly_secret = Refinery::Core.dragonfly_secret
@@ -44,6 +45,19 @@ module Refinery
       def s3_region
         config.s3_region.presence || Refinery::Core.s3_region
       end
+
+      def custom_backend
+        config.custom_backend_class.nil? ? Refinery::Core.custom_backend : config.custom_backend_class.present?
+      end
+
+      def custom_backend_class
+        config.custom_backend_class.nil? ? Refinery::Core.custom_backend_class : config.custom_backend_class.constantize
+      end
+
+      def custom_backend_opts
+        config.custom_backend_opts.nil? ? Refinery::Core.custom_backend_opts : config.custom_backend_opts
+      end
+
     end
   end
 end

--- a/resources/lib/refinery/resources/dragonfly.rb
+++ b/resources/lib/refinery/resources/dragonfly.rb
@@ -34,6 +34,10 @@ module Refinery
               s3.region = Refinery::Resources.s3_region if Refinery::Resources.s3_region
             end
           end
+
+          if ::Refinery::Resources.custom_backend
+            app_resources.datastore = Refinery::Resources.custom_backend_class.new(Refinery::Resources.custom_backend_opts)
+          end
         end
 
         ##

--- a/resources/spec/lib/resources_spec.rb
+++ b/resources/spec/lib/resources_spec.rb
@@ -18,4 +18,24 @@ describe  Refinery::Resources do
       described_class.s3_bucket_name.should == "kfc"
     end
   end
+
+  describe "with a custom storage backend" do
+    before do
+      Refinery::Core.custom_backend_class = 'DummyBackend1'
+      class DummyBackend1; end
+      class DummyBackend2; end
+    end
+    after { Refinery::Core.custom_backend_class = nil }
+    let(:backend1) { DummyBackend1.new }
+    let(:backend2) { DummyBackend2.new }
+
+    it "uses the default configuration if present" do
+      described_class.custom_backend_class.should == backend1.class
+    end
+
+    it "prefers custom values over the defaults" do
+      described_class.custom_backend_class = 'DummyBackend2'
+      described_class.custom_backend_class.should == backend2.class
+    end
+  end
 end


### PR DESCRIPTION
This code enables the use of custom written Dragonfly storage backends. I'm not sure if tests can be written for it since all it does is load a class and pass it a hash of options. All tests pass with this modification, but info about writing tests for it would be greatly appreciated.

I think you could even use this feature to use the other official Dragonfly backends.
