### PR TITLE
Generator for form is broken

### DIFF
--- a/core/lib/generators/refinery/form/templates/app/controllers/refinery/namespace/plural_name_controller.rb.erb
+++ b/core/lib/generators/refinery/form/templates/app/controllers/refinery/namespace/plural_name_controller.rb.erb
@@ -45,7 +45,7 @@ module Refinery
     protected
 
       def find_page
-        @page = Refinery::Page.find_by_link_url('/<%= plural_name %>/new', :include => [:parts])
+        @page = Refinery::Page.find_by_link_url('/<%= plural_name %>', :include => [:parts])
       end
 
     end

--- a/core/lib/generators/refinery/form/templates/config/routes.rb.erb
+++ b/core/lib/generators/refinery/form/templates/config/routes.rb.erb
@@ -1,15 +1,16 @@
 Refinery::Core::Engine.routes.draw do
   # Frontend routes
-  namespace :<%= namespacing.underscore %> do
-    resources :<%= plural_name %><%= ", :path => ''" if namespacing.underscore == plural_name %>, :only => [:new, :create] do
-      collection do
-        get :thank_you
+  namespace :<%= namespacing.underscore %>, :path => '' do
+    get '/<%= plural_name %>', :to => '<%= plural_name %>#new', :as => 'new_<%= plural_name %>'
+
+    resources :<%= plural_name %>, 
+      :only => [:new, :create],
+      :as => :<%= plural_name %>,
+      :controller => '<%= plural_name %>' do
+        get :thank_you, :on => :collection
       end
-    end
-  end
 
   # Admin routes
-  namespace :<%= namespacing.underscore %>, :path => '' do
     namespace :admin, :path => "#{Refinery::Core.backend_route}/<%= namespacing.underscore %>" do
       resources :<%= plural_name %>, :path => '' <% if @includes_spam %> do
         collection do
@@ -23,4 +24,3 @@ Refinery::Core::Engine.routes.draw do
     end
   end
 end
-


### PR DESCRIPTION
Fix the forms generator
- Generating forms was broken as of 2.1.3 release. This commit fixes the generator although it does not add the rspec tests mentioned in https://github.com/refinery/refinerycms/issues/2690
- rspec tests to follow in a future commit
