### PR TITLE
Fix issue - 404 page can not use "render_with_templates?" method

### DIFF
--- a/pages/lib/refinery/pages/instance_methods.rb
+++ b/pages/lib/refinery/pages/instance_methods.rb
@@ -10,7 +10,7 @@ module Refinery
       def error_404(exception=nil)
         if (@page = ::Refinery::Page.where(:menu_match => "^/404$").includes(:parts).first).present?
           # render the application's custom 404 page with layout and meta.
-          if self.respond_to? :render_with_templates?
+          if self.respond_to? :render_with_templates?, true
             render_with_templates? @page, :status => 404
           else
             render :template => '/refinery/pages/show', :formats => [:html], :status => 404


### PR DESCRIPTION
Because "render_with_template?" is a protected method, when I use `self.respond_to? :render_with_templates?`, it returns false (which should return true I suppose). The code fixes this issue.
