### PR TITLE
Remove refinery.routes initializer which broke omniauth callback to be c...

### DIFF
--- a/core/lib/refinery/core/engine.rb
+++ b/core/lib/refinery/core/engine.rb
@@ -65,12 +65,6 @@ module Refinery
         end
       end
 
-      initializer "refinery.routes", :after => :set_routes_reloader_hook do |app|
-        Refinery::Core::Engine.routes.append do
-          get '/refinery/*path' => 'admin/base#error_404'
-        end
-      end
-
       initializer "refinery.autoload_paths" do |app|
         app.config.autoload_paths += [
           Rails.root.join('app', 'presenters'),


### PR DESCRIPTION
I am using spree e-commerce and refinerycms together. I also use spree_social to add facebook authentication function to my site. However, once I gem refinerycms, even I didn't try to integrate spree and refinery user, the facebook authentication failed.

when you call OmniauthCallbacksController#passthru, it should be intercepted by omniauth and redirect to callback url, like this:

```
Started GET "/spree_user/auth/facebook" for 127.0.0.1 at 2013-07-05 12:50:54 +0800
(facebook) Calling through to underlying application for setup.
(facebook) Callback phase initiated. 
```

However, after add refinerycms, it will just go into passthru method and give me an 404 error, like this:

```
Started GET "/spree_user/auth/facebook/" for 127.0.0.1 at 2013-07-05 12:46:36 +0800
Processing by Spree::OmniauthCallbacksController#passthru as HTML
  Parameters: {"provider"=>"facebook"}
```

After trace for two days, I found the problem is caused by this initializer:

```
initializer "refinery.routes", :after => :set_routes_reloader_hook do |app|
  Refinery::Core::Engine.routes.append do
    get '/refinery/*path' => 'admin/base#error_404'
  end
end
```

I remove this initializer and omniauth works again.
In fact, I don't know why it happens, but it just works.

BTW, since you can set `config.backend_route` now, I don't think set `get '/refinery/*path' => 'admin/base#error_404`" is correct because refinery is hardcoded.

I set `config.backend_route` to "cms" now and everything is alright. So I believe this route is useless.
Could you just remove it?
