### PR TITLE
Use before_inclusion hooks to register plugins.

### DIFF
--- a/core/lib/generators/refinery/engine/templates/lib/refinery/plural_name/engine.rb.erb
+++ b/core/lib/generators/refinery/engine/templates/lib/refinery/plural_name/engine.rb.erb
@@ -6,7 +6,7 @@ module Refinery
 
       engine_name :refinery_<%= extension_plural_name %>
 
-      initializer "register refinerycms_<%= plural_name %> plugin" do
+      before_inclusion do
         Refinery::Plugin.register do |plugin|
           plugin.name = "<%= plural_name %>"
           plugin.url = proc { Refinery::Core::Engine.routes.url_helpers.<%= namespacing.underscore %>_admin_<%= plural_name %>_path }

--- a/core/lib/generators/refinery/form/templates/lib/refinery/plural_name/engine.rb.erb
+++ b/core/lib/generators/refinery/form/templates/lib/refinery/plural_name/engine.rb.erb
@@ -6,7 +6,7 @@ module Refinery
 
       engine_name :refinery_<%= extension_plural_name %>
 
-      initializer "register refinerycms_<%= plural_name %> plugin" do
+      before_inclusion do
         Refinery::Plugin.register do |plugin|
           plugin.name = "<%= plural_name %>"
           plugin.url = proc { Refinery::Core::Engine.routes.url_helpers.<%= namespacing.underscore %>_admin_<%= plural_name %>_path }


### PR DESCRIPTION
Fixes issue #2267 for the 2.1 stable branch.
