### PR TITLE
Possible fix for previewing pages with inherited templates.

### DIFF
--- a/core/lib/generators/refinery/dummy/dummy_generator.rb
+++ b/core/lib/generators/refinery/dummy/dummy_generator.rb
@@ -52,6 +52,15 @@ module Refinery
       end
     end
 
+    def test_dummy_inherited_templates
+      template "rails/search_form.html.erb",
+        "#{dummy_path}/app/views/application/_search_form.html.erb",
+        :force => true
+      template "rails/searchable.html.erb",
+        "#{dummy_path}/app/views/refinery/pages/searchable.html.erb",
+        :force => true
+    end
+
     attr :database
 
   protected

--- a/core/lib/generators/refinery/dummy/templates/rails/search_form.html.erb
+++ b/core/lib/generators/refinery/dummy/templates/rails/search_form.html.erb
@@ -1,0 +1,1 @@
+Form application/search_form

--- a/core/lib/generators/refinery/dummy/templates/rails/searchable.html.erb
+++ b/core/lib/generators/refinery/dummy/templates/rails/searchable.html.erb
@@ -1,0 +1,1 @@
+<%%= render 'search_form' %>

--- a/pages/app/controllers/refinery/pages/admin/preview_controller.rb
+++ b/pages/app/controllers/refinery/pages/admin/preview_controller.rb
@@ -1,11 +1,14 @@
 module Refinery
   module Pages
     module Admin
-      class PreviewController < AdminController
-        include Pages::InstanceMethods
+      class PreviewController < Refinery::PagesController
+        include ::Refinery::ApplicationController
+        helper ApplicationHelper
+        helper Refinery::Core::Engine.helpers
+        include Refinery::Admin::BaseController
         include Pages::RenderOptions
 
-        before_filter :find_page
+        skip_before_filter :error_404, :set_canonical
 
         layout :layout
 

--- a/pages/spec/features/refinery/admin/pages_spec.rb
+++ b/pages/spec/features/refinery/admin/pages_spec.rb
@@ -252,6 +252,18 @@ module Refinery
               ::I18n.t('switch_to_website', :scope => 'refinery.site_bar')
             )
           end
+
+          it 'will show pages with inherited templates', :js do
+            visit refinery.admin_pages_path
+
+            find('a[tooltip^=Edit]').click
+            fill_in 'Title', :with => 'Searchable'
+            click_link 'Advanced options'
+            select 'Searchable', :from => 'View template'
+            click_button 'Preview'
+
+            new_window_should_have_content('Form application/search_form')
+          end
         end
 
         context 'a brand new page' do


### PR DESCRIPTION
There is an issue with previewing pages, which uses templates inheritance.
Rails fails to find partials from views/refinery/pages and views/application folders, because `Refinery::Pages::Admin::PreviewController` not inherited from `Refinery::PagesController`.
It fails with exception message: 

```
Missing partial refinery/pages/admin/preview/inherited_partial, refinery/admin/inherited_partial with {:locale=>[:en], :formats=>[:html], :handlers=>[:erb, :builder, :coffee]}.
```

Example app for this issue:
https://github.com/Rakoth/refienry-2.1.0-pages-preview
