### PR TITLE
Add Catalan (es-CT) translations

### DIFF
--- a/authentication/config/locales/es-CT.yml
+++ b/authentication/config/locales/es-CT.yml
@@ -1,0 +1,74 @@
+es-CT:
+  refinery:
+    plugins:
+      refinery_users:
+        title: Usuaris
+        description: Gestionar usuaris
+    admin:
+      users:
+        delete: Esborrar a aquest usuari per sempre
+        edit: Editar aquest usuari
+        update:
+          lockout_prevented: "No pots eliminar el plugin 'Usuaris' per a l'usuari actual."
+        form:
+          blank_password_keeps_current: "Deixar la contrasenya en blanc mantindrà l'actual"
+          plugin_access: Gestionar plugins
+          role_access: Gestionar rols
+          enable_all: permetre tot
+        actions:
+          create_new_user: Crear nou usuari
+        user:
+          email_user: Enviar un email a aquest usuari
+          preview: '(%{who}) creat %{created_at}'
+    sessions:
+      new:
+        hello_please_sign_in: "Hola! Per favor, identifica't."
+        sign_in: Entrar
+        forgot_password: He oblidat la meva contrasenya
+    user_mailer:
+      reset_notification:
+        subject: Enllaç per canviar la teva contrasenya
+        reset_request_received_for: "Petició de restabliment de contrasenya rebut per %{username}"
+        visit_this_url: Visita aquesta URL per establir una contrasenya nova
+        remain_same_if_no_action: La contrasenya serà la mateixa si no realitzes aquesta acció
+    users:
+      new:
+        fill_form: Emplena els detalls següents per poder començar.
+        sign_up: Registrar-me
+      create:
+        welcome: 'Benvingut a Refinery, %{who}.'
+      forgot:
+        email_address: Adreça e-mail
+        enter_email_address: "Indica l'e-mail del teu compte."
+        reset_password: Resetear contrasenya
+        blank_email: No has indicat un e-mail vàlid.
+        email_not_associated_with_account_html: "Perdò, però, '%{email}' no està associat a cap compte.<br />Segur que ho has teclejat correctament?"
+        email_reset_sent: "T'hem enviat un e-mail amb un enllaç per canviar la teva contrasenya."
+        password_encryption: "Necessites restablir la teva contrasenya perque va haver-hi canvis en els mètodes d'encriptació de contrasenyes que Refinery usa, ja que ara les contrasenyes són emmagatzemades amb una encriptació més forta que abans."
+      reset:
+        code_invalid: "Ho sentim, però aquest codi per canviar la contrasenya ha expirat o no és vàlid. Si tens problemes intenta copiar i pegar l'adreça des de l'e-mail que t'enviem o comença de nou el procés per canviar la contrasenya."
+        successful: "Contrasenya canviada correctament per a '%{email}'"
+        pick_new_password_for: "Tria una nova contrasenya per a %{email}"
+        reset_password: Canviar contrasenya
+    roles:
+      superuser: Superusuari
+      refinery: Refinery
+  devise:
+    failure:
+      unauthenticated: Necessites accedir al teu compte o registrar-te abans de continuar.
+      invalid: Contrasenya o Email incorrecte.
+      not_found_in_database: "Sorry, your login or password was incorrect."
+    sessions:
+      signed_in: 'Has accedit correctament.'
+  activerecord:
+    models:
+      refinery/user: usuari
+    attributes:
+      refinery/user:
+        login: Usuari o email
+        username: Usuari
+        password: Contrasenya
+        password_confirmation: Confirmar contrasenya
+        email: Email
+        remember_me: Recordar-me
+        full_name: Nom complet

