### PR TITLE
Allow user-defined geometries in image#thumbnail_dimensions

### DIFF
--- a/images/app/models/refinery/image.rb
+++ b/images/app/models/refinery/image.rb
@@ -38,7 +38,7 @@ module Refinery
 
     # Get a thumbnail job object given a geometry.
     def thumbnail(geometry = nil)
-      if geometry.is_a?(Symbol) and Refinery::Images.user_image_sizes.keys.include?(geometry)
+      if geometry.is_a?(Symbol) && Refinery::Images.user_image_sizes.keys.include?(geometry)
         geometry = Refinery::Images.user_image_sizes[geometry]
       end
 
@@ -51,7 +51,12 @@ module Refinery
 
     # Intelligently works out dimensions for a thumbnail of this image based on the Dragonfly geometry string.
     def thumbnail_dimensions(geometry)
-      geometry = geometry.to_s
+      geometry = if geometry.is_a?(Symbol) && Refinery::Images.user_image_sizes.keys.include?(geometry)
+        Refinery::Images.user_image_sizes[geometry]
+      else
+        geometry.to_s
+      end
+
       width = original_width = self.image_width.to_f
       height = original_height = self.image_height.to_f
       geometry_width, geometry_height = geometry.split(%r{\#{1,2}|\+|>|!|x}im)[0..1].map(&:to_f)

--- a/images/spec/models/refinery/image_spec.rb
+++ b/images/spec/models/refinery/image_spec.rb
@@ -174,5 +174,15 @@ module Refinery
       end
     end
 
+    describe '#thumbnail_dimensions returns correctly with user-defined geometries' do
+      it ':medium' do
+        created_image.thumbnail_dimensions(:medium).should == { :width => 225, :height => 169 }
+      end
+
+      it ':large' do
+        created_image.thumbnail_dimensions(:large).should == { :width => 450, :height => 338 }
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Hey there,

The `image_fu` helper (and `thumbnail_dimensions` method) supported the following scenarios:
- `image_fu(image, nil)`
- `image_fu(image, "200x200")`
- `image_fu(image, "200x200#")`, etc.

With this PR now you can pass user-defined sizes (from Refinery::Images.user_image_sizes)

Example:
`image_fu(image, :medium)`
