### PR TITLE
#2308 Google Analytics snippet has been outdated.

### DIFF
--- a/core/app/views/refinery/_google_analytics.html.erb
+++ b/core/app/views/refinery/_google_analytics.html.erb
@@ -1,8 +1,15 @@
 <% page_code = Refinery::Core.google_analytics_page_code.to_s.strip %>
 <% unless local_request? or refinery_user? or page_code =~ /^(UA-xxxxxx-x)?$/ -%>
-<!-- asynchronous google analytics: mathiasbynens.be/notes/async-analytics-snippet -->
-<script>var _gaq=[['_setAccount','<%= page_code %>'],['_trackPageview'],['_trackPageLoadTime']];(function(d,t){
-var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
-g.async=1;g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)
-}(document,'script'))</script>
+<!-- asynchronous google analytics snippet -->
+<script type="text/javascript">
+  var _gaq = _gaq || [];
+  _gaq.push(['_setAccount', '<%= page_code %>']);
+  _gaq.push(['_trackPageview']);
+
+  (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();
+</script>
 <% end -%>


### PR DESCRIPTION
The GA snippet has been outdated. The parameter _trackPageLoadTime has been deprecated by Google.
Sites could not be verified by Googles webmaster tools anymore based on the old script.
