### PR TITLE
Update menu_presenter.rb to get hide_children back and allow styling of ul

### DIFF
--- a/pages/app/presenters/refinery/pages/menu_presenter.rb
+++ b/pages/app/presenters/refinery/pages/menu_presenter.rb
@@ -11,7 +11,7 @@ module Refinery
       include ActiveSupport::Configurable
 
       config_accessor :roots, :menu_tag, :list_tag, :list_item_tag, :css, :dom_id,
-                      :max_depth, :selected_css, :first_css, :last_css
+                      :max_depth, :selected_css, :first_css, :last_css, :list_tag_css, :hide_children
       self.dom_id = 'menu'
       self.css = 'menu clearfix'
       self.menu_tag = :nav
@@ -20,6 +20,9 @@ module Refinery
       self.selected_css = :selected
       self.first_css = :first
       self.last_css = :last
+      self.list_tag_css = 'nav'
+      self.hide_children = false
+
       def roots
         config.roots.presence || collection.roots
       end
@@ -45,7 +48,7 @@ module Refinery
 
       def render_menu_items(menu_items)
         if menu_items.present?
-          content_tag(list_tag) do
+          content_tag(list_tag, :class => list_tag_css) do
             menu_items.each_with_index.inject(ActiveSupport::SafeBuffer.new) do |buffer, (item, index)|
               buffer << render_menu_item(item, index)
             end
@@ -57,6 +60,10 @@ module Refinery
         content_tag(list_item_tag, :class => menu_item_css(menu_item, index)) do
           buffer = ActiveSupport::SafeBuffer.new
           buffer << link_to(menu_item.title, context.refinery.url_for(menu_item.url))
+          if hide_children != true
+            buffer << render_menu_items(menu_item_children(menu_item))
+          end
+
           buffer << render_menu_items(menu_item_children(menu_item))
           buffer
         end


### PR DESCRIPTION
I updated the menu_presenter to have a condition with hide_children as I was using it before

I also added a list_tag_css which is usefull to style the ul (needed with twitter bootstrap nav)

I don't know if it is really interesting to integrate. It was just to let you know.