--- a/core/config/locales/es-CT.yml
+++ b/core/config/locales/es-CT.yml
@@ -1,0 +1,82 @@
+es-CT:
+  refinery:
+    js:
+      admin:
+        confirm_changes: "Qualsevol canvi que s'hagi fet es perdrà. Segur que vols continuar sense desar?"
+    plugins:
+      refinery_core:
+        title: Refinery
+        description: Core plugin de Refinery
+      refinery_dialogs:
+        title: Diàlegs
+        description: Diàlegs del Core plugin de Refinery
+    welcome:
+      there_are_no_users: "No hi ha usuaris registrats, així que hem de registrar al primer."
+    crudify:
+      created: "%{what} s'ha creat correctament."
+      updated: "%{what} s'ha actualitzat correctament."
+      destroyed: "%{what} s'ha esborrat correctament."
+    site_bar:
+      log_out: Sortir
+      switch_to_your_website: Veure el teu web
+      switch_to_your_website_editor: Editar el teu web
+    admin:
+      menu:
+        reorder_menu: Reordenar menú
+        reorder_menu_done: He acabat de reordenar el menú
+      dialogs:
+        show:
+          save: Guardar
+          cancel: Cancel·lar
+      continue_editing:
+        save_and_continue_editing: Guardar i seguir editant
+      form_actions:
+        save: Guardar
+        cancel: Cancelar
+        cancel_lose_changes: En cancel·lar es perdran els canvis que has realitzat aquí
+        delete: Esborrar
+        close: Tancar
+      image_picker:
+        none_selected: "No hi ha cap imatge seleccionada, fes clic aquí per afegir una."
+        remove_current: Eliminar imatge actual
+        change: Fes clic aquí per escollir una imatge
+        show: Mostrar
+      resource_picker:
+        download_current: Descarregar arxiu actual
+        opens_in_new_window: Obre en una finestra nova
+        remove_current: "Eliminar arxiu actual"
+        no_resource_selected: "No hi ha cap arxiu seleccionat, fes clic aqui per agregar un."
+        name: Agregar arxiu
+        current: Arxiu actual
+      search:
+        button_text: Buscar
+        results_for_html: "Resultats de la recerca &#8216;<em>%{query}</em>&#8217;"
+        no_results: "No s'han trobat resultats"
+        cancel_search: 'Cancelar recerca'
+        search_input_notice: "Posa aquí una cadena d'almenys 3 caràcters que conté el que estas buscant."
+      delete:
+        message: "Segur que vols suprimir '%{title}'?"
+      error_messages:
+        problems_in_following_fields: Va haver-hi problemes amb els següents camps
+      help: ajuda
+      form_advanced_options_menu:
+        advanced_options: Opcions avançades
+        toggle_advanced_options: Prem per accedir a les opcions de meta tags i menú
+        save_as_draft: Guardar com a esborrador
+    message:
+      close: Tancar
+      close_this_message: Tancar aquest missatge
+    draft_page_message:
+      not_live: Aquesta pàgina NO està visible per al públic.
+    footer:
+      copyright: "Copyright © %{year} %{site_name}"
+    no_script:
+      enable_javascript_html: "Per obtenir una funcionalitat completa d'aquesta pàgina és necessari activar Javascript."
+      here_are: Aquí estan les
+      instructions_enable_javascript_html: instruccions de com habilitar Javascript al teu navegador web
+  time:
+    formats:
+      short: "%A, %d %B %Y"
+  will_paginate:
+    previous_label: "&laquo;"
+    next_label: "&raquo;"

--- a/dashboard/config/locales/es-CT.yml
+++ b/dashboard/config/locales/es-CT.yml
@@ -1,0 +1,31 @@
+es-CT:
+  refinery:
+    plugins:
+      refinery_dashboard:
+        title: Panell de control
+        description: "Resum de l'activitat a Refinery"
+    admin:
+      dashboard:
+        index:
+          quick_tasks: Tasques Comuns
+        actions:
+          add_a_new_page: Afegir nova pàgina
+          update_a_page: Actualitzar una pàgina
+          upload_a_image: Pujar una imatge
+          upload_a_file: Pujar un arxiu
+          change_language: "Canviar l'idioma"
+          see_home_page: Veure la pàgina principal
+        recent_activity:
+          empty: No hi ha activitat recent.
+          latest_activity: Última acció
+          latest_activity_message: '%{what} %{kind} ha estat %{action}'
+        recent_inquiries:
+          latest_inquiries: Últimes Sol·licituds
+    updated:
+      'with_article "the"': actualitzat
+      'with_article "femeniní"': actualitzada
+      'with_article "masculí"': actualitzat
+    created:
+      'with_article "the"': creat
+      'with_article "femení"':  creada
+      'with_article "masculí"':  creat

