### PR TITLE
Fix preview of image, when changing image field

### DIFF
--- a/core/app/assets/javascripts/refinery/admin.js.erb
+++ b/core/app/assets/javascripts/refinery/admin.js.erb
@@ -868,7 +868,7 @@ var image_picker = {
     this.image.src = $(this.image).attr('data-' + size);
     current_image = $(this.container).find(this.picker.options.image_display);
     current_image.replaceWith(
-      $("<img src='"+this.image.src+"?"+Math.floor(Math.random() * 100000)+"' id='"+current_image.attr('id')+"' class='"+this.picker.options.image_display.replace(/^./, '')+" brown_border' />")
+      $("<img src='"+this.image.src+"' id='"+current_image.attr('id')+"' class='"+this.picker.options.image_display.replace(/^./, '')+" brown_border' />")
     );
 
     $(this.container).find(this.picker.options.remove_image_button).show();


### PR DESCRIPTION
Problem: when inserting an image with the image picker in an image field, the preview is broken (broken image tag). (otherwise the preview works)

Solution: the image path is: `<path>?sha=some_sha?23432`, notice the random integer at the end, which isn't needed anymore (I assume). So I just deleted that part in the js file.

Background:
- the problem was mentioned by @eshaiju in https://github.com/refinery/refinerycms/issues/2681#issuecomment-56522971
- the random int was added here: https://github.com/refinery/refinerycms/commit/ec3f2a907116a8c1c9afc59bb082cdb8c3b9c2b5
