### PR TITLE
Improve messages when running refinerycms command with various options.

### DIFF
--- a/bin/refinerycms
+++ b/bin/refinerycms
@@ -4,7 +4,7 @@ require 'rails/generators'
 require 'rails/generators/rails/app/app_generator'
 template_path = File.expand_path('../../templates/refinery/installer.rb', __FILE__)
 
-if ARGV.size == 0 || ARGV[0] == "--help"
+def show_help_message
   puts "Usage:"
   puts "  refinerycms APP_NAME [options]"
   puts ""
@@ -22,7 +22,20 @@ if ARGV.size == 0 || ARGV[0] == "--help"
     dasherized = [option.aliases, "[#{dasherized}]"].flatten.join(', ') if option.aliases.any?
     puts "  #{dasherized}".ljust(28) << "# #{option.description}"
   end
+end
+
+if ARGV.empty?
+  show_help_message
   exit 0
+end
+
+case ARGV.first
+  when "-h", "--help"
+    show_help_message
+    exit 0
+  when "-v", "--version"
+    puts "Refinery CMS #{Gem.loaded_specs['refinerycms'].version}"
+    exit 0
 end
 
 application_name = ARGV.shift


### PR DESCRIPTION
This also:
- shows help message when no arguments are specified
- adds -h (for --help) shortcut to see help message
- adds -v, --version to see current gem version

![screen shot 2013-07-30 at 11 18 42 am](https://f.cloud.github.com/assets/148708/877364/b5ac0f02-f8f0-11e2-8c9b-7c36f4ac04d3.png)
