### PR TITLE
move head tags from refinery head partial to application layout

### DIFF
--- a/core/app/views/layouts/application.html.erb
+++ b/core/app/views/layouts/application.html.erb
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <%= render "/refinery/html_tag" %>
   <% site_bar = render('/refinery/site_bar', :head => true) -%>
-  <%= render "/refinery/head" %>
+  <head>
+    <%= render "/refinery/head" %>
+  </head>
   <body id="<%= canonical_id @page %>">
     <%= site_bar -%>
     <div id="page_container">

--- a/core/app/views/refinery/_head.html.erb
+++ b/core/app/views/refinery/_head.html.erb
@@ -1,16 +1,14 @@
-<head>
-  <meta charset='<%= Rails.application.config.encoding %>' />
-  <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" /><![endif]-->
-  <title><%= browser_title(yield(:title)) %></title>
-  <%= raw %(<meta name="description" content="#{@meta.meta_description}" />) if @meta.meta_description.present? -%>
-  <%= raw %(<link rel="canonical" content="#{@canonical}" />) if @canonical.present? -%>
-  <%= csrf_meta_tags if Refinery::Core.authenticity_token_on_frontend -%>
-  <%= yield :meta %>
+<meta charset='<%= Rails.application.config.encoding %>' />
+<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" /><![endif]-->
+<title><%= browser_title(yield(:title)) %></title>
+<%= raw %(<meta name="description" content="#{@meta.meta_description}" />) if @meta.meta_description.present? -%>
+<%= raw %(<link rel="canonical" content="#{@canonical}" />) if @canonical.present? -%>
+<%= csrf_meta_tags if Refinery::Core.authenticity_token_on_frontend -%>
+<%= yield :meta %>
 
-  <%= stylesheet_link_tag "application" %>
-  <%= yield :stylesheets %>
+<%= stylesheet_link_tag "application" %>
+<%= yield :stylesheets %>
 
-  <%= render '/refinery/google_analytics' %>
+<%= render '/refinery/google_analytics' %>
 
-  <%= javascript_include_tag 'modernizr-min' %>
-</head>
+<%= javascript_include_tag 'modernizr-min' %>


### PR DESCRIPTION
Noticed that when replacing the application layout to include additional content within the head, that we had to copy over an extra refinery partial to do so. When replacing the application layout and then re-including the refinery head partial, we now had the head tags being rendered twice.
