### PR TITLE
Update and rename 4 - Extending Controllers and Models with Decorators.t...

### DIFF
--- a/doc/guides/2 - Refinery Basics/4 - Extending Controllers with Decorators.textile
+++ b/doc/guides/2 - Refinery Basics/4 - Extending Controllers with Decorators.textile
@@ -1,8 +1,8 @@
-h2. Extending Controllers and Models with Decorators
+h2. Extending Controllers with Decorators
 
-The default behavior of Refinery or a Refinery extension and its controllers and models may not be exactly what you are looking for. This guide will show you how to:
+The default behavior of Refinery or a Refinery extension and its controllers may not be exactly what you are looking for. This guide will show you how to:
 
-* Extend a Controller or Model to add new behavior
+* Extend a Controller to add new behavior
 
 endprologue.
 


### PR DESCRIPTION
...extile to 4 - Extending Controllers with Decorators.textile

I removed all mention of extending models from this file (including the title) because there is another document on extending models and this document does not provide any direction for extending models.

Will need to be pulled into 2-0-stable as well.

With this addition the link from my previous pull request will probably break now that the name of this file is different so feel free to reject that pull request and I can fix it.
