### PR TITLE
Bump Dragonfly for security

### DIFF
--- a/images/refinerycms-images.gemspec
+++ b/images/refinerycms-images.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.files             = `git ls-files`.split("\n")
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
-  s.add_dependency 'dragonfly',        '~> 0.9.12'
+  s.add_dependency 'dragonfly',        '~> 0.9.14'
   s.add_dependency 'refinerycms-core', version
 end


### PR DESCRIPTION
More info:
https://groups.google.com/forum/?fromgroups=#!topic/refinery-cms/IJ-g7VSl93Q
https://groups.google.com/forum/?fromgroups=#!topic/dragonfly-users/3c3WIU3VQTo

Maybe backport to 2.0 and 1.0 stables and release new versions?
