### PR TITLE
2544: explain the 'author missing' gemspec warning; change engine -> extension where appropriate

### DIFF
--- a/doc/guides/1 - Getting Started/3 - Generate an Extension to Use Your MVCs.textile
+++ b/doc/guides/1 - Getting Started/3 - Generate an Extension to Use Your MVCs.textile
@@ -25,9 +25,9 @@ This guide does not assume that you have any prior experience with Refinery beyo
 
 h3. The Anatomy of an Extension
 
-Think of a Refinery extension as a miniature Rails application running in your +vendor/extensions+ directory. Each extension specifies its own routes in its config directory and has its own views and controllers in its own app directory. In fact, each extension is actually a *Rails engine.*  Engines can serve up their own images, stylesheets and javascripts by utilizing the asset pipeline, which got introduced in Rails 3.1.  You can define your own models, views, and controllers in an extension and they can take full advantage of all of the functionality that Refinery offers.  
+Think of a Refinery extension as a miniature Rails application running in your +vendor/extensions+ directory. Each extension specifies its own routes in its config directory and has its own views and controllers in its own app directory. In fact, each extension is actually a *Rails E.*  Es can serve up their own images, stylesheets and javascripts by utilizing the asset pipeline, which got introduced in Rails 3.1.  You can define your own models, views, and controllers in an extension and they can take full advantage of all of the functionality that Refinery offers.  
 
-Since an extension is a kind of engine, it has the same familiar directory structure.  You'll see folders for your models, views, controllers, helpers, decorators, config, and so forth.  Your code goes in those folders just as it does in a regular Rails application or engine.
+Since an extension is a kind of E, it has the same familiar directory structure.  You'll see folders for your models, views, controllers, helpers, decorators, config, and so forth.  Your code goes in those folders just as it does in a regular Rails application or E.
 
 
 h3. Generating an extension
@@ -38,7 +38,7 @@ Refinery ships with an extension generator that makes adding your own functional
 $ rails generate refinery:engine singular_model_name attribute:type [attribute:type ...]
 </shell>
 
-TIP: to see all the options supported by the +refinery:engine+ generator just run +rails g refinery:engine+.
+TIP: to see all the options supported by the +refinery:E+ generator just run +rails g refinery:E+.
 
 Here is a list of the most often used field types and what they give you:
 
@@ -105,7 +105,7 @@ Please restart your rails server.
 ------------------------
 </shell>
 
-As the output shows next run:
+As the output shows, next run these commands:
 
 <shell>
 $ bundle install
@@ -114,11 +114,21 @@ $ rake db:migrate
 $ rake db:seed
 </shell>
 
-A +refinery:events+ generator is created for you to install the migration to create the events table.
+A line for the events extension has been added in the Gemfile of your application. +bundle install+ will verify and load the extension.  A generator has been created for you that will automatically create the event table and db seed calls for you: +rails generate refinery:events+ will generate the migration and db seed files for the extension based on the fields you specified in the +rails generate refinery:engine ...+ command.  And finally, running +rake db:migrate+ and +rake db:seed+ will load and run the migration and db:seed files that you just generated for the events extension. .
+
+When you run bundle install, you may see a message that says
+
+<shell>
+...extensions/events did not have a valid gemspec. This prevents bundler from installing bins or native extensions, but that may not affect its functionality. The validation message from Rubygems was: 
+   authors may not be empty
+</shell>
+
+This is a warning message from RubyGems telling you that no author is specified for this extension.  This is only important if you are going to create a gem from this extension.  You can safely ignore this message.  If you do want to resolve it and get rid of the message, you can edit the "gem specification file":http://guides.rubygems.org/specification-reference/ for the extension  +refinerycms-events.gemspec+ and put your name in there as the author. Just put this line: +s.author = 'yourname'+ in the do block (after the +s.version....+ line is fine). 
+
 
 TIP: When new extensions are added it's a good idea to restart your server for new changes to be loaded in.
 
-TIP: Models in Refinery engines expect a string field that acts as the title identifier when displayed in lists in the admin pages. If a title field is not included, the first string field found will be used. Models without a usable field for a title will cause the admin to raise an error, so please include a title field or alias when creating models in your engine.
+TIP: Models in Refinery extensions expect a string field that acts as the title identifier when displayed in lists in the admin pages. If a title field is not included, the first string field found will be used. Models without a usable field for a title will cause the admin to raise an error, so please include a title field or alias when creating models in your extensions.
 
 Now go to the backend of your Refinery site ("http://localhost:3000/refinery":http://localhost:3000/refinery) and you'll notice a new tab called "Events". Click on "Add new event" and you'll see something like this:
 
@@ -140,9 +150,9 @@ But I've noticed one problem. The "2011 Music Awards" is showing up in the middl
 
 h3. Testing your extension
 
-There is a separate guide which covers this subject found at "How to Test Your Engine":/guides/testing/.
+There is a separate guide which covers this subject found at "Testing Your Extension":/guides/testing/.
 
-h3. Crudify: The Backbone of Refinery Engines
+h3. Crudify: The Backbone of Refinery Extensions
 
 Any Refinery extension, even the built-in ones, that focus on Create, Read, Update and Delete are driven by crudify. Crudify is a highly reusable module included with Refinery that gives you all the standard CRUD actions as well as reordering, searching and paging.
 


### PR DESCRIPTION
Changes to the Getting Started/ 3 - Generate an Extension... guide:
1. changed "engine" to "extension" where appropriate
2. updated the reference to the testing guide to use the correct guide title
3. Put in some explanation about the commands to run after generating the extension.  This will be obvious to anyone with some rails experience, but will provide some context and explanation to newbies.
4. Issue #2544 - put in an explanation of the bundler/RubyGem warning about missing author from the .gemspec file.  I'm not sure if there's agreement about what should/shouldn't be put in the guide for this issue.  The wording I put in starts with "When you run bundle install, you may see a message that says..."
