### PR TITLE
Preventing a scenario where, in some rare/odd cases a Refinery::Menu ite...

### DIFF
--- a/core/lib/refinery/menu.rb
+++ b/core/lib/refinery/menu.rb
@@ -30,7 +30,7 @@ module Refinery
 
     protected
     def minimum_depth
-      map(&:depth).min
+      map(&:depth).compact.min
     end
 
   end


### PR DESCRIPTION
...m has a nil depth, we don't want it to cause an issue when getting the min depth
