### PR TITLE
Enable setting page view template by default.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -52,6 +52,7 @@
 * Added draft page support when displaying the home page. [#2298](https://github.com/refinery/refinerycms/pull/2298). [Philip Arndt](https://github.com/parndt)
 * Removed `Refinery::WINDOWS` constant. [Philip Arndt](https://github.com/parndt)
 * Removed `jquery.corner` library and invocations. [#2328](https://github.com/refinery/refinerycms/pull/2328). [Philip Arndt](https://github.com/parndt)
+* Removed `Refinery::Pages.view_template_whitelist` and `Refinery::Pages.use_view_templates` configuration options and enabled setting per page view template to be active by default. [#2331](https://github.com/refinery/refinerycms/pull/2331). [Uģis Ozols](https://github.com/ugisozols)
 * [See full list](https://github.com/refinery/refinerycms/compare/2-0-stable...master)
 
 ## 2.0.11 [unreleased]

--- a/pages/app/controllers/refinery/admin/pages_controller.rb
+++ b/pages/app/controllers/refinery/admin/pages_controller.rb
@@ -91,8 +91,7 @@ module Refinery
         @valid_layout_templates = Pages.layout_template_whitelist &
                                   Pages.valid_templates('app', 'views', '{layouts,refinery/layouts}', '*html*')
 
-        @valid_view_templates = Pages.view_template_whitelist &
-                                Pages.valid_templates('app', 'views', '{pages,refinery/pages}', '*html*')
+        @valid_view_templates = Pages.valid_templates('app', 'views', '{pages,refinery/pages}', '*html*')
       end
 
       def restrict_access

--- a/pages/app/helpers/refinery/admin/pages_helper.rb
+++ b/pages/app/helpers/refinery/admin/pages_helper.rb
@@ -12,15 +12,24 @@ module Refinery
       end
 
       def template_options(template_type, current_page)
-        return {} if current_page.send(template_type)
+        html_options = { :selected => send("default_#{template_type}", current_page) }
 
-        if current_page.parent_id?
-          # Use Parent Template by default.
-          { :selected => current_page.parent.send(template_type) }
-        else
-          # Use Default Template (First in whitelist)
-          { :selected => Refinery::Pages.send("#{template_type}_whitelist").first }
+        if (template = current_page.send(template_type).presence)
+          html_options.update :selected => template
+        elsif current_page.parent_id? && !current_page.send(template_type).presence
+          template = current_page.parent.send(template_type).presence
+          html_options.update :selected => template if template
         end
+
+        html_options
+      end
+
+      def default_view_template(current_page)
+        current_page.link_url == "/" ? "home" : "show"
+      end
+
+      def default_layout_template(current_page)
+        "application"
       end
 
       # In the admin area we use a slightly different title

--- a/pages/app/views/refinery/admin/pages/_form_advanced_options.html.erb
+++ b/pages/app/views/refinery/admin/pages/_form_advanced_options.html.erb
@@ -20,7 +20,6 @@
                    template_options(:layout_template, @page) %>
     </div>
     <% end %>
-    <% if Refinery::Pages.use_view_templates %>
     <div class='field'>
       <span class='label_with_help'>
         <%= f.label :view_template, t('.view_template') %>
@@ -29,7 +28,6 @@
       <%= f.select :view_template, @valid_view_templates.map { |t| [t.titleize, t] },
                    template_options(:view_template, @page) %>
     </div>
-    <% end %>
 
     <div class='field'>
       <span class='label_with_help'>

--- a/pages/lib/generators/refinery/pages/templates/config/initializers/refinery/pages.rb.erb
+++ b/pages/lib/generators/refinery/pages/templates/config/initializers/refinery/pages.rb.erb
@@ -47,11 +47,7 @@ Refinery::Pages.configure do |config|
 
   # config.layout_template_whitelist = <%= Refinery::Pages.layout_template_whitelist.inspect %>
 
-  # config.view_template_whitelist = <%= Refinery::Pages.view_template_whitelist.inspect %>
-
   # config.use_layout_templates = <%= Refinery::Pages.use_layout_templates.inspect %>
-
-  # config.use_view_templates = <%= Refinery::Pages.use_view_templates.inspect %>
 
   # config.page_title = <%= Refinery::Pages.page_title.inspect %>
 

--- a/pages/lib/refinery/pages/configuration.rb
+++ b/pages/lib/refinery/pages/configuration.rb
@@ -6,8 +6,7 @@ module Refinery
                     :marketable_urls, :approximate_ascii, :strip_non_ascii,
                     :default_parts, :use_custom_slugs, :scope_slug_by_parent,
                     :cache_pages_backend, :cache_pages_full, :layout_template_whitelist,
-                    :view_template_whitelist, :use_layout_templates,
-                    :use_view_templates, :page_title, :absolute_page_links, :types,
+                    :use_layout_templates, :page_title, :absolute_page_links, :types,
                     :auto_expand_admin_tree, :show_title_in_body
 
     self.pages_per_dialog = 14
@@ -22,17 +21,12 @@ module Refinery
     self.cache_pages_backend = false
     self.cache_pages_full = false
     self.layout_template_whitelist = ["application"]
-    self.view_template_whitelist = ["home", "show"]
     class << self
       def layout_template_whitelist
         Array(config.layout_template_whitelist).map(&:to_s)
       end
-      def view_template_whitelist
-        Array(config.view_template_whitelist).map(&:to_s)
-      end
     end
     self.use_layout_templates = false
-    self.use_view_templates = false
     self.page_title = {
       :chain_page_title => false,
       :ancestors => {

--- a/pages/lib/refinery/pages/render_options.rb
+++ b/pages/lib/refinery/pages/render_options.rb
@@ -7,11 +7,11 @@ module Refinery
         if Refinery::Pages.use_layout_templates && page.layout_template.present?
           render_options[:layout] = page.layout_template
         end
-        if Refinery::Pages.use_view_templates && page.view_template.present?
-          render_options[:template] = "refinery/pages/#{page.view_template}"
-        elsif
-          render_options[:template] = "refinery/pages/show"
-        end
+
+        template = page.link_url == "/" ? "home" : "show"
+
+        render_options[:template] = "refinery/pages/#{page.view_template.presence || template}"
+
         render_options
       end
 

--- a/pages/spec/controllers/refinery/pages_controller_spec.rb
+++ b/pages/spec/controllers/refinery/pages_controller_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+module Refinery
+  describe PagesController do
+    before do
+      FactoryGirl.create(:page, :link_url => "/")
+      FactoryGirl.create(:page, :title => "test")
+    end
+
+    describe "#home" do
+      it "renders home template" do
+        get :home
+        expect(response).to render_template("home")
+      end
+    end
+
+    describe "#show" do
+      it "renders show template" do
+        get :show, :path => "test"
+        expect(response).to render_template("show")
+      end
+    end
+  end
+end

--- a/pages/spec/features/refinery/admin/pages_spec.rb
+++ b/pages/spec/features/refinery/admin/pages_spec.rb
@@ -573,9 +573,7 @@ module Refinery
           context 'when parent page has templates set' do
             before do
               Refinery::Pages.stub(:use_layout_templates).and_return(true)
-              Refinery::Pages.stub(:use_view_templates).and_return(true)
               Refinery::Pages.stub(:layout_template_whitelist).and_return(['abc', 'refinery'])
-              Refinery::Pages.stub(:view_template_whitelist).and_return(['abc', 'refinery'])
               Refinery::Pages.stub(:valid_templates).and_return(['abc', 'refinery'])
               parent_page = Page.create :title => 'Parent Page',
                                         :view_template => 'refinery',

--- a/pages/spec/helpers/refinery/pages/admin/pages_helper_spec.rb
+++ b/pages/spec/helpers/refinery/pages/admin/pages_helper_spec.rb
@@ -5,40 +5,34 @@ module Refinery
     describe PagesHelper do
       describe "#template_options" do
         context "when page layout/view template is set" do
-          it "returns empty hash" do
+          it "returns those templates as selected" do
             page = FactoryGirl.create(:page)
 
             page.view_template = "rspec_template"
-            helper.template_options(:view_template, page).should eq({})
+            helper.template_options(:view_template, page).should eq(:selected => "rspec_template")
 
             page.layout_template = "rspec_layout"
-            helper.template_options(:layout_template, page).should eq({})
+            helper.template_options(:layout_template, page).should eq(:selected => "rspec_layout")
           end
         end
 
-        context "when page layout/view template is set using symbols" do
+        context "when page layout template is set using symbols" do
           before do
-            Pages.config.stub(:view_template_whitelist).and_return [:one, :two, :three]
             Pages.config.stub(:layout_template_whitelist).and_return [:three, :one, :two]
           end
 
           it "works as expected" do
-            page = FactoryGirl.create(:page)
+            page = FactoryGirl.create(:page, :layout_template => "three")
 
-            helper.template_options(:view_template, page).should eq(:selected => 'one' )
             helper.template_options(:layout_template, page).should eq(:selected => 'three')
           end
         end
 
-        context "when page layout/view template isn't set" do
-          context "when page has parent" do
-            it "returns option hash based on parent page" do
-              parent = FactoryGirl.create(:page, :view_template => "rspec_view",
-                                                 :layout_template => "rspec_layout")
+        context "when page layout template isn't set" do
+          context "when page has parent and parent has layout_template set" do
+            it "returns parent layout_template as selected" do
+              parent = FactoryGirl.create(:page, :layout_template => "rspec_layout")
               page = FactoryGirl.create(:page, :parent_id => parent.id)
-
-              expected_view = { :selected => parent.view_template }
-              helper.template_options(:view_template, page).should eq(expected_view)
 
               expected_layout = { :selected => parent.layout_template }
               helper.template_options(:layout_template, page).should eq(expected_layout)
@@ -46,18 +40,10 @@ module Refinery
           end
 
           context "when page doesn't have parent page" do
-            before do
-              Pages.config.stub(:view_template_whitelist).and_return %w(one two)
-              Pages.config.stub(:layout_template_whitelist).and_return %w(two one)
-            end
-
-            it "returns option hash with first item from configured whitelist" do
+            it "returns default application template" do
               page = FactoryGirl.create(:page)
 
-              expected_view = { :selected => "one" }
-              helper.template_options(:view_template, page).should eq(expected_view)
-
-              expected_layout = { :selected => "two" }
+              expected_layout = { :selected => "application" }
               helper.template_options(:layout_template, page).should eq(expected_layout)
             end
           end


### PR DESCRIPTION
The idea:
- enable view template selection by default in advanced form options
- remove page.view_template_whitelist
- if page.view_template isn't set then use "show" or "home" template depending on page.link_url
- if page.view_template is set then use that

This also fixes bug where show template is used to render PagesController home action.
