### PR TITLE
Use correct attribute (href) in canonical link. Full path preferred.

### DIFF
--- a/core/app/views/refinery/_head.html.erb
+++ b/core/app/views/refinery/_head.html.erb
@@ -2,7 +2,7 @@
 <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" /><![endif]-->
 <title><%= browser_title(yield(:title)) %></title>
 <%= raw %(<meta name="description" content="#{@meta.meta_description}" />) if @meta.meta_description.present? -%>
-<%= raw %(<link rel="canonical" content="#{@canonical}" />) if @canonical.present? -%>
+<%= raw %(<link rel="canonical" href="#{request.protocol}#{request.host_with_port}#{@canonical}" />) if @canonical.present? -%>
 <%= csrf_meta_tags if Refinery::Core.authenticity_token_on_frontend -%>
 <%= yield :meta %>
 

--- a/pages/spec/features/refinery/pages_spec.rb
+++ b/pages/spec/features/refinery/pages_spec.rb
@@ -156,6 +156,14 @@ module Refinery
       before do
         Page.stub(:fast_menu).and_return([page_cs])
       end
+      
+      describe 'canonical url' do
+        it 'should have a canonical url' do
+          visit '/about-us'
+
+          page.should have_selector('head link[rel="canonical"][href^="http://www.example.com/about-us"]', visible: false)
+        end
+      end
 
       describe 'not set' do
         it 'makes friendly_id from title' do


### PR DESCRIPTION
Canonical link tag fails to validate. Link attribute should be `href` not `content`. Also changed to absolute link by default, [as recommended by Google](https://support.google.com/webmasters/answer/139394).
