### PR TITLE
Moved RDBMS gems into groups in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,13 +22,17 @@ unless ENV['TRAVIS']
 end
 
 if !ENV['TRAVIS'] || ENV['DB'] == 'mysql'
-  gem 'activerecord-jdbcmysql-adapter', '>= 1.3.0.rc1', :platform => :jruby
-  gem 'mysql2', :platform => :ruby
+  group :mysql do
+    gem 'activerecord-jdbcmysql-adapter', '>= 1.3.0.rc1', :platform => :jruby
+    gem 'mysql2', :platform => :ruby
+  end
 end
 
 if !ENV['TRAVIS'] || ENV['DB'] == 'postgresql'
-  gem 'activerecord-jdbcpostgresql-adapter', '>= 1.3.0.rc1', :platform => :jruby
-  gem 'pg', :platform => :ruby
+  group :postgres do  
+    gem 'activerecord-jdbcpostgresql-adapter', '>= 1.3.0.rc1', :platform => :jruby
+    gem 'pg', :platform => :ruby
+  end
 end
 
 group :test do


### PR DESCRIPTION
I've wrapped the mysql2 and pg gems inside of groups to allow users to choose whether or not they'd like to install a respective RDBMS gem. The previous Gemfile would install both MySQL and PostgreSQL gems if Travis was not found in the shell environment. To choose which RDBMS gem you'd like to use, you can run `bundle install --without mysql` to install pg ONLY, or you can run `bundle install --without postgres` to install mysql2 ONLY. This should work whether or not Travis is found.
