### PR TITLE
Add frontend_locales helper.

### DIFF
--- a/core/app/helpers/refinery/locale_helper.rb
+++ b/core/app/helpers/refinery/locale_helper.rb
@@ -1,0 +1,9 @@
+module Refinery
+  module LocaleHelper
+    def frontend_locales
+      Refinery::I18n.frontend_locales.select do |locale|
+        Refinery::I18n.locales.keys.include?(locale)
+      end
+    end
+  end
+end

--- a/core/app/views/refinery/admin/_locale_picker.html.erb
+++ b/core/app/views/refinery/admin/_locale_picker.html.erb
@@ -1,7 +1,7 @@
 <input type="hidden" name="switch_locale" id="switch_locale" value="<%= local_assigns[:current_locale] %>" />
-<% if (locales ||= Refinery::I18n.frontend_locales).present? and locales.many? %>
+<% if frontend_locales.many? %>
   <ul id="switch_locale_picker" class="clearfix">
-    <% locales.each do |locale| %>
+    <% frontend_locales.each do |locale| %>
       <li<%= %Q{ class=selected} if locale.to_s == local_assigns[:current_locale].to_s %>>
         <%= link_to refinery_icon_tag(%Q{flags/#{locale}.png}, :size => '32x22'),
                     refinery.url_for(:switch_locale => locale) %>

--- a/core/spec/helpers/refinery/locale_helper_spec.rb
+++ b/core/spec/helpers/refinery/locale_helper_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+module Refinery
+  describe LocaleHelper do
+
+    describe "#frontend_locales" do
+      it "returns frontend locales which are also specified in Refinery::I18n.locales hash" do
+        Refinery::I18n.stub(:frontend_locales).and_return([:en, :lv, :xx])
+        Refinery::I18n.stub(:locales).and_return({:en => "English", :lv => "Latviski"})
+
+        expect(helper.frontend_locales).to eq([:en, :lv])
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
It returns an array of locales which are only defined both in `Refinery::I18n.frontend_locales` and `Refinery::I18n.locales`.

This also fixes bug where user configures `Refinery::I18n.frontend_locales` to hold locales which `Refinery::I18n.locales` doesn't know about but the flags for these 'unknown' locales are still shown when creating/editing page.
