### PR TITLE
Add support for Dragonfly's url_host

### DIFF
--- a/images/lib/generators/refinery/images/templates/config/initializers/refinery/images.rb.erb
+++ b/images/lib/generators/refinery/images/templates/config/initializers/refinery/images.rb.erb
@@ -39,6 +39,7 @@ Refinery::Images.configure do |config|
   # config.dragonfly_secret = <%= Refinery::Images.dragonfly_secret.inspect %>
   # If you decide to trust file extensions replace :ext below with :format
   # config.dragonfly_url_format = <%= Refinery::Images.dragonfly_url_format.inspect %>
+  # config.dragonfly_url_host = <%= Refinery::Images.dragonfly_url_host.inspect %>
   # config.datastore_root_path = <%= Refinery::Images.datastore_root_path.inspect %>
   # config.trust_file_extensions = <%= Refinery::Images.trust_file_extensions.inspect %>
 

--- a/images/lib/refinery/images/configuration.rb
+++ b/images/lib/refinery/images/configuration.rb
@@ -2,7 +2,7 @@ module Refinery
   module Images
     include ActiveSupport::Configurable
 
-    config_accessor :dragonfly_insert_before, :dragonfly_secret, :dragonfly_url_format,
+    config_accessor :dragonfly_insert_before, :dragonfly_secret, :dragonfly_url_format, :dragonfly_url_host,
                     :max_image_size, :pages_per_dialog, :pages_per_admin_index,
                     :pages_per_dialog_that_have_size_options, :user_image_sizes,
                     :image_views, :preferred_image_view, :datastore_root_path,
@@ -14,6 +14,7 @@ module Refinery
     self.dragonfly_secret = Refinery::Core.dragonfly_secret
     # If you decide to trust file extensions replace :ext below with :format
     self.dragonfly_url_format = '/system/images/:job/:basename.:ext'
+    self.dragonfly_url_host = ''
     self.trust_file_extensions = false
 
     self.max_image_size = 5242880

--- a/images/lib/refinery/images/dragonfly.rb
+++ b/images/lib/refinery/images/dragonfly.rb
@@ -20,6 +20,7 @@ module Refinery
           app_images.configure_with(:rails) do |c|
             c.datastore.root_path = Refinery::Images.datastore_root_path
             c.url_format = Refinery::Images.dragonfly_url_format
+            c.url_host = Refinery::Images.dragonfly_url_host
             c.secret = Refinery::Images.dragonfly_secret
             c.trust_file_extensions = Refinery::Images.trust_file_extensions
           end

--- a/resources/lib/generators/refinery/resources/templates/config/initializers/refinery/resources.rb.erb
+++ b/resources/lib/generators/refinery/resources/templates/config/initializers/refinery/resources.rb.erb
@@ -22,6 +22,7 @@ Refinery::Resources.configure do |config|
   # config.dragonfly_insert_before = <%= Refinery::Resources.dragonfly_insert_before.inspect %>
   # config.dragonfly_secret = <%= Refinery::Resources.dragonfly_secret.inspect %>
   # config.dragonfly_url_format = <%= Refinery::Resources.dragonfly_url_format.inspect %>
+  # config.dragonfly_url_host = <%= Refinery::Resources.dragonfly_url_host.inspect %>
   # config.datastore_root_path = <%= Refinery::Resources.datastore_root_path.inspect %>
   # config.content_disposition = <%= Refinery::Resources.content_disposition.inspect %>
 

--- a/resources/lib/refinery/resources/configuration.rb
+++ b/resources/lib/refinery/resources/configuration.rb
@@ -2,7 +2,7 @@ module Refinery
   module Resources
     include ActiveSupport::Configurable
 
-    config_accessor :dragonfly_insert_before, :dragonfly_secret, :dragonfly_url_format,
+    config_accessor :dragonfly_insert_before, :dragonfly_secret, :dragonfly_url_format, :dragonfly_url_host,
                     :max_file_size, :pages_per_dialog, :pages_per_admin_index,
                     :s3_backend, :s3_bucket_name, :s3_region,
                     :s3_access_key_id, :s3_secret_access_key,
@@ -11,6 +11,7 @@ module Refinery
     self.dragonfly_insert_before = 'ActionDispatch::Callbacks'
     self.dragonfly_secret = Refinery::Core.dragonfly_secret
     self.dragonfly_url_format = '/system/resources/:job/:basename.:format'
+    self.dragonfly_url_host = ''
 
     self.content_disposition = :attachment
     self.max_file_size = 52428800

--- a/resources/lib/refinery/resources/dragonfly.rb
+++ b/resources/lib/refinery/resources/dragonfly.rb
@@ -20,6 +20,7 @@ module Refinery
           app_resources.configure do |c|
             c.datastore.root_path = Refinery::Resources.datastore_root_path
             c.url_format = Refinery::Resources.dragonfly_url_format
+            c.url_host = Refinery::Resources.dragonfly_url_host
             c.secret = Refinery::Resources.dragonfly_secret
           end
 


### PR DESCRIPTION
This change fixes #2049 by adding configuration support for Dragonfly's url_host setting. If you set this to your CDN or other caching server, your Rails app won't get hit at all for redundant dragonfly requests. I realize that Rack::Cache is in place, but this still allows for a further optimization for image heavy sites.

I chose to stick with Dragonfly's existing configuration because the changes are seamless for the rest of Refinery. The url_host is automatically included by Dragonfly's url method. It also gives flexibility to use a different server for dragonfly images than for other static assets, for example: a passthrough CDN for dragonfly and an S3-based Cloudfront distribution for static assets.

Note that Dragonfly does not support a %d placeholder in the host string like Rails does, it only supports a single host. Also, the string must be a full url starting with the protocol scheme (http or https).
