### PR TITLE
Require refinery/pages/url when it's used, not in the spec.

### DIFF
--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -1,6 +1,7 @@
 # Encoding: utf-8
 require 'friendly_id'
 require 'refinery/core/base_model'
+require 'refinery/pages/url'
 
 module Refinery
   class Page < Core::BaseModel

--- a/pages/spec/lib/refinery/pages/url_spec.rb
+++ b/pages/spec/lib/refinery/pages/url_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require 'refinery/pages/url'
 
 module Refinery
   module Pages


### PR DESCRIPTION
Per https://groups.google.com/forum/#!msg/refinery-cms/L9Im-h8MJmE/Oi0aaj725ggJ
