### PR TITLE
Remove marketable_urls check from find_by_path_or_id.

### DIFF
--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -73,7 +73,7 @@ module Refinery
       # and if the path is unfriendly then a different finder method is required
       # than find_by_path.
       def find_by_path_or_id(path, id)
-        if Pages.marketable_urls && path.present?
+        if path.present?
           if path.friendly_id?
             find_by_path(path)
           else

--- a/pages/spec/models/refinery/page_spec.rb
+++ b/pages/spec/models/refinery/page_spec.rb
@@ -474,11 +474,7 @@ module Refinery
       let(:path) { "market" }
       let(:id) { market.id }
 
-      context "when marketable urls are true and path is present" do
-        before do
-          Page.stub(:marketable_urls).and_return(true)
-        end
-
+      context "when path param is present" do
         context "when path is friendly_id" do
           it "finds page using path" do
             Page.find_by_path_or_id(path, "").should eq(market)
@@ -492,11 +488,7 @@ module Refinery
         end
       end
 
-      context "when id is present" do
-        before do
-          Page.stub(:marketable_urls).and_return(false)
-        end
-
+      context "when id param is present" do
         it "finds page using id" do
           Page.find_by_path_or_id("", id).should eq(market)
         end


### PR DESCRIPTION
When marketable_urls is false and only the path is passed, then neither
find_by_path nor find is triggered (ht @renechz).

Fix for #2192.
