### PR TITLE
Add Code Climate badge to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ __An open source Ruby on Rails content management system for Rails 3.__
 
 More information at [http://refinerycms.com](http://refinerycms.com)
 
-[![Build Status](https://secure.travis-ci.org/refinery/refinerycms.png)](http://travis-ci.org/refinery/refinerycms)
+[![Build Status](https://secure.travis-ci.org/refinery/refinerycms.png)](http://travis-ci.org/refinery/refinerycms)  [![Code Climate](https://codeclimate.com/github/refinery/refinerycms.png)](https://codeclimate.com/github/refinery/refinerycms)
 
 ## Requirements
 


### PR DESCRIPTION
Hi,

Someone added Refinery CMS to Code Climate awhile back, and I thought you might be interested to check it out (if you haven't already).

Basically, Code Climate is my hosted static analysis tool that helps developers improve the quality of their code. It's free for OSS and the reports live here:

https://codeclimate.com/github/refinery/refinerycms

This PR just adds a dynamic badge to the README (similar to Travis) that displays the code quality GPA in case you want this information to be available to Refinery contributors.

If you have any questions or feedback, please let me know.

Cheers,
-Bryan
