### PR TITLE
Use find_page as a before filter and use @page

### DIFF
--- a/pages/app/controllers/refinery/pages/admin/preview_controller.rb
+++ b/pages/app/controllers/refinery/pages/admin/preview_controller.rb
@@ -5,10 +5,12 @@ module Refinery
         include Pages::InstanceMethods
         include Pages::RenderOptions
 
+        before_filter :find_page
+
         layout :layout
 
         def show
-          render_with_templates? page, :template => template
+          render_with_templates? @page, :template => template
         end
 
         protected


### PR DESCRIPTION
The new method find_page in pages preview controller does not always returns the page object as expected by render_options_for_template. It returns he params hash in the case of hash assignation (to preview existing pages) :

``` ruby
# pages/app/controllers/refinery/pages/admin/preview_controller.rb
def find_page
  if @page = Refinery::Page.find_by_path_or_id(params[:path], params[:id])
    # Preview existing pages
    @page.attributes = params[:page] # >>>>> HERE <<<<<
  elsif params[:page]
    # Preview a non-persisted page
    @page = Page.new params[:page]
  end
end
```

This break previews view view_templates as object methods are called in RenderOptions::render_options_for_template.

See changes in https://github.com/refinery/refinerycms/pull/2089/files#L2R22
