### PR TITLE
Image metadata should not be stripped from thumbnails by default

### DIFF
--- a/images/app/models/refinery/image.rb
+++ b/images/app/models/refinery/image.rb
@@ -38,7 +38,7 @@ module Refinery
 
     # Get a thumbnail job object given a geometry and whether to strip image profiles and comments.
     def thumbnail(options = {})
-      options = { :geometry => nil, :strip => true }.merge(options)
+      options = { :geometry => nil, :strip => false }.merge(options)
       geometry = convert_to_geometry(options[:geometry])
       thumbnail = image
       thumbnail = thumbnail.thumb(geometry) if geometry


### PR DESCRIPTION
As per the discussion [here](https://github.com/refinery/refinerycms/pull/2261#issuecomment-29126082), it makes sense for the default behaviour of `Refinery::Image#thumbnail` to be consistent with that of Dragonfly and ImageMagick, i.e. not stripping metadata from images by default. This avoids unexpected behaviour.
