### PR TITLE
Use current dragonfly api to setup datastore.

### DIFF
--- a/images/lib/refinery/images/dragonfly.rb
+++ b/images/lib/refinery/images/dragonfly.rb
@@ -31,7 +31,7 @@ module Refinery
             }
             # S3 Region otherwise defaults to 'us-east-1'
             options.update(region: Refinery::Images.s3_region) if Refinery::Images.s3_region
-            app_images.datastore :s3, options
+            app_images.use_datastore :s3, options
           end
 
           if Images.custom_backend?

--- a/resources/lib/refinery/resources/dragonfly.rb
+++ b/resources/lib/refinery/resources/dragonfly.rb
@@ -32,7 +32,7 @@ module Refinery
               secret_access_key: Refinery::Resources.s3_secret_access_key
             }
             options.update(region: Refinery::Resources.s3_region) if Refinery::Resources.s3_region
-            app_resources.datastore :s3, options
+            app_resources.use_datastore :s3, options
           end
 
           if Resources.custom_backend?


### PR DESCRIPTION
I did an upgrade from Refinery CMS 2.1.1 and run into issue where I couldn't compile assets because it was  throwing an exception. In the process of debugging I found out that we're not using current dragonfly api.