--- a/images/config/locales/es-CT.yml
+++ b/images/config/locales/es-CT.yml
@@ -1,0 +1,44 @@
+es-CT:
+  refinery:
+    plugins:
+      refinery_images:
+        title: Imatges
+        description: Gestionar imatges
+        article: femení
+    admin:
+      images:
+        delete: Esborrar aquesta imatge per sempre
+        edit: Editar aquesta imatge
+        form:
+          image: Imatge
+          use_current_image: Usar imatge actual
+          or: o
+          replace_image: " reemplaçar-la amb aquesta altra..."
+          current_image: Imatge actual
+          maximum_image_size: "El pes màxim per a una imatge són %{bytes}."
+        actions:
+          create_new_image: Crear nova imatge
+        records:
+          no_images_yet: Encara no hi ha imatges. Fes clic a "Crear nova imatge" per afegir la primera.
+        index:
+          view:
+            switch_to: "Canviar a vista %{view_name}"
+            list: llista
+            grid: quadrícula
+        view_live_html: Veure imatge <br/><em>Obre en finestra nova</em>
+        existing_image:
+          button_text: Inserir
+          resize_image: Redimensionar la imatge?
+          size: Mida
+        insert:
+          existing_image: Imatge existent
+          new_image: Nova imatge
+  activerecord:
+    models:
+      refinery/image: "imatge"
+    errors:
+      models:
+        refinery/image:
+          blank: Has d'indicar què imatge vols pujar
+          too_big: "La imatge ha de pesar menys de %{size} bytes"
+          incorrect_format: "La teva imatge ha de ser un arxiu JPG, PNG o GIF"

