### PR TITLE
gemspec for refinerycms-pages now depends on globalize ~> 3.1

### DIFF
--- a/pages/refinerycms-pages.gemspec
+++ b/pages/refinerycms-pages.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
   s.add_dependency 'friendly_id',                 '~> 4.0.9'
-  s.add_dependency 'globalize',                   '~> 3.0.1'
+  s.add_dependency 'globalize',                   '~> 3.1.0'
   s.add_dependency 'awesome_nested_set',          '~> 2.1.3'
   s.add_dependency 'seo_meta',                    '~> 1.4.0'
   s.add_dependency 'refinerycms-core',            version


### PR DESCRIPTION
Done to support uniqueness scopes on ActiveRecord >= 3.1
