### PR TITLE
fix regex bug.

### DIFF
--- a/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/settings/edit.html.erb
+++ b/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/settings/edit.html.erb
@@ -1,4 +1,4 @@
-<%% if @setting.name.to_s.titleize =~ /R|recipients$/ %>
+<%% if @setting.name.to_s.titleize =~ /(R|r)ecipients$/ %>
   <%%= render 'notification_recipients_form', :edit => true -%>
 <%% else %>
   <%%= render 'confirmation_email_form', :edit => true -%>


### PR DESCRIPTION
the current regex (/R|recipients$/) won't work if someone has a form engine named "friend referrals", since the title-ized setting names become "Friend Referral Confirmation Body" and "Friend Referral Notification Recipients" . Both match that regex. 