--- a/pages/config/locales/es-CT.yml
+++ b/pages/config/locales/es-CT.yml
@@ -1,0 +1,86 @@
+es-CT:
+  refinery:
+    plugins:
+      refinery_pages:
+        title: Pàgines
+        description: Gestionar pàgines de contingut
+        article: femení
+    admin:
+      pages_dialogs:
+        page_link:
+          link_to_this_page: Enllaç a aquesta pàgina
+        link_to:
+          insert: Inserir
+          your_page:
+            tab_name: La teva pàgina
+          web_address:
+            tab_name: Webs
+            location: Adreça
+            new_window: Nova finestra
+            new_window_label: "Marca aquesta casella perquè l'enllaç s'obri en una finestra nova del navegador."
+            not_sure: No saps què escriure en el camp anterior?
+            step1: Cerca en la web quina pàgina vols enllaçar.
+            step2: "Copia l'adreça web des de la barra d'adreces del teu navegador i pega-la en el camp anterior."
+          email_address:
+            tab_name: Adreça e-mail
+            subject_line_optional: Assumpte opcional
+            body_optional:  Missatge opcional
+            not_sure: No saps què escriure en aquests camps?
+            step1_html: "Escriu o còpia i pega (per ex. des de la teva llibreta d'adreces) l'adreça e-mail a la qual vols enllaçar en el camp '<strong>Adreça e-mail</strong>' anterior."
+            step2_html: "Usa el camp <strong>Assumpte opcional</strong> si vols que el missatge s'enviï amb un <strong>assumpte predeterminat</strong>."
+            step3_html: "Usa el camp <strong>Missatge opcional</strong> si vols que el missatge s'enviï amb un <strong>contingut predeterminat</strong>."
+          your_resource:
+            tab_name: El teu arxiu
+            link_to_this_resource: Enllaç a aquest arxiu
+      pages:
+        delete: Esborrar aquesta pàgina per sempre
+        edit: Editar aquesta pàgina
+        new: Afegir una nova sub-pàgina
+        expand_collapse: Expandir o contreure les sub-pàgines
+        page:
+          view_live_html: "Veure aquesta pàgina com a oberta al públic<br/><em>(l'obre en finestra nova)</em>"
+          hidden: oculta
+          draft: esborrador
+        form:
+          preview: Previsualizar
+          preview_changes: Previsualizar canvis abans de guardar-los
+        form_new_page_parts:
+          title: Títol
+        form_page_parts:
+          create_content_section: Crear secció de contingut
+          delete_content_section: Esborrar secció de contingut
+          reorder_content_section: Reordenar secció de contingut
+          reorder_content_section_done: Ja està reordenada la secció de continguts
+        form_advanced_options:
+          page_options: Opcions de pàgina
+          parent_page: Pàgina pare
+          menu_title: Títol del menú
+          custom_slug: Custom slug
+          show_in_menu_title: Veure en menú
+          show_in_menu_description: Mostrar aquesta pàgina en el menú de la web
+          show_in_menu_help: Deixa sense marcar aquesta casella per eliminar una pàgina del menú del teu web. Pot ser útil si tens una pàgina que vols que la gent enllaci directament però no vols mostrar-la en el menú.
+          skip_to_first_child: Saltar pàgina de primer nivell
+          skip_to_first_child_label: Redirigir als visitants a la primera pàgina filla.
+          skip_to_first_child_help: Aquesta opció fa que aquesta pàgina enllaci a la seva primera pàgina filla. Pot ser útil per agrupar diverses pàgines juntes.
+          link_url: Redirigir aquesta pàgina a una altra web o a una altra pàgina
+          link_url_help: Si vols que aquesta pàgina enviï a una altra web o pàgina llavors prem aquesta pàgina en el menú i introdueix una URL (per example http://google.com). En cas contrari deixa-ho en blanc.
+          parent_page_help: "Pots incloure una pàgina dins d'una altra seleccionant-la en la llista. Si vols que sigui una pàgina de primer nivell, deixa-ho en blanc."
+          menu_title_help: Si vols que el menú mostri un títol diferent al que es mostra a la pàgina, introdueix-ho aquí.
+          custom_slug_help: "Un slug és un ID entendible pels humans. Per exemple 'sobre-nosaltres'. Per sobreescriure el slug que Refinery crea automàticament, introdueix el teu slug personalitzat aquí."
+          layout_template: Plantilla per layout
+          layout_template_help: Pots triar una plantilla per el layout diferenta per aquesta pàgina
+          view_template: Veure plantilla
+          view_template_help: Pots triar una plantilla diferent
+        actions:
+          create_new_page: Crear nova pàgina
+          reorder_pages: Reordenar pàgines
+          reorder_pages_done: Reordenació de pàgines completada
+        records:
+          no_pages_yet: Encara no hi ha pàgines. Prem "Crear nova pàgina" per afegir la teva primera pàgina.
+        translator_access: No tens el permís requerit per modificar pàgines en aquesta llengua.
+  activerecord:
+    models:
+      refinery/page: "pàgina"
+    attributes:
+      refinery/page:
+        title: Títol

--- a/resources/config/locales/es-CT.yml
+++ b/resources/config/locales/es-CT.yml
@@ -1,0 +1,36 @@
+es-CT:
+  refinery:
+    plugins:
+      refinery_files:
+        title: Arxius
+        description: Pujar i enllaçar arxius
+    admin:
+      resources:
+        delete: Esborrar aquest arxiu per sempre
+        edit: Editar aquest arxiu
+        form:
+          download_current: Descarregar arxiu actual
+          or: o
+          replace: " reemplaçar-ho per aquest altre..."
+          maximum_file_size: "El pes màxim per a l'arxiu és de %{bytes}."
+        resource:
+          download: "Descarregar aquest arxiu (%{size})"
+        actions:
+          upload_new: Pujar nou arxiu
+        records:
+          no_files_yet: Encara no hi ha arxius. Prem "Pujar nou arxiu" per afegir el teu primer arxiu.
+        insert:
+          existing: Arxiu existent
+          new: Nou arxiu
+          no_files: No hi ha arxius.
+        existing_resource:
+          link_to_file: Enllaçar aquest arxiu
+          button_text: Inserir
+  activerecord:
+    models:
+      refinery/resource: "arxiu"
+    errors:
+      models:
+        refinery/resource:
+          blank: Selecciona quin arxiu vols pujar
+          too_big: "L'arxiu ha de pesar menys de %{size} bytes"


### PR DESCRIPTION
Hi!
I've added the locales for Catalan (es-CT).
The native name of the language is "Català".

This is the flag:

![es-ct](https://cloud.githubusercontent.com/assets/1818725/3071898/8d024dd8-e2be-11e3-963d-45a895a7f152.png)

It's the same than https://github.com/refinery/refinerycms-i18n/blob/master/app/assets/images/refinery/icons/flags/catalonia.png
but renamed as es-CT.png (country code).
