### PR TITLE
Don't use the unsecure refinery logo when under ssl.

### DIFF
--- a/core/app/views/refinery/_site_bar.html.erb
+++ b/core/app/views/refinery/_site_bar.html.erb
@@ -8,7 +8,7 @@
       <div id='editor_switch'>
         <%= site_bar_switch_link -%>
       </div>
-      <%= link_to image_tag("#{"http://refinerycms.com/images/" unless local_request?}refinery/logo-site-bar.png", :alt => "Refinery (tm) Content Manager"),
+      <%= link_to image_tag("#{"http://refinerycms.com/images/" unless local_request? || request.ssl? }refinery/logo-site-bar.png", :alt => "Refinery (tm) Content Manager"),
                   'http://refinerycms.com',
                   :target => '_blank',
                   :id => 'site_bar_refinery_cms_logo' %>


### PR DESCRIPTION
The admin site bar references the refinery logo on refinerycms.com when in production.  This is a problem when the site is running under SSL, as it is a request for unauthenticated content.  

My preference would be to just remove the condition in the view, but I assume the reference is there for a reason.
