### PR TITLE
Remove eval from wymeditor class so closure compiler works

### DIFF
--- a/core/app/assets/javascripts/wymeditor/classes.js.erb
+++ b/core/app/assets/javascripts/wymeditor/classes.js.erb
@@ -636,9 +636,7 @@ WYMeditor.Lexer.prototype._invokeParser = function(content, is_match)
   }
   var current = this._mode.getCurrent();
   var handler = this._mode_handlers[current];
-  var result;
-  eval('result = this._parser.' + handler + '(content, is_match);');
-  return result;
+  return this._parser[handler](content, is_match);
 };
 
 /**


### PR DESCRIPTION
-- Google's closure compiler fails to deal with eval statements
   properly. In this function, it optimizes out the second parameter
   because its only use is inside an eval string. At runtime, is_match
   is undefined. By reworking the code a bit, we can now compress
   this through the closure compiler.
