### PR TITLE
Remove '_content' from section id

### DIFF
--- a/doc/guides/1 - Getting Started/2 - Getting Started.textile
+++ b/doc/guides/1 - Getting Started/2 - Getting Started.textile
@@ -221,10 +221,10 @@ Every view in Refinery has an instance variable called +@page+ available. The be
 Replace the contents of +app/views/refinery/pages/show.html.erb+ with this:
 
 <erb>
-<section id='body_content'>
+<section id='body'>
   <%=raw @page.content_for(:body) %>
 </section>
-<section id='side_body_content'>
+<section id='side_body'>
   <%=raw @page.content_for(:side_body) %>
 </section>
 </erb>


### PR DESCRIPTION
The default Home page and the CSS expect #body and #side_body. To ensure the styling is applied correctly to the About page we need to remove '_content' from the section id.
