### PR TITLE
Add onOpenDialog and onCloseDialog javascript to admin.js

### DIFF
--- a/core/app/assets/javascripts/refinery/admin.js.erb
+++ b/core/app/assets/javascripts/refinery/admin.js.erb
@@ -94,6 +94,24 @@ init_modal_dialogs = function(){
   });
 };
 
+onOpenDialog = function(dialog) {
+  if ($('.ui-dialog').height() < $(window).height()) {
+    if(iframed()) {
+      $(parent.document.body).addClass('hide-overflow');
+    } else {
+      $(document.body).addClass('hide-overflow');
+    }
+  }
+};
+
+onCloseDialog = function(dialog) {
+  if(iframed()) {
+    $(parent.document.body).removeClass('hide-overflow');
+  } else {
+    $(document.body).removeClass('hide-overflow');
+  }
+};
+
 refinery_dialog_success = function(e) {
   close_dialog();
 


### PR DESCRIPTION
The refinerycms-page-images gem breaks without the wymeditor. I debugged the javascript, and it was missing the onOpenDialog and onCloseDialog routines. They were dragged along with the wymeditor extraction.

There are already init_modal_dialogs and similar javascript in admin.js.erb so I added them there.
