### PR TITLE
Revise images controller for better compatibility with current Dragonfly.

### DIFF
--- a/images/app/controllers/refinery/admin/images_controller.rb
+++ b/images/app/controllers/refinery/admin/images_controller.rb
@@ -47,7 +47,7 @@ module Refinery
           else
             @images << (@image = ::Refinery::Image.create(image_params))
           end
-        rescue Dragonfly::FunctionManager::UnableToHandle
+        rescue NotImplementedError
           logger.warn($!.message)
           @image = ::Refinery::Image.new
         end


### PR DESCRIPTION
The 'create' action of 'Refinery::Admin::ImagesController' was trying to rescue
'Dragonfly::FunctionManager::UnableToHandle', which has been removed from
the current version of Dragonfly.

This patch instead rescues 'NotImplementedError', which is what 'Dragonfly::FunctionManager::UnableToHandle' used to subclass. Whether this is the correct thing to try to rescue is just a guess, as I haven't tried to determine what errors are actually issued by the current version of Dragonfly.
