### PR TITLE
Fix custom page view template preview.

### DIFF
--- a/pages/app/controllers/refinery/pages/admin/preview_controller.rb
+++ b/pages/app/controllers/refinery/pages/admin/preview_controller.rb
@@ -10,7 +10,7 @@ module Refinery
         layout :layout
 
         def show
-          render_with_templates? @page, :template => template
+          render_with_templates?
         end
 
         protected
@@ -31,10 +31,6 @@ module Refinery
 
         def layout
           'application'
-        end
-
-        def template
-          '/refinery/pages/show'
         end
       end
     end

--- a/pages/lib/refinery/pages/render_options.rb
+++ b/pages/lib/refinery/pages/render_options.rb
@@ -8,7 +8,9 @@ module Refinery
           render_options[:layout] = page.layout_template
         end
         if Refinery::Pages.use_view_templates && page.view_template.present?
-          render_options[:action] = page.view_template
+          render_options[:template] = "refinery/pages/#{page.view_template}"
+        elsif
+          render_options[:template] = "refinery/pages/show"
         end
         render_options
       end


### PR DESCRIPTION
Using `render_options[:action] = page.view_template` does not work with refactored pages preview controller. Instead, I set relative template path (refinery/pages) is set for Pages::PreviewController (not root path as fixed in #2146)

I moved all the "default template logic" to the common Pages::RenderOptions module although not necessary for the original PagesController.
