### PR TITLE
Update refinerycms-core.gemspec

### DIFF
--- a/core/refinerycms-core.gemspec
+++ b/core/refinerycms-core.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'sass-rails',                  '~> 3.2.3'
   s.add_dependency 'coffee-rails',                '~> 3.2.1'
   s.add_dependency 'uglifier',                    '>= 1.0.3'
-  s.add_dependency 'jquery-rails',                '~> 2.0.0'
+  s.add_dependency 'jquery-rails',                '~> 2.2.0'
 end


### PR DESCRIPTION
I'm working on integrating spree + refinerycms and have a problem with incompatible jquery-rails versions.
For example:
spree use s.add_dependency 'jquery-rails', '~> 2.2.0'
https://github.com/spree/spree/blob/1-3-stable/core/spree_core.gemspec#L25

refinerycms use s.add_dependency 'jquery-rails',  '~> 2.0.0'

This patch fixes the problem.
