### PR TITLE
Added pages_helper back for backwards compatibility

### DIFF
--- a/pages/app/helpers/refinery/pages_helper.rb
+++ b/pages/app/helpers/refinery/pages_helper.rb
@@ -1,0 +1,5 @@
+module Refinery
+  module PagesHelper
+
+  end
+end


### PR DESCRIPTION
I recently upgraded my RefineryCMS from 2-0-stable 2.0.10 to 2.1.0 and had a problem of a missing pages_helper.rb I had to create a pages helper directly in my application which I don't think makes sense. It was removed here a94b6712f1739abfac567af06b5b3b5e4629e0ce There's a a pages_controller, page.rb model, page views etc. in refinery so it follows to expect to have a helper to override.
