### PR TITLE
Remove alt shell unfriendly globbing for testing tasks

### DIFF
--- a/testing/lib/refinery/tasks/testing.rake
+++ b/testing/lib/refinery/tasks/testing.rake
@@ -52,7 +52,7 @@ namespace :refinery do
     end
 
     task :init_test_database do
-      system "RAILS_ENV=test bundle exec rake -f #{File.join(dummy_app_path, 'Rakefile')} db:{create,migrate}"
+      system "RAILS_ENV=test bundle exec rake -f #{File.join(dummy_app_path, 'Rakefile')} db:create db:migrate"
     end
 
     task :specs do


### PR DESCRIPTION
On certain shells, bracket expansion will fail and will throw errors
when trying to create the dummy app. Instead of using the bracket
expansion, we can simply use the native rake syntax by chaining rake
commands after each other.
