### PR TITLE
Rename locale for Catalan as ca

### DIFF
--- a/authentication/config/locales/ca.yml
+++ b/authentication/config/locales/ca.yml
@@ -1,4 +1,4 @@
-es-CT:
+ca:
   refinery:
     plugins:
       refinery_users:

--- a/core/config/locales/ca.yml
+++ b/core/config/locales/ca.yml
@@ -1,4 +1,4 @@
-es-CT:
+ca:
   refinery:
     js:
       admin:

--- a/dashboard/config/locales/ca.yml
+++ b/dashboard/config/locales/ca.yml
@@ -1,4 +1,4 @@
-es-CT:
+ca:
   refinery:
     plugins:
       refinery_dashboard:

--- a/images/config/locales/ca.yml
+++ b/images/config/locales/ca.yml
@@ -1,4 +1,4 @@
-es-CT:
+ca:
   refinery:
     plugins:
       refinery_images:

--- a/pages/config/locales/ca.yml
+++ b/pages/config/locales/ca.yml
@@ -1,4 +1,4 @@
-es-CT:
+ca:
   refinery:
     plugins:
       refinery_pages:

--- a/resources/config/locales/ca.yml
+++ b/resources/config/locales/ca.yml
@@ -1,4 +1,4 @@
-es-CT:
+ca:
   refinery:
     plugins:
       refinery_files:


### PR DESCRIPTION
Hi!
This is a correction of my previous pull request.
I thought that you used country codes for locales, but you use language code, so the correct code for Catalan is "ca".
Thanks!
