### PR TITLE
Rename globalize and change version to allow 4.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'seo_meta', github: 'parndt/seo_meta', branch: 'master'
 
 # Fixes uniqueness constraint on translated columns.
 # See: https://github.com/svenfuchs/globalize3/pull/121
-gem 'globalize3', github: 'svenfuchs/globalize3', branch: 'rails4'
+gem 'globalize', github: 'globalize/globalize', branch: 'master'
 gem 'paper_trail', github: 'airblade/paper_trail', branch: 'master'
 gem 'awesome_nested_set', github: 'collectiveidea/awesome_nested_set', branch: 'master'
 

--- a/pages/lib/refinery/pages.rb
+++ b/pages/lib/refinery/pages.rb
@@ -46,7 +46,7 @@ end
 
 ActiveSupport.on_load(:active_record) do
   require 'awesome_nested_set'
-  require 'globalize3'
+  require 'globalize'
 end
 require 'friendly_id'
 require 'seo_meta'

--- a/pages/refinerycms-pages.gemspec
+++ b/pages/refinerycms-pages.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
   s.add_dependency 'friendly_id',                 '>= 5.0.0.beta1'
-  s.add_dependency 'globalize3',                  '~> 0.3.0'
+  s.add_dependency 'globalize',                  '>= 3.0.0'
   s.add_dependency 'awesome_nested_set',          '~> 3.0.0.rc.1'
   s.add_dependency 'seo_meta',                    '~> 1.4.0'
   s.add_dependency 'refinerycms-core',            version


### PR DESCRIPTION
Hi Guys,

I notice the globalize gem has had come name/version changes that breaks master.

It has moved form `svenfuchs/globalize3` to `globalize/globalize` and there is no longer a rails4 branch.

The rails 4 stuff is now in master and has the version 4.0.0.alpha.1

Is pages the only thing referencing globalize?
