### PR TITLE
Dynamically set attr_accessible for all defined SeoMeta attributes.

### DIFF
--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -10,7 +10,7 @@ module Refinery
 
     class Translation
       is_seo_meta
-      attr_accessible :browser_title, :meta_description, :locale
+      attr_accessible *::SeoMeta.attributes.keys, :locale
     end
 
     # Delegate SEO Attributes to globalize3 translation
@@ -19,9 +19,9 @@ module Refinery
 
     attr_accessible :id, :deletable, :link_url, :menu_match,
                     :skip_to_first_child, :position, :show_in_menu, :draft,
-                    :parts_attributes, :browser_title, :meta_description,
-                    :parent_id, :menu_title, :page_id, :layout_template,
-                    :view_template, :custom_slug, :slug, :title
+                    :parts_attributes, :parent_id, :menu_title, :page_id,
+                    :layout_template, :view_template, :custom_slug, :slug,
+                    :title, *::SeoMeta.attributes.keys
 
     validates :title, :presence => true
 


### PR DESCRIPTION
Recently I had a need to add back `meta_keywords` to SeoMeta. I struggled with properly decorating `Refinery::Page::Translation` to set `attr_accessible :meta_keywords` so I came up with a simple solution and IMO it's even better to not hardcode SeoMeta attributes but instead access them dynamically.

@parndt maybe I'm overlooking something so I need your opinion here :) 
