### PR TITLE
Tell friendly_id to regenerate slug if title has changed.

### DIFF
--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -37,6 +37,11 @@ module Refinery
       end
     end
 
+    # If title changes tell friendly_id to regenerate slug when saving record
+    def should_generate_new_friendly_id?
+      changes.keys.include?("title")
+    end
+
     # Delegate SEO Attributes to globalize translation
     delegate(*(Translation.seo_fields << {:to => :translation}))
 

--- a/pages/spec/models/refinery/page_spec.rb
+++ b/pages/spec/models/refinery/page_spec.rb
@@ -293,6 +293,19 @@ module Refinery
       end
     end
 
+    describe "#should_generate_new_friendly_id?" do
+      context "when title changes" do
+        it "regenerates slug upon save" do
+          page = Page.create!(:title => "Test Title")
+
+          page.title = "Test Title 2"
+          page.save!
+
+          expect(page.slug).to eq("test-title-2")
+        end
+      end
+    end
+
     context 'content sections (page parts)' do
       before do
         page.parts.new(:title => 'body', :content => "I'm the first page part for this page.", :position => 0)


### PR DESCRIPTION
This is due change in friendly_id 5.0.x where it doesn’t regenerate slug when record is saved.

Directly from https://github.com/norman/friendly_id readme:

> Slugs are no longer regenerated when a record is saved. If you want to regenerate a slug, you must explicitly set the slug column to nil.
> 
> You can restore some of the old behavior by overriding the should_generate_new_friendly_id? method.
