### PR TITLE
Fix Javascript for enabling Plugin access

### DIFF
--- a/authentication/app/views/refinery/admin/users/_form.html.erb
+++ b/authentication/app/views/refinery/admin/users/_form.html.erb
@@ -86,7 +86,7 @@
   <script>
     $(document).ready(function() {
       $('#user_plugins_enable_all').click(function(e, a) {
-        $('div.field.plugin_access ul#plugins li input:checkbox').attr('checked', true);
+        $('div.field.plugin_access ul#plugins li input:checkbox').prop('checked', true);
         e.preventDefault();
       });
     });


### PR DESCRIPTION
I just noticed the javascript is broken. jQuery 1.6+ now uses `.prop`.
