### PR TITLE
Move wymeditor javascript to after application.

### DIFF
--- a/core/app/views/refinery/admin/_javascripts.html.erb
+++ b/core/app/views/refinery/admin/_javascripts.html.erb
@@ -4,10 +4,10 @@
 </script>
 <%= javascript_include_tag 'admin' -%>
 <%= javascript_include_tag 'refinery/refinery' -%>
+<%= javascript_include_tag 'refinery/application' -%>
 <% visual_editor_javascripts.each do |js| %>
   <%= javascript_include_tag js %>
 <% end %>
-<%= javascript_include_tag 'refinery/application' -%>
 <%= yield :after_javascript_libraries -%>
 <% custom_javascripts.each do |js| %>
   <%= javascript_include_tag js %>


### PR DESCRIPTION
Wymeditor javascripts use functionality included by the 'refinery/application' manifest. Therefore, it must be included afterwards.

This change in conjunction with my other pull request - parndt/refinerycms-wymeditor#10 fixes a problem where refinery/admin.js would be included twice, initialising refinery admin twice, so ajax pagination would trigger two ajax requests when clicking a page change rather than just the desired one.

This should fix the failing test `core/spec/features/refinery/admin/xhr_paging_spec.rb`.
