### PR TITLE
Require decorators after Refinery::Core::Engine has been loaded.

### DIFF
--- a/core/lib/refinery/core.rb
+++ b/core/lib/refinery/core.rb
@@ -15,3 +15,7 @@ module Refinery
     end
   end
 end
+
+# this require has to be down here
+# see https://github.com/refinery/refinerycms/issues/2273
+require 'decorators'

--- a/core/lib/refinery/core/engine.rb
+++ b/core/lib/refinery/core/engine.rb
@@ -1,5 +1,3 @@
-require 'decorators'
-
 module Refinery
   module Core
     class Engine < ::Rails::Engine


### PR DESCRIPTION
#2273
