### PR TITLE
Add named paths for pages to workaround rails #16058

### DIFF
--- a/pages/app/views/refinery/admin/pages/_page.html.erb
+++ b/pages/app/views/refinery/admin/pages/_page.html.erb
@@ -14,7 +14,7 @@
       <span class='locales'>
         <% page.translations.sort_by{|t| Refinery::I18n.frontend_locales.index(t.locale)}.each do |translation| %>
           <%= link_to refinery_icon_tag("flags/#{translation.locale}.png", :size => '16x11'),
-                      refinery.edit_admin_page_path(page.nested_url, :switch_locale => translation.locale),
+                      refinery.admin_edit_page_path(page.nested_url, :switch_locale => translation.locale),
                       :class => 'locale' if translation.title.present? %>
         <% end %>
       </span>
@@ -30,11 +30,11 @@
                   :title => t('new', :scope => 'refinery.admin.pages') %>
 
       <%= link_to refinery_icon_tag('application_edit.png'),
-                  refinery.edit_admin_page_path(page.nested_url, :switch_locale => (page.translations.first.locale unless page.translated_to_default_locale?)),
+                  refinery.admin_edit_page_path(page.nested_url, :switch_locale => (page.translations.first.locale unless page.translated_to_default_locale?)),
                   :title => t('edit', :scope => 'refinery.admin.pages') %>
 
       <%= link_to refinery_icon_tag('delete.png'),
-                  refinery.admin_page_path(page.nested_url),
+                  refinery.admin_delete_page_path(page.nested_url),
                   :class => "cancel confirm-delete",
                   :title => t('delete', :scope => 'refinery.admin.pages'),
                   :data => {

--- a/pages/config/routes.rb
+++ b/pages/config/routes.rb
@@ -1,32 +1,32 @@
 Refinery::Core::Engine.routes.draw do
-  root :to => 'pages#home', :via => :get
-  get '/pages/:id', :to => 'pages#show', :as => :page
+  root to: 'pages#home', via: :get
+  get '/pages/:id', to: 'pages#show', as: :page
 
-  namespace :pages, :path => '' do
-    namespace :admin, :path => Refinery::Core.backend_route do
-      scope :path => :pages do
-        post 'preview', :to => 'preview#show', :as => :preview_pages
-        patch 'preview/*path', :to => 'preview#show', :as => :preview_page
+  namespace :pages, path: '' do
+    namespace :admin, path: Refinery::Core.backend_route do
+      scope path: :pages do
+        post 'preview', to: 'preview#show', as: :preview_pages
+        patch 'preview/*path', to: 'preview#show', as: :preview_page
       end
     end
   end
 
-  namespace :admin, :path => Refinery::Core.backend_route do
-    get 'pages/*path/edit', :to => 'pages#edit'
-    get 'pages/*path/children', :to => 'pages#children', :as => 'children_pages'
-    patch 'pages/*path', :to => 'pages#update'
-    delete 'pages/*path', :to => 'pages#destroy'
+  namespace :admin, path: Refinery::Core.backend_route do
+    get 'pages/*path/edit', to: 'pages#edit', as: 'edit_page'
+    get 'pages/*path/children', to: 'pages#children', as: 'children_pages'
+    patch 'pages/*path', to: 'pages#update', as: 'update_page'
+    delete 'pages/*path', to: 'pages#destroy', as: 'delete_page'
 
-    resources :pages, :except => :show do
-      post :update_positions, :on => :collection
+    resources :pages, except: :show do
+      post :update_positions, on: :collection
     end
 
-    resources :pages_dialogs, :only => [] do
+    resources :pages_dialogs, only: [] do
       collection do
         get :link_to
       end
     end
 
-    resources :page_parts, :only => [:new, :create, :destroy]
+    resources :page_parts, only: [:new, :create, :destroy]
   end
 end


### PR DESCRIPTION
This PR adds and uses named paths for `pages#edit`, `pages#update` and `pages#delete`. The named paths avoid rails generating URLs with %2F in place of a slash.
