### PR TITLE
Changed expired Ruby Version Manager(RVM) URL in Installation Prerequisi...

### DIFF
--- a/doc/guides/1 - Getting Started/1 - Installation Prerequisites.textile
+++ b/doc/guides/1 - Getting Started/1 - Installation Prerequisites.textile
@@ -25,7 +25,7 @@ h3. Ubuntu
 
 h4. Ruby
 
-TIP. If you're planning on using Ruby a lot, the best way to install it is using the "Ruby Version Manager":https://rvm.beginrescueend.com/ (RVM)
+TIP. If you're planning on using Ruby a lot, the best way to install it is using the "Ruby Version Manager":https://rvm.io/rvm/install (RVM)
 
 <shell>sudo apt-get install ruby</shell>
 
@@ -55,7 +55,7 @@ h3. Mac OS X
 
 h4. Ruby
 
-TIP. The best way to install Ruby is using the "Ruby Version Manager":https://rvm.beginrescueend.com/ (RVM)
+TIP. The best way to install Ruby is using the "Ruby Version Manager":https://rvm.io/rvm/install (RVM)
 
 h4. Rubygems
 


### PR DESCRIPTION
...tes guide

The previous URL (https://rvm.beginrescueend.com/) no longer exists. I have changed it to point to (https://rvm.io/rvm/install)
