### PR TITLE
Ignore SHA parameter on dragonfly URLs

### DIFF
--- a/images/spec/models/refinery/image_spec.rb
+++ b/images/spec/models/refinery/image_spec.rb
@@ -70,7 +70,7 @@ module Refinery
       end
 
       it "contains its filename at the end" do
-        expect(created_image.url.split('/').last).to eq(created_image.image_name)
+        expect(URI(created_image.url).path.split('/').last).to eq(created_image.image_name)
       end
 
       it "becomes different when supplying geometry" do

--- a/resources/spec/models/refinery/resource_spec.rb
+++ b/resources/spec/models/refinery/resource_spec.rb
@@ -20,7 +20,7 @@ module Refinery
       end
 
       it "should contain its filename at the end" do
-        resource.url.split('/').last.should == resource.file_name
+        URI(resource.url).path.split('/').last.should == resource.file_name
       end
     end
 


### PR DESCRIPTION
Let refinerycms/images and refinerycms/resources pass testing by ignoring any parameters (SHA, for instance) appended to dragonfly URLs.
