### PR TITLE
Fixed Image.thumbnail incorrectly thumbnailing when geometry is nil, causing Dragonfly to fail

### DIFF
--- a/images/app/models/refinery/image.rb
+++ b/images/app/models/refinery/image.rb
@@ -38,10 +38,10 @@ module Refinery
 
     # Get a thumbnail job object given a geometry and whether to strip image profiles and comments.
     def thumbnail(options = {})
-      options = { :geometry => :no_geometry, :strip => true }.merge(options)
+      options = { :geometry => nil, :strip => true }.merge(options)
       geometry = convert_to_geometry(options[:geometry])
       thumbnail = image
-      thumbnail = thumbnail.thumb(geometry) unless geometry.is_a?(Symbol)
+      thumbnail = thumbnail.thumb(geometry) if geometry
       thumbnail = thumbnail.strip if options[:strip]
       thumbnail
     end

--- a/images/spec/models/refinery/image_spec.rb
+++ b/images/spec/models/refinery/image_spec.rb
@@ -79,6 +79,11 @@ module Refinery
         created_image.thumbnail(:geometry => '200x200').url.should_not == created_image.thumbnail(:geometry => '200x201').url
       end
 
+      it "doesn't call thumb when geometry is nil" do
+        created_image.image.should_not_receive(:thumb)
+        created_image.thumbnail(geometry: nil)
+      end
+
       it "uses right geometry when given a thumbnail name" do
         name, geometry = Refinery::Images.user_image_sizes.first
         created_image.thumbnail(:geometry => name).url.should == created_image.thumbnail(:geometry => geometry).url


### PR DESCRIPTION
Changed default option for geometry to nil.
Changed thumbnail.thumb to only occur when geometry is present, otherwise return original.
Added supporting test to ensure that when geometry is nil, thumb is not called on the image.

Scenario to reproduce this is calling image_fu on an image and not supplying geometry.
