### PR TITLE
Fix attach-refinery-{images|resources}-with-dragonfly initialization ord...

### DIFF
--- a/images/lib/refinery/images/engine.rb
+++ b/images/lib/refinery/images/engine.rb
@@ -8,7 +8,7 @@ module Refinery
 
       config.autoload_paths += %W( #{config.root}/lib )
 
-      initializer 'attach-refinery-images-with-dragonfly', :after => :load_config_initializers do |app|
+      initializer 'attach-refinery-images-with-dragonfly', :before => :build_middleware_stack do |app|
         ::Refinery::Images::Dragonfly.configure!
         ::Refinery::Images::Dragonfly.attach!(app)
       end

--- a/resources/lib/refinery/resources/engine.rb
+++ b/resources/lib/refinery/resources/engine.rb
@@ -8,7 +8,7 @@ module Refinery
 
       config.autoload_paths += %W( #{config.root}/lib )
 
-      initializer 'attach-refinery-resources-with-dragonfly', :after => :load_config_initializers do |app|
+      initializer 'attach-refinery-resources-with-dragonfly', :before => :build_middleware_stack do |app|
         ::Refinery::Resources::Dragonfly.configure!
         ::Refinery::Resources::Dragonfly.attach!(app)
       end


### PR DESCRIPTION
In our setup, `after: :load_config_initializers` causes the `attach-refinery-{images|resources}-with-dragonfly` initializers to be run after `:build_middleware_stack`, which effectively breaks image/resource loading. In master, there is a fix for this, which uses `before: :finisher_hook`, but this may still cause the initializer to be run after `:build_middleware_stack`. 

For details, cf. http://guides.rubyonrails.org/configuring.html#initializers
