### PR TITLE
Fix a small typo in the dutch locale for the images module.

### DIFF
--- a/images/config/locales/nl.yml
+++ b/images/config/locales/nl.yml
@@ -18,7 +18,7 @@ nl:
         actions:
           create_new_image: Nieuwe afbeelding toevoegen
         records:
-          no_images_yet: Er zijn nog geen afbeeldingen. Klik op "Nieuwe afbeelding toevoegen" om uw eerste afbleelding toe te voegen.
+          no_images_yet: Er zijn nog geen afbeeldingen. Klik op "Nieuwe afbeelding toevoegen" om uw eerste afbeelding toe te voegen.
         index:
           view:
             switch_to: De %{view_name}versie bekijken


### PR DESCRIPTION
This small typo pops up every time I create a Refinery powered website.
