### PR TITLE
Bump selenium-webdriver ~> 2.38.0.

### DIFF
--- a/testing/refinerycms-testing.gemspec
+++ b/testing/refinerycms-testing.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'factory_girl_rails',      '~> 4.2.1'
   s.add_dependency 'rspec-rails',             '~> 2.13'
   s.add_dependency 'capybara',                '~> 2.1.0'
-  s.add_dependency 'selenium-webdriver',      '~> 2.35.1'
+  s.add_dependency 'selenium-webdriver',      '~> 2.38.0'
 end


### PR DESCRIPTION
Originally from https://github.com/refinery/refinerycms/commit/d36ca50c9f998242cb655baad458e6d7a727c4f9#commitcomment-4835682.
