### PR TITLE
Page#title in menu link title attribute, when different from anchor text.

### DIFF
--- a/core/app/helpers/refinery/menu_helper.rb
+++ b/core/app/helpers/refinery/menu_helper.rb
@@ -60,6 +60,15 @@ module Refinery
       # Now use all possible vectors to try to find a valid match,
       # finally passing to rails' "current_page?" method.
       [path, URI.decode(path)].include?(url) || path == "/#{page.original_id}"
+    end 
+    
+    # Returns menu_branch.link_title only if it's different from the menu_branch.title
+    def menu_branch_link_title(menu_branch)
+      if menu_branch.title != menu_branch.link_title
+        return menu_branch.link_title
+      else
+        return nil
+      end    
     end
 
   end

--- a/core/app/views/refinery/_menu_branch.html.erb
+++ b/core/app/views/refinery/_menu_branch.html.erb
@@ -4,7 +4,7 @@
   end
 -%>
 <li<%= ['', css].compact.join(' ').gsub(/\ *$/, '').html_safe %>>
-<%= link_to(menu_branch.title, refinery.url_for(menu_branch.url)) -%>
+<%= link_to(menu_branch.title, refinery.url_for(menu_branch.url), title: menu_branch_link_title(menu_branch)) -%>
   <% if ( (children = menu_branch.children unless hide_children).present? &&
           (!local_assigns[:menu_levels] || menu_branch.ancestors.length < local_assigns[:menu_levels]) ) -%>
     <ul class='clearfix'>

--- a/core/lib/refinery/menu_item.rb
+++ b/core/lib/refinery/menu_item.rb
@@ -3,7 +3,7 @@ module Refinery
 
     class << self
       def attributes
-        [:title, :parent_id, :lft, :rgt, :depth, :url, :menu, :menu_match]
+        [:title, :link_title, :parent_id, :lft, :rgt, :depth, :url, :menu, :menu_match]
       end
 
       def apply_attributes!

--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -379,7 +379,13 @@ module Refinery
 
     def refinery_menu_title
       [page_menu_title, page_title, menu_title, title].detect(&:present?)
-    end
+    end  
+    
+    # If Page#menu_title is set, then the menu link will show Page#title in its title attribute for
+    # both SEO and accessibility purposes
+    def refinery_menu_link_title
+      [page_title, title].detect(&:present?)
+    end    
 
     def to_refinery_menu_item
       {
@@ -389,6 +395,7 @@ module Refinery
         :parent_id => parent_id,
         :rgt => rgt,
         :title => refinery_menu_title,
+        :link_title => refinery_menu_link_title,
         :type => self.class.name,
         :url => url
       }


### PR DESCRIPTION
If Page#menu_title is set, its menu link will now show Page#title in its title attribute for both SEO and accessibility purposes.

https://github.com/refinery/refinerycms/pull/2363 backport.
