### PR TITLE
Update 3 - Upgrading to the Latest Stable Version.textile

### DIFF
--- a/doc/guides/6 - Updating Refinery/3 - Upgrading to the Latest Stable Version.textile
+++ b/doc/guides/6 - Updating Refinery/3 - Upgrading to the Latest Stable Version.textile
@@ -33,7 +33,7 @@ Use the rails generator to update your Refinery installation:
 TIP: You only need to run the below step when upgrading between major or minor versions. Bug fix releases should not change the database structure. For example, if you are going from 1.0.3 -> 1.0.8 (Bugfix) you do not need to run this command. 
 
 <shell>
-$ bundle exec rails generate refinery:cms --update
+$ rails generate refinery:cms --update
 </shell>
 
 Database migrations and new gem dependencies may have been added, so finish your Refinery update with:


### PR DESCRIPTION
`rails generate refinerycms --update` now results in `Could not find generator refinerycms.`
