### PR TITLE
add authors to engine gemspec template

### DIFF
--- a/core/lib/generators/refinery/engine/templates/refinerycms-extension_plural_name.gemspec
+++ b/core/lib/generators/refinery/engine/templates/refinerycms-extension_plural_name.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |s|
   s.description       = 'Ruby on Rails <%= extension_plural_name.titleize %> extension for Refinery CMS'
   s.date              = '<%= Time.now.strftime('%Y-%m-%d') %>'
   s.summary           = '<%= extension_plural_name.titleize %> extension for Refinery CMS'
+  s.authors           = ['Your Name(s) Here']
   s.require_paths     = %w(lib)
   s.files             = Dir["{app,config,db,lib}/**/*"] + ["readme.md"]
 


### PR DESCRIPTION
Gemspecs are not valid without authors, so adding this reminder placeholder saves a little trial and error when attempting to release an engine as a gem.
