### PR TITLE
user_mailer noreply address localpart is configurable Closes #2579

### DIFF
--- a/authentication/app/mailers/refinery/user_mailer.rb
+++ b/authentication/app/mailers/refinery/user_mailer.rb
@@ -10,7 +10,7 @@ module Refinery
 
       mail(:to => user.email,
            :subject => t('subject', :scope => 'refinery.user_mailer.reset_notification'),
-           :from => "\"#{Refinery::Core.site_name}\" <no-reply@#{request.domain}>")
+           :from => "\"#{Refinery::Core.site_name}\" <#{Refinery::Core.noreply_localpart}@#{request.domain}>")
     end
 
   protected

--- a/core/lib/generators/refinery/core/templates/config/initializers/refinery/core.rb.erb
+++ b/core/lib/generators/refinery/core/templates/config/initializers/refinery/core.rb.erb
@@ -21,6 +21,9 @@ Refinery::Core.configure do |config|
 
   # Site name
   # config.site_name = <%= Refinery::Core.site_name.inspect %>
+  
+  # Notification email address localpart
+  # config.noreply_localpart = <%= Refinery::Core.noreply_localpart.inspect %>
 
   # This activates Google Analytics tracking within your website. If this
   # config is left blank or set to UA-xxxxxx-x then no remote calls to

--- a/core/lib/generators/refinery/form/templates/app/mailers/refinery/namespace/mailer.rb.erb
+++ b/core/lib/generators/refinery/form/templates/app/mailers/refinery/namespace/mailer.rb.erb
@@ -6,7 +6,7 @@ module Refinery
         @<%= singular_name %> = <%= singular_name %>
         mail :subject  => Refinery::<%= namespacing %>::Setting.confirmation_subject,
              :to       => <%= singular_name %>.email,
-             :from     => "\"#{Refinery::Core.site_name}\" <no-reply@#{request.domain}>",
+             :from     => "\"#{Refinery::Core.site_name}\" <#{Refinery::Core.noreply_localpart}@#{request.domain}>",
              :reply_to => Refinery::<%= namespacing %>::Setting.notification_recipients.split(',').first
       end
 
@@ -14,7 +14,7 @@ module Refinery
         @<%= singular_name %> = <%= singular_name %>
         mail :subject  => Refinery::<%= namespacing %>::Setting.notification_subject,
              :to       => Refinery::<%= namespacing %>::Setting.notification_recipients,
-             :from     => "\"#{Refinery::Core.site_name}\" <no-reply@#{request.domain}>"
+             :from     => "\"#{Refinery::Core.site_name}\" <#{Refinery::Core.noreply_localpart}@#{request.domain}>"
       end
 
     end

--- a/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/settings/_confirmation_email_form.html.erb
+++ b/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/settings/_confirmation_email_form.html.erb
@@ -20,7 +20,7 @@
         <label class='stripped'><%%= t('.from') %></label>
       </td>
       <td>
-        <%%= "#{Refinery::Core.site_name} &lt;no-reply@#{request.domain}&gt;".html_safe %>
+        <%%= "#{Refinery::Core.site_name} &lt;#{Refinery::Core.noreply_localpart}@#{request.domain}&gt;".html_safe %>
       </td>
     </tr>
     <tr>

--- a/core/lib/refinery/core/configuration.rb
+++ b/core/lib/refinery/core/configuration.rb
@@ -8,7 +8,8 @@ module Refinery
                     :s3_bucket_name, :s3_region, :s3_access_key_id,
                     :s3_secret_access_key, :force_ssl, :backend_route,
                     :dragonfly_custom_backend_class, :dragonfly_custom_backend_opts,
-                    :visual_editor_javascripts, :visual_editor_stylesheets
+                    :visual_editor_javascripts, :visual_editor_stylesheets, 
+                    :noreply_localpart
 
     self.rescue_not_found = false
     self.s3_backend = false
@@ -29,6 +30,7 @@ module Refinery
     self.dragonfly_custom_backend_opts = {}
     self.visual_editor_javascripts = []
     self.visual_editor_stylesheets = []
+    self.noreply_localpart = "no-reply"
 
     def config.register_javascript(name)
       self.javascripts << name
@@ -70,6 +72,10 @@ module Refinery
 
       def site_name
         ::I18n.t('site_name', :scope => 'refinery.core.config', :default => config.site_name)
+      end
+      
+      def noreply_localpart
+        ::I18n.t('noreply_localpart', :scope => 'refinery.core.config', :default => config.noreply_localpart)
       end
 
       def wymeditor_whitelist_tags=(tags)

--- a/core/spec/lib/refinery/core/configuration_spec.rb
+++ b/core/spec/lib/refinery/core/configuration_spec.rb
@@ -32,6 +32,37 @@ module Refinery
           end
         end
       end
+      
+      describe '.noreply_localpart' do
+        # reset any previously defined noreply localpart
+        before do
+          Refinery::Core.noreply_localpart = nil
+        end
+        
+        context 'when set in configuration' do
+          it 'returns name set by Refinery::Core.config' do
+            Refinery::Core.stub(:noreply_localpart).and_return('support')
+            Refinery::Core.noreply_localpart.should eq('support')
+          end
+        end
+
+        context 'when set in locale file' do
+          before do
+            ::I18n.backend.store_translations :en, :refinery => {
+              :core => {
+                :config => {
+                  :noreply_localpart => 'supporto'
+                }
+              }
+            }
+          end
+
+          it 'returns name set in locale' do
+            Refinery::Core.noreply_localpart.should eq('supporto')
+          end
+        end
+      end
+      
 
       describe 'custom storage backend' do
         it 'class should be nil by default' do


### PR DESCRIPTION
See https://github.com/refinery/refinerycms/issues/2579

Please note that, even though unrelated to this implementation, there are 6 failing specs:

```
rspec ./pages/spec/features/refinery/pages_spec.rb:370 # page frontend with multiple locales redirects should redirect to second locale slug
rspec ./pages/spec/features/refinery/pages_spec.rb:364 # page frontend with multiple locales redirects should redirect to default locale slug
rspec ./pages/spec/features/refinery/pages_spec.rb:395 # page frontend with multiple locales redirects nested page should redirect to localized url
rspec ./pages/spec/features/refinery/admin/pages_spec.rb:576 # Pages with translations add a page with title only for secondary locale when page is a child page succeeds
rspec ./pages/spec/features/refinery/admin/pages_spec.rb:439 # Pages with translations add a page with title for both locales succeeds
rspec ./core/spec/features/refinery/admin/xhr_paging_spec.rb:20 # Crudify xhr_paging when set to true should perform ajax paging of index
```
