### PR TITLE
Form generator: fix generator, add specs and correct the 'new' route via index

### DIFF
--- a/core/lib/generators/refinery/form/form_generator.rb
+++ b/core/lib/generators/refinery/form/form_generator.rb
@@ -7,6 +7,16 @@ module Refinery
 
     include Refinery::ExtensionGeneration
 
+    class_option :include_spam,
+      :desc => 'Generate extension with spam filtering',
+      :type => :boolean,
+      :default => false,
+      :required => false
+
+    def include_spam?
+      options[:include_spam]
+    end
+
     def description
       "Generates an extension which is set up for frontend form submissions like a contact page."
     end

--- a/core/lib/generators/refinery/form/templates/Gemfile
+++ b/core/lib/generators/refinery/form/templates/Gemfile
@@ -1,0 +1,38 @@
+source "http://rubygems.org"
+
+gemspec
+
+gem 'refinerycms', '~> <%= Refinery::Version %>'
+
+# Database Configuration
+platforms :jruby do
+  gem 'activerecord-jdbcsqlite3-adapter'
+  gem 'activerecord-jdbcmysql-adapter'
+  gem 'activerecord-jdbcpostgresql-adapter'
+  gem 'jruby-openssl'
+end
+
+platforms :ruby do
+  gem 'sqlite3'
+  gem 'mysql2'
+  gem 'pg'
+end
+
+group :development, :test do
+  gem 'refinerycms-testing', '~> <%= Refinery::Version %>'
+  gem "rspec-its"
+  platforms :ruby do
+    require 'rbconfig'
+    if RbConfig::CONFIG['target_os'] =~ /linux/i
+      gem 'therubyracer', '~> 0.11.4'
+    end
+  end
+end
+
+# Gems used only for assets and not required
+# in production environments by default.
+group :assets do
+  gem 'sass-rails'
+  gem 'coffee-rails'
+  gem 'uglifier'
+end

--- a/core/lib/generators/refinery/form/templates/Rakefile
+++ b/core/lib/generators/refinery/form/templates/Rakefile
@@ -1,0 +1,20 @@
+#!/usr/bin/env rake
+begin
+  require 'bundler/setup'
+rescue LoadError
+  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+end
+
+ENGINE_PATH = File.dirname(__FILE__)
+APP_RAKEFILE = File.expand_path("../spec/dummy/Rakefile", __FILE__)
+
+if File.exists?(APP_RAKEFILE)
+  load 'rails/tasks/engine.rake'
+end
+
+require "refinerycms-testing"
+Refinery::Testing::Railtie.load_tasks
+Refinery::Testing::Railtie.load_dummy_tasks(ENGINE_PATH)
+
+load File.expand_path('../tasks/testing.rake', __FILE__)
+load File.expand_path('../tasks/rspec.rake', __FILE__)

--- a/core/lib/generators/refinery/form/templates/app/controllers/refinery/namespace/admin/plural_name_controller.rb.erb
+++ b/core/lib/generators/refinery/form/templates/app/controllers/refinery/namespace/admin/plural_name_controller.rb.erb
@@ -6,7 +6,7 @@ module Refinery
         crudify :'refinery/<%= namespacing.underscore %>/<%= singular_name %>', <% if (title = attributes.detect { |a| a.type.to_s == "string" }).present? %>
                 :title_attribute => "<%= title.name %>", <% end %>
                 :order => "created_at DESC"
-<% if @includes_spam -%>
+<% if include_spam? -%>
 
         before_filter :get_spam_count, :only => [:index, :spam]
 

--- a/core/lib/generators/refinery/form/templates/app/controllers/refinery/namespace/admin/settings_controller.rb.erb
+++ b/core/lib/generators/refinery/form/templates/app/controllers/refinery/namespace/admin/settings_controller.rb.erb
@@ -26,17 +26,17 @@ module Refinery
 
       protected
         def check_setting
-          setting = params[:id].gsub("<%= singular_name %>_", "")
+          scoped_setting_id = params[:id].gsub("<%= singular_name %>_", "")
 
-          Refinery::<%= namespacing %>::Setting.send(setting) if Refinery::<%= namespacing %>::Setting.respond_to?(setting)
+          Refinery::Setting.send(scoped_setting_id) if Refinery::<%= namespacing %>::Setting.respond_to?(params[:id])
         end
 
         def save_subject_for_confirmation
-          Refinery::<%= namespacing %>::Setting.confirmation_subject = params[:subject] if params.keys.include?('subject')
+          Refinery::<%= namespacing %>::Setting.confirmation_subject = params[:confirmation_subject] if params.keys.include?('confirmation_subject')
         end
 
         def save_message_for_confirmation
-          Refinery::<%= namespacing %>::Setting.confirmation_message = params[:message] if params.keys.include?('message')
+          Refinery::<%= namespacing %>::Setting.confirmation_message = params[:confirmation_message] if params.keys.include?('confirmation_message')
         end
 
       end

--- a/core/lib/generators/refinery/form/templates/app/controllers/refinery/namespace/plural_name_controller.rb.erb
+++ b/core/lib/generators/refinery/form/templates/app/controllers/refinery/namespace/plural_name_controller.rb.erb
@@ -5,7 +5,7 @@ module Refinery
       before_filter :find_page, :only => [:create, :new]
 
       def index
-        redirect_to :action => "new"
+        redirect_to refinery.new_<%= plural_name %>_<%= singular_name %>_path
       end
 
       def thank_you

--- a/core/lib/generators/refinery/form/templates/app/controllers/refinery/namespace/plural_name_controller.rb.erb
+++ b/core/lib/generators/refinery/form/templates/app/controllers/refinery/namespace/plural_name_controller.rb.erb
@@ -24,14 +24,14 @@ module Refinery
             Mailer.notification(@<%= singular_name %>, request).deliver
           rescue => e
             logger.warn "There was an error delivering the <%= singular_name %> notification.\n#{e.message}\n"
-          end<% if @includes_spam %> if @<%= singular_name %>.ham?<% end %>
+          end<% if include_spam? %> if @<%= singular_name %>.ham?<% end %>
 
           if <%= class_name %>.column_names.map(&:to_s).include?('email')
             begin
               Mailer.confirmation(@<%= singular_name %>, request).deliver
             rescue => e
               logger.warn "There was an error delivering the <%= singular_name %> confirmation:\n#{e.message}\n"
-            end<% if @includes_spam %> if @<%= singular_name %>.ham?<% end %>
+            end<% if include_spam? %> if @<%= singular_name %>.ham?<% end %>
           else
             logger.warn "Please add an 'email' field to <%= class_name %> if you wish to send confirmation emails when forms are submitted."
           end

--- a/core/lib/generators/refinery/form/templates/app/models/refinery/namespace/setting.rb.erb
+++ b/core/lib/generators/refinery/form/templates/app/models/refinery/namespace/setting.rb.erb
@@ -1,10 +1,10 @@
 module Refinery
   module <%= namespacing %>
-    class Setting < Refinery::Core::BaseModel
+    class Setting
 
       class << self
-        def confirmation_body
-          Refinery::Setting.find_or_set(:<%= singular_name %>_confirmation_body,
+        def confirmation_message
+          Refinery::Setting.find_or_set(:<%= singular_name %>_confirmation_message,
             "Thank you for your <%= singular_name.humanize.downcase %> %name%,\n\nThis email is a receipt to confirm we have received your <%= singular_name.humanize.downcase %> and we'll be in touch shortly.\n\nThanks."
           )
         end
@@ -12,10 +12,6 @@ module Refinery
         def confirmation_subject
           Refinery::Setting.find_or_set(:<%= singular_name %>_confirmation_subject,
                                         "Thank you for your <%= singular_name.humanize.downcase %>")
-        end
-
-        def confirmation_subject=(value)
-          Refinery::Setting.set(:<%= singular_name %>_confirmation_subject, value)
         end
 
         def notification_recipients
@@ -27,8 +23,20 @@ module Refinery
           Refinery::Setting.find_or_set(:<%= singular_name %>_notification_subject,
                                         "New <%= singular_name.humanize.downcase %> from your website")
         end
-      end
 
+        def confirmation_message=(value)
+          Refinery::Setting.set(:<%= singular_name %>_confirmation_message, value)
+        end
+
+        def confirmation_subject=(value)
+          Refinery::Setting.set(:<%= singular_name %>_confirmation_subject, value)
+        end
+
+        def notification_recipients=(value)
+          Refinery::Setting.set(:<%= singular_name %>_notification_recipients, value)
+        end
+
+      end
     end
   end
 end

--- a/core/lib/generators/refinery/form/templates/app/models/refinery/namespace/singular_name.rb.erb
+++ b/core/lib/generators/refinery/form/templates/app/models/refinery/namespace/singular_name.rb.erb
@@ -1,9 +1,17 @@
+<% if include_spam? %>
+require 'filters_spam'
+<% end %>
+
 module Refinery
   module <%= class_name.pluralize %>
     class <%= class_name %> < Refinery::Core::BaseModel
 <% if table_name == namespacing.underscore.pluralize -%>
       self.table_name = 'refinery_<%= plural_name %>'
 <% end -%>
+
+<% if include_spam? %>
+  filters_spam author_field: :name
+<% end %>
 
       attr_accessible <%= names_for_attr_accessible.map { |a| ":#{a}" }.join(', ') %>, :position
 <% if (text_fields = attributes.map { |a| a.name if a.type == :text }.compact.uniq).any? && text_fields.detect{ |a| a.to_s == 'message' }.nil? -%>

--- a/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/plural_name/_singular_name.html.erb
+++ b/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/plural_name/_singular_name.html.erb
@@ -12,7 +12,7 @@
 
     <%%= link_to refinery_icon_tag('zoom.png'), refinery.<%= namespacing.underscore %>_admin_<%= singular_name %>_path(<%= singular_name %>),
                 :title => t('.read_<%= singular_name %>') -%>
-<% if @includes_spam %>
+<% if @include_spam %>
     <%% if <%= singular_name %>.spam? %>
       <%%= link_to refinery_icon_tag('email.png'), refinery.toggle_spam_<%= namespacing.underscore %>_admin_<%= singular_name %>_path(<%= singular_name %>),
                   :title => t('.mark_as_ham') -%>

--- a/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/plural_name/_singular_name.html.erb
+++ b/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/plural_name/_singular_name.html.erb
@@ -6,7 +6,7 @@
   <span class='actions'>
     <%%= link_to refinery_icon_tag('delete.png'), refinery.<%= namespacing.underscore %>_admin_<%= singular_name %>_path(<%= singular_name %>),
                 :class => "cancel confirm-delete",
-                :title => t('admin.<%= plural_name %>.delete'),
+                :title => t('.delete_<%= singular_name %>'),
                 :'data-confirm' => t('shared.admin.delete.message', :title => <%= singular_name %>.name),
                 :'data-method' => "delete" -%>
 

--- a/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/plural_name/_singular_name.html.erb
+++ b/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/plural_name/_singular_name.html.erb
@@ -12,7 +12,7 @@
 
     <%%= link_to refinery_icon_tag('zoom.png'), refinery.<%= namespacing.underscore %>_admin_<%= singular_name %>_path(<%= singular_name %>),
                 :title => t('.read_<%= singular_name %>') -%>
-<% if @include_spam %>
+<% if include_spam? %>
     <%% if <%= singular_name %>.spam? %>
       <%%= link_to refinery_icon_tag('email.png'), refinery.toggle_spam_<%= namespacing.underscore %>_admin_<%= singular_name %>_path(<%= singular_name %>),
                   :title => t('.mark_as_ham') -%>

--- a/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/plural_name/_submenu.html.erb
+++ b/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/plural_name/_submenu.html.erb
@@ -9,7 +9,7 @@
       <%%= link_to t('.inbox'), refinery.<%= namespacing.underscore %>_admin_<%= plural_name %>_path, :class => "email_icon" %>
     </li><% if include_spam? %>
     <li <%%= "class='selected'" if params[:action] == "spam" %>>
-      <%% if @spam_count.any?  %>
+      <%% if @spam_count > 0 %>
         <%%= link_to "#{t('.spam')} (#{@spam_count})", refinery.spam_<%= namespacing.underscore %>_admin_<%= plural_name %>_path, :class => "spam_icon" %>
       <%% else %>
         <%%= link_to t('.spam'), refinery.spam_<%= namespacing.underscore %>_admin_<%= plural_name %>_path, :class => "spam_empty_icon" %>

--- a/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/plural_name/_submenu.html.erb
+++ b/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/plural_name/_submenu.html.erb
@@ -7,7 +7,7 @@
     <%% end %>
     <li <%%= "class='selected'" if params[:action] == "index" %>>
       <%%= link_to t('.inbox'), refinery.<%= namespacing.underscore %>_admin_<%= plural_name %>_path, :class => "email_icon" %>
-    </li><% if @includes_spam %>
+    </li><% if include_spam? %>
     <li <%%= "class='selected'" if params[:action] == "spam" %>>
       <%% if @spam_count.any?  %>
         <%%= link_to "#{t('.spam')} (#{@spam_count})", refinery.spam_<%= namespacing.underscore %>_admin_<%= plural_name %>_path, :class => "spam_icon" %>

--- a/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/plural_name/_submenu.html.erb
+++ b/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/plural_name/_submenu.html.erb
@@ -22,7 +22,7 @@
     </li>
     <li>
       <%%= link_to t('.edit_confirmation_email'),
-                  refinery.edit_<%= namespacing.underscore %>_admin_setting_path(:<%= singular_name %>_confirmation_body, :dialog => true),
+                  refinery.edit_<%= namespacing.underscore %>_admin_setting_path(:<%= singular_name %>_confirmation_message, :dialog => true),
                   :class => "edit_email_icon" %>
     </li>
   </ul>

--- a/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/plural_name/show.html.erb
+++ b/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/plural_name/show.html.erb
@@ -28,7 +28,7 @@
   <h2><%%= t('.details')%></h2>
   <p>
     <strong><%%= t('.age') %>:</strong> <%%= time_ago_in_words(@<%= singular_name %>.created_at) %>
-  </p><% if @includes_spam %>
+  </p><% if include_spam? %>
   <%% if @<%= singular_name %>.spam? %>
     <p>
       <strong><%%= t('.spam') %>:</strong> <%%= t('.spam_yes') %>

--- a/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/plural_name/show.html.erb
+++ b/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/plural_name/show.html.erb
@@ -41,10 +41,10 @@
                    :class => "back_icon" %>
     </li>
     <li>
-      <%%= link_to t('delete', :scope => 'refinery.<%= namespacing.underscore %>.admin.<%= plural_name %>'),
+      <%%= link_to t('delete_<%= singular_name %>', :scope => 'refinery.<%= namespacing.underscore %>.admin.<%= plural_name %>.<%= singular_name %>'),
                   refinery.<%= namespacing.underscore %>_admin_<%= singular_name %>_path(@<%= singular_name %>),
                   :class => 'delete_icon no-tooltip confirm-delete',
-                  :title => t('delete', :scope => 'refinery.<%= namespacing.underscore %>.admin.<%= plural_name %>'),
+                  :title => t('delete_<%= singular_name %>', :scope => 'refinery.<%= namespacing.underscore %>.admin.<%= plural_name %>.<%= singular_name %>'),                  
                   :'data-confirm' => t('message', :scope => 'refinery.admin.delete', :title => @<%= singular_name %>.name),
                   :'data-method' => "delete" %>
     </li>

--- a/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/plural_name/show.html.erb
+++ b/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/plural_name/show.html.erb
@@ -44,7 +44,7 @@
       <%%= link_to t('delete_<%= singular_name %>', :scope => 'refinery.<%= namespacing.underscore %>.admin.<%= plural_name %>.<%= singular_name %>'),
                   refinery.<%= namespacing.underscore %>_admin_<%= singular_name %>_path(@<%= singular_name %>),
                   :class => 'delete_icon no-tooltip confirm-delete',
-                  :title => t('delete_<%= singular_name %>', :scope => 'refinery.<%= namespacing.underscore %>.admin.<%= plural_name %>.<%= singular_name %>'),                  
+                  :title => t('delete_<%= singular_name %>', :scope => 'refinery.<%= namespacing.underscore %>.admin.<%= plural_name %>.<%= singular_name %>'),
                   :'data-confirm' => t('message', :scope => 'refinery.admin.delete', :title => @<%= singular_name %>.name),
                   :'data-method' => "delete" %>
     </li>

--- a/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/plural_name/show.html.erb
+++ b/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/plural_name/show.html.erb
@@ -37,7 +37,7 @@
   <h2><%%= t('.actions') %></h2>
   <ul>
     <li>
-      <%%= link_to t('.back_to_all_<%= plural_name %>'), refinery.url_for(:action => 'index'),
+    <%%= link_to t('.back_to_all_<%= plural_name %>'), refinery.<%= namespacing.underscore %>_admin_<%= plural_name %>_path,
                    :class => "back_icon" %>
     </li>
     <li>

--- a/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/plural_name/show.html.erb
+++ b/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/plural_name/show.html.erb
@@ -1,6 +1,6 @@
 <div id='records'>
   <h2><%%= t('.<%= singular_name %>') %></h2>
-  <table id='<%= singular_name %>' class='inquiry'>
+  <table id='<%= singular_name %>' class='<%= singular_name %>'>
 <% attributes.each do |attribute| -%>
       <tr>
         <td<%= " valign='top'" if attribute.type.to_s == 'text' %>>

--- a/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/settings/_confirmation_email_form.html.erb
+++ b/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/admin/settings/_confirmation_email_form.html.erb
@@ -25,19 +25,18 @@
     </tr>
     <tr>
       <td>
-        <label class='stripped'><%%= t('.subject') %></label>
+        <%%= label_tag "confirmation_subject", t('.subject'), :class => 'stripped' %>
       </td>
       <td>
-        <%%= text_field_tag 'subject', Refinery::<%= namespacing %>::Setting.confirmation_subject,
-                           :class => 'widest' %>
+        <%%= text_field_tag "confirmation_subject", Refinery::<%= namespacing %>::Setting.confirmation_subject, :class => 'widest' %>
       </td>
     </tr>
     <tr>
       <td valign='top'>
-        <%%= f.label :value, t('.message'), :class => 'stripped' %>
+        <%%= label_tag "confirmation_message", t('.message'), :class => 'stripped' %>
       </td>
       <td>
-        <%%= f.text_area :value, :value => @setting.value, :rows => "7", :class => 'widest' %>
+        <%%= text_area_tag "confirmation_message", Refinery::<%= namespacing %>::Setting.confirmation_message, :rows => "7", :class => 'widest' %>
         <br/>
         <em><%%= t('.note') %></em>
       </td>

--- a/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/mailer/confirmation.html.erb
+++ b/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/mailer/confirmation.html.erb
@@ -1,1 +1,1 @@
-<%%= simple_format(strip_tags(Refinery::<%= namespacing %>::Setting.confirmation_body.gsub("%name%", @<%= singular_name %>.name))) %>
+<%%= simple_format(strip_tags(Refinery::<%= namespacing %>::Setting.confirmation_message.gsub("%name%", @<%= singular_name %>.name))) %>

--- a/core/lib/generators/refinery/form/templates/config/locales/cs.yml
+++ b/core/lib/generators/refinery/form/templates/config/locales/cs.yml
@@ -11,8 +11,8 @@ cs:
           privacy_policy: Chráníme vaše soukromí
       admin:
         <%= plural_name %>:
-          delete: Trvale odstranit <%= singular_name.humanize.downcase %>
           <%= singular_name %>:
+            delete_<%= singular_name %>: Trvale odstranit <%= singular_name.humanize.downcase %>
             read_<%= singular_name %>: Přečíst <%= singular_name.humanize.downcase %>
             said: řekl
             mark_as_spam: Označit jako spam

--- a/core/lib/generators/refinery/form/templates/config/locales/da.yml
+++ b/core/lib/generators/refinery/form/templates/config/locales/da.yml
@@ -13,14 +13,8 @@ da:
       admin:
         <%= plural_name %>:
           <%= singular_name %>:
-            move_<%= singular_name %>_to_closed: Flyt til lukkede henvendelser
-            move_<%= singular_name %>_to_open: Flyt til åbne henvendelser
             read_<%= singular_name %>: Læs henvendelse
-            remove_<%= singular_name %>: "Er du sikker på du vil slette denne henvendelse fra '%{name}'?"
-            title: <%= plural_name.titleize %>
-          toggle_status:
-            closed: "Henvendelsen '%{<%= singular_name %>}' er lukket"
-            reopened: "Henvendelsen '%{<%= singular_name %>}' er genåbnet"
+            delete_<%= singular_name %>: "Er du sikker på du vil slette denne henvendelse fra '%{name}'?"
           index:
             no_<%= plural_name %>: Du har endnu ikke modtaget nogen henvendelser.
           show:

--- a/core/lib/generators/refinery/form/templates/config/locales/de.yml
+++ b/core/lib/generators/refinery/form/templates/config/locales/de.yml
@@ -11,8 +11,8 @@ de:
           privacy_policy: Ihre Privatsphäre ist uns wichtig
       admin:
         <%= plural_name %>:
-          delete: Diese Kontaktanfrage für immer löschen
           <%= singular_name %>:
+            delete_<%= singular_name %>: Diese Kontaktanfrage für immer löschen
             read_<%= singular_name %>: Kontaktanfrage lesen
             said: schrieb
             mark_as_spam: Als Spam markieren

--- a/core/lib/generators/refinery/form/templates/config/locales/en.yml
+++ b/core/lib/generators/refinery/form/templates/config/locales/en.yml
@@ -11,9 +11,9 @@ en:
           privacy_policy: We value your privacy
       admin:
         <%= plural_name %>:
-          delete: Remove this <%= singular_name.humanize.downcase %> forever
           <%= singular_name %>:
             read_<%= singular_name %>: Read the <%= singular_name.humanize.downcase %>
+            delete_<%= singular_name %>: Remove this <%= singular_name.humanize.downcase %> forever
             said: said
             mark_as_spam: Mark as spam
             mark_as_ham: Move to inbox

--- a/core/lib/generators/refinery/form/templates/config/locales/es.yml
+++ b/core/lib/generators/refinery/form/templates/config/locales/es.yml
@@ -13,14 +13,8 @@ es:
       admin:
         <%= plural_name %>:
           <%= singular_name %>:
-            move_<%= singular_name %>_to_closed: Cambiar esta consulta a cerrada
-            move_<%= singular_name %>_to_open: Cambiar esta consulta a abierta
             read_<%= singular_name %>: Leer esta consulta
-            remove_<%= singular_name %>: "Estas seguro que quieres borrar esta consulta de '%{name}'?"
-            title: <%= plural_name.titleize %>
-          toggle_status:
-            closed: "La consulta '%{<%= singular_name %>}' esta cerrada"
-            reopened: "La consulta '%{<%= singular_name %>}' esta abierta"
+            delete_<%= singular_name %>: "Estas seguro que quieres borrar esta consulta de '%{name}'?"
           index:
             no_<%= plural_name %>: No has recibido ninguna consulta aun.
           show:

--- a/core/lib/generators/refinery/form/templates/config/locales/fr.yml
+++ b/core/lib/generators/refinery/form/templates/config/locales/fr.yml
@@ -11,8 +11,8 @@ fr:
           privacy_policy: Nous respectons votre vie privée
       admin:
         <%= plural_name %>:
-          delete: Supprimer définitivement cette requête
           <%= singular_name %>:
+            delete_<%= singular_name %>: Supprimer définitivement cette requête
             read_<%= singular_name %>: Lire la requête
             said: a dit
             mark_as_spam: Marquer comme spam

--- a/core/lib/generators/refinery/form/templates/config/locales/it.yml
+++ b/core/lib/generators/refinery/form/templates/config/locales/it.yml
@@ -13,14 +13,8 @@ it:
       admin:
         <%= plural_name %>:
           <%= singular_name %>:
-            move_<%= singular_name %>_to_closed: Spostare questa inchiesta chiusa
-            move_<%= singular_name %>_to_open: Spostare questa indagine per aprire
             read_<%= singular_name %>: Leggi l'inchiesta
-            remove_<%= singular_name %>: "Sei sicuro di voler cancellare la richiesta di '%{name}'?"
-            title: <%= plural_name.titleize %>
-          toggle_status:
-            closed: "Inchiesta '%{<%= singular_name %>}' è chiuso"
-            reopened: "Inchiesta '%{<%= singular_name %>}' si riapre"
+            delete_<%= singular_name %>: "Sei sicuro di voler cancellare la richiesta di '%{name}'?"
           index:
             no_<%= plural_name %>: Non hai ancora ricevuto alcuna richiesta in.
           show:

--- a/core/lib/generators/refinery/form/templates/config/locales/lv.yml
+++ b/core/lib/generators/refinery/form/templates/config/locales/lv.yml
@@ -10,8 +10,8 @@ lv:
           privacy_policy: Mēs cienam Jūsu privātumu
       admin:
         <%= plural_name %>:
-          delete: Dzēst šo pieprasījumu
           <%= singular_name %>:
+            delete_<%= singular_name %>: Dzēst šo pieprasījumu
             read_<%= singular_name %>: Lasīt pieprasījumu
             said: sacīja
             mark_as_spam: Atzīmēt kā spamu

--- a/core/lib/generators/refinery/form/templates/config/locales/nb.yml
+++ b/core/lib/generators/refinery/form/templates/config/locales/nb.yml
@@ -13,17 +13,11 @@ nb:
       admin:
         <%= plural_name %>:
           <%= singular_name %>:
-            move_<%= singular_name %>_to_closed: Flytt denne forespørselen til lukket
-            move_<%= singular_name %>_to_open: Flytt denne forespørselen til åpen
             read_<%= singular_name %>: Les forespørselen
-            remove_<%= singular_name %>: "Er du sikker på at du ønsker å slette denne forespørselen fra '%{name}'?"
-            title: <%= plural_name.titleize %>
+            delete_<%= singular_name %>: "Er du sikker på at du ønsker å slette denne forespørselen fra '%{name}'?"
             said: sa
             mark_as_spam: Merk som søppel
             mark_as_ham: Flytt til innboksen
-          toggle_status:
-            closed: "Forespørselen '%{<%= singular_name %>}' er lukket"
-            reopened: "Forespørselen '%{<%= singular_name %>}' er gjenåpnet"
           submenu:
             update_notified: Oppdater hvem som blir informert
             edit_confirmation_email: Rediger bekreftelses e-posten

--- a/core/lib/generators/refinery/form/templates/config/locales/nl.yml
+++ b/core/lib/generators/refinery/form/templates/config/locales/nl.yml
@@ -11,8 +11,8 @@ nl:
           privacy_policy: Wij respecteren uw privacy
       admin:
         <%= plural_name %>:
-          delete: Deze <%= singular_name.humanize.downcase %> definitief verwijderen
           <%= singular_name %>:
+            delete_<%= singular_name %>: Deze <%= singular_name.humanize.downcase %> definitief verwijderen
             read_<%= singular_name %>: Lees de <%= singular_name.humanize.downcase %>
             said: zei
             mark_as_spam: Als spam markeren

--- a/core/lib/generators/refinery/form/templates/config/locales/pt-BR.yml
+++ b/core/lib/generators/refinery/form/templates/config/locales/pt-BR.yml
@@ -11,8 +11,8 @@ pt-BR:
           privacy_policy: "Nós valorizamos sua privacidade"
       admin:
         <%= plural_name %>:
-          delete: Remover esta mensagem para sempre
           <%= singular_name %>:
+            delete_<%= singular_name %>: Remover esta mensagem para sempre
             read_<%= singular_name %>: Ler a mensagem
             said: disse
             mark_as_spam: Marcar como spam

--- a/core/lib/generators/refinery/form/templates/config/locales/ru.yml
+++ b/core/lib/generators/refinery/form/templates/config/locales/ru.yml
@@ -13,17 +13,11 @@ ru:
       admin:
         <%= plural_name %>:
           <%= singular_name %>:
-            move_<%= singular_name %>_to_closed: "Переместить этот запрос в закрытые"
-            move_<%= singular_name %>_to_open: "Переместить этот запрос в открытые"
             read_<%= singular_name %>: "Прочитать запрос"
-            remove_<%= singular_name %>: "Вы уверены, что хотите удалить запрос от '%{name}'?"
-            title: <%= plural_name.titleize %>
+            delete_<%= singular_name %>: "Вы уверены, что хотите удалить запрос от '%{name}'?"
             said: "пишет"
             mark_as_spam: "Пометить как спам"
             mark_as_ham: "Переместить во Входящие"
-          toggle_status:
-            closed: "Запрос '%{<%= singular_name %>}' закрыт"
-            reopened: "Запрос '%{<%= singular_name %>}' открыт заново"
           submenu:
             inbox: "Входящие"
             spam: "Спам"

--- a/core/lib/generators/refinery/form/templates/config/locales/sk.yml
+++ b/core/lib/generators/refinery/form/templates/config/locales/sk.yml
@@ -11,8 +11,8 @@ sk:
           privacy_policy: Chránime vaše súkromie
       admin:
         <%= plural_name %>:
-          delete: Trvalo odstrániť <%= singular_name.humanize.downcase %>
           <%= singular_name %>:
+            delete_<%= singular_name %>: Trvalo odstrániť <%= singular_name.humanize.downcase %>
             read_<%= singular_name %>: Prečítať <%= singular_name.humanize.downcase %>
             said: povedal
             mark_as_spam: Označiť ako spam

--- a/core/lib/generators/refinery/form/templates/config/locales/sl.yml
+++ b/core/lib/generators/refinery/form/templates/config/locales/sl.yml
@@ -14,14 +14,8 @@ sl:
         <%= plural_name %>:
           <%= singular_name %>:
             said: pravi
-            move_<%= singular_name %>_to_closed: Premakni povpraševanje v zaprto
-            move_<%= singular_name %>_to_open: Premakni povpraševanje v odprto
             read_<%= singular_name %>: Preberi povpraševanje
-            remove_<%= singular_name %>: "Ali ste prepričani da želite odstraniti povpraševanje od '%{name}'?"
-            title: <%= plural_name.titleize %>
-          toggle_status:
-            closed: "Povpraševanje '%{<%= singular_name %>}' je zaprto"
-            reopened: "Povpraševanje '%{<%= singular_name %>}' je ponovno odprto"
+            delete_<%= singular_name %>: "Ali ste prepričani da želite odstraniti povpraševanje od '%{name}'?"
           index:
             no_<%= plural_name %>: Trenutno še ni nobenega povpraševanja.
           submenu:

--- a/core/lib/generators/refinery/form/templates/config/locales/tr.yml
+++ b/core/lib/generators/refinery/form/templates/config/locales/tr.yml
@@ -11,8 +11,8 @@ tr:
           privacy_policy: Mahremiyetinize onem veriyoruz.
       admin:
         <%= plural_name %>:
-          delete: Sonsuza dek <%= singular_name.humanize.downcase %> sil
           <%= singular_name %>:
+            delete_<%= singular_name %>: Sonsuza dek <%= singular_name.humanize.downcase %> sil
             read_<%= singular_name %>: Read the <%= singular_name.humanize.downcase %>
             said: dedi
             mark_as_spam: Spam olarak isaretle

--- a/core/lib/generators/refinery/form/templates/config/locales/zh-CN.yml
+++ b/core/lib/generators/refinery/form/templates/config/locales/zh-CN.yml
@@ -11,8 +11,8 @@ zh-CN:
           privacy_policy: 我们重视您的隐私
       admin:
         <%= plural_name %>:
-          delete: 永久删除 <%= singular_name.humanize.downcase %>
           <%= singular_name %>:
+            delete_<%= singular_name %>: 永久删除 <%= singular_name.humanize.downcase %>
             read_<%= singular_name %>: 阅读这个 <%= singular_name.humanize.downcase %>
             said: 说
             mark_as_spam: 标记为垃圾邮件

--- a/core/lib/generators/refinery/form/templates/config/routes.rb.erb
+++ b/core/lib/generators/refinery/form/templates/config/routes.rb.erb
@@ -12,17 +12,18 @@ Refinery::Core::Engine.routes.draw do
   # Admin routes
   namespace :<%= namespacing.underscore %>, :path => '' do
     namespace :admin, :path => "#{Refinery::Core.backend_route}" do
-      resources :<%= plural_name %> do
-      <% if include_spam? %>
+      resources :<%= plural_name %> do <% if include_spam? %>
         collection do
           get :spam
         end
         member do
           get :toggle_spam
-        end
-    <% end %>
+        end <% end %>
+  end
+
+      scope :path => '<%= plural_name %>' do
+        resources :settings, :only => [:edit, :update]
       end
-      resources :settings, :only => [:edit, :update]
     end
   end
 end

--- a/core/lib/generators/refinery/form/templates/config/routes.rb.erb
+++ b/core/lib/generators/refinery/form/templates/config/routes.rb.erb
@@ -11,7 +11,7 @@ Refinery::Core::Engine.routes.draw do
   # Admin routes
   namespace :<%= namespacing.underscore %>, :path => '' do
     namespace :admin, :path => "#{Refinery::Core.backend_route}/<%= namespacing.underscore %>" do
-      resources :<%= plural_name %>, :path => '' <% if @includes_spam %> do
+      resources :<%= plural_name %>, :path => '' <% if include_spam? %> do
         collection do
           get :spam
         end

--- a/core/lib/generators/refinery/form/templates/config/routes.rb.erb
+++ b/core/lib/generators/refinery/form/templates/config/routes.rb.erb
@@ -1,7 +1,8 @@
 Refinery::Core::Engine.routes.draw do
   # Frontend routes
   namespace :<%= namespacing.underscore %> do
-    resources :<%= plural_name %><%= ", :path => ''" if namespacing.underscore == plural_name %>, :only => [:new, :create] do
+
+    resources :<%= plural_name %><%= ", :path => ''" if namespacing.underscore == plural_name %>, :only => [:index, :new, :create] do
       collection do
         get :thank_you
       end
@@ -10,15 +11,17 @@ Refinery::Core::Engine.routes.draw do
 
   # Admin routes
   namespace :<%= namespacing.underscore %>, :path => '' do
-    namespace :admin, :path => "#{Refinery::Core.backend_route}/<%= namespacing.underscore %>" do
-      resources :<%= plural_name %>, :path => '' <% if include_spam? %> do
+    namespace :admin, :path => "#{Refinery::Core.backend_route}" do
+      resources :<%= plural_name %> do
+      <% if include_spam? %>
         collection do
           get :spam
         end
         member do
           get :toggle_spam
         end
-      end<% end %>
+    <% end %>
+      end
       resources :settings, :only => [:edit, :update]
     end
   end

--- a/core/lib/generators/refinery/form/templates/db/migrate/1_create_plural_name.rb.erb
+++ b/core/lib/generators/refinery/form/templates/db/migrate/1_create_plural_name.rb.erb
@@ -17,8 +17,10 @@ class Create<%= class_name.pluralize %> < ActiveRecord::Migration
 -%>
       t.<%= attribute.type %> :<%= attribute.name %>
 <% end -%>
-
-      t.timestamps
+<% if include_spam? %>
+       t.boolean :spam, :default => false
+     <% end %>
+     t.timestamps
     end
 
     add_index :refinery_<%= table_name %>, :id

--- a/core/lib/generators/refinery/form/templates/db/seeds.rb.erb
+++ b/core/lib/generators/refinery/form/templates/db/seeds.rb.erb
@@ -29,3 +29,10 @@ Refinery::I18n.frontend_locales.each do |lang|
     end
   end
 end
+
+(Refinery::<%= namespacing %>::Setting.methods.sort - Refinery::Setting.methods).each do |setting|
+
+    Refinery::<%= namespacing %>::Setting.send(setting) unless setting.to_s =~ /=$/
+
+end
+

--- a/core/lib/generators/refinery/form/templates/db/seeds.rb.erb
+++ b/core/lib/generators/refinery/form/templates/db/seeds.rb.erb
@@ -12,7 +12,7 @@ Refinery::I18n.frontend_locales.each do |lang|
 
   if defined?(Refinery::Page)
     url = "/<%= [(namespacing.underscore if namespacing.underscore != plural_name), plural_name].compact.join('/') %>"
-    page = Refinery::Page.where(:link_url => url).first_or_create!(
+    page = Refinery::Page.where(:link_url => "#{url}/new").first_or_create!(
       :title => "<%= class_name.pluralize.underscore.titleize %>",
       :deletable => false,
       :menu_match => "^#{url}(\/|\/.+?|)$"

--- a/core/lib/generators/refinery/form/templates/readme.md
+++ b/core/lib/generators/refinery/form/templates/readme.md
@@ -1,0 +1,10 @@
+# <%= extension_plural_name.titleize %> extension for Refinery CMS.
+
+## How to build this extension as a gem
+
+    cd vendor/extensions/<%= extension_plural_name %>
+    gem build refinerycms-<%= extension_plural_name %>.gemspec
+    gem install refinerycms-<%= extension_plural_name %>.gem
+
+    # Sign up for a http://rubygems.org/ account and publish the gem
+    gem push refinerycms-<%= extension_plural_name %>.gem

--- a/core/lib/generators/refinery/form/templates/refinerycms-plural_name.gemspec
+++ b/core/lib/generators/refinery/form/templates/refinerycms-plural_name.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   # Runtime dependencies
   s.add_dependency    'refinerycms-core',     '~> <%= Refinery::Version %>'
   s.add_dependency    'refinerycms-settings', '~> <%= [Refinery::Version.major, Refinery::Version.minor, 0].join(".") %>'
+  s.add_dependency    'filters_spam', '~> 0.3'
 
   # Development dependencies (usually used for testing)
   s.add_development_dependency 'refinerycms-testing', '~> <%= Refinery::Version %>'

--- a/core/lib/generators/refinery/form/templates/refinerycms-plural_name.gemspec
+++ b/core/lib/generators/refinery/form/templates/refinerycms-plural_name.gemspec
@@ -13,4 +13,8 @@ Gem::Specification.new do |s|
   # Runtime dependencies
   s.add_dependency    'refinerycms-core',     '~> <%= Refinery::Version %>'
   s.add_dependency    'refinerycms-settings', '~> <%= [Refinery::Version.major, Refinery::Version.minor, 0].join(".") %>'
+
+  # Development dependencies (usually used for testing)
+  s.add_development_dependency 'refinerycms-testing', '~> <%= Refinery::Version %>'
+
 end

--- a/core/lib/generators/refinery/form/templates/spec/controllers/refinery/plural_name/plural_name_controller_spec.rb
+++ b/core/lib/generators/refinery/form/templates/spec/controllers/refinery/plural_name/plural_name_controller_spec.rb
@@ -1,0 +1,64 @@
+require "spec_helper"
+
+module Refinery
+  module <%= namespacing %>
+    describe <%= class_name.pluralize %>Controller do
+
+      routes { Refinery::Core::Engine.routes }
+
+      before(:each) do
+        Refinery::<%= namespacing %>::Engine::load_seed
+
+        @new_page = Refinery::Page.new
+        Refinery::Page.stub(:find_by_link_url).and_return(@new_page)
+      end
+
+      describe "GET new" do
+        it "before_filter assigns a new <%= singular_name %>" do
+          get :new
+          expect(assigns(:<%= singular_name %>)).to be_a_new(<%= class_name %>)
+        end
+        it "before_filter assigns page to <%= plural_name %>/new" do
+          get :new
+          expect(assigns(:page)).to eq @new_page
+        end
+      end
+
+      describe "POST create" do
+
+        before(:each){
+          <%= class_name %>.any_instance.stub(:save).and_return( true )
+        }
+
+        it "before_filter assigns page to <%= plural_name %>/new" do
+          post :create
+          expect(assigns(:page)).to eq @new_page
+        end
+
+        it "before_filter assigns a new <%= singular_name %>" do
+          post :create
+          expect(assigns(:<%= singular_name %>)).to be_a_new(<%= class_name %>)
+        end
+
+        it "redirects to thank_you" do
+          post :create #, <%= singular_name %>: FactoryGirl.attributes_for(:<%= singular_name %>)
+          response.should redirect_to "/<%= plural_name %>/thank_you"
+        end
+
+        describe "when it can't save the <%= singular_name %>" do
+
+          before(:each) {
+            <%= class_name %>.any_instance.stub(:save).and_return( false )
+          }
+
+          it "redirects to new if it can't save" do
+            post :create #, <%= singular_name %>: @no_save_<%= singular_name %>
+
+            response.should render_template(:new)
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/core/lib/generators/refinery/form/templates/spec/features/refinery/namespace/admin/plural_name_spec.rb.erb
+++ b/core/lib/generators/refinery/form/templates/spec/features/refinery/namespace/admin/plural_name_spec.rb.erb
@@ -75,8 +75,8 @@ module Refinery
             page.should have_content("'UniqueTitleOne' was successfully removed.")
             Refinery::<%= namespacing %>::<%= class_name %>.count.should == 0
           end
-        end
-<% end %>
+          end
+        <% end %>
       end
     end
   end

--- a/core/lib/generators/refinery/form/templates/spec/features/refinery/namespace/admin/plural_name_spec.rb.erb
+++ b/core/lib/generators/refinery/form/templates/spec/features/refinery/namespace/admin/plural_name_spec.rb.erb
@@ -3,9 +3,10 @@ require "spec_helper"
 
 module Refinery
   module <%= namespacing %>
-    describe "Admin" do
-      describe "<%= plural_name %>" do
+    module Admin
+      describe <%= class_name %> do
         refinery_login_with :refinery_user
+
 <% if (title = attributes.detect { |a| a.type.to_s == "string" }).present? %>
 
        describe "<%= plural_name %> list" do
@@ -21,17 +22,98 @@ module Refinery
           end
         end
 
-      <% if include_spam? %>
+       describe "show" do
+         let!(:<%= singular_name %>) do
+            FactoryGirl.create(:<%= singular_name %>, :<%= title.name %> => "UniqueTitleOne")
+          end
+
+         it "has expected text and menu" do
+           visit refinery.<%= namespacing.underscore %>_admin_<%= plural_name %>_path
+
+           click_link "Read the <%= singular_name %>"
+
+           expect(page).to have_content("UniqueTitleOne")
+           expect(page).not_to have_content("UniqueTitleTwo")
+
+           within "#actions" do
+             expect(page).to have_content("Age")
+             expect(page).to have_content("Back to all <%= plural_name %>")
+             expect(page).to have_selector("a[href='/#{Refinery::Core.backend_route}/<%= plural_name %>']")
+             expect(page).to have_content("Remove this <%= singular_name %> forever")
+             expect(page).to have_selector("a[href='/#{Refinery::Core.backend_route}/<%= plural_name %>/#{<%= singular_name %>.id}']")
+           end
+         end
+       end
+
+       describe "when no " do
+         before { Refinery::<%= namespacing %>::<%= class_name %>.destroy_all }
+
+         context "<%= plural_name %>" do
+           it "shows expected message" do
+            visit refinery.<%= plural_name %>_admin_<%= plural_name %>_path
+
+            expect(page).to have_content("You have not received any <%= plural_name %> yet.")
+
+            end
+           end
+           <% if include_spam? %>
+         context "spam <%= plural_name %>" do
+            it "shows expected message" do
+              visit refinery.spam_<%= plural_name %>_admin_<%= plural_name %>_path
+
+              expect(page).to have_content("Hooray! You don't have any spam.")
+            end
+         end
+          <% end %>
+       end
+
+      describe "action links" do
+        before { visit refinery.<%= plural_name %>_admin_<%= plural_name %>_path }
+
+        specify "in the side pane" do
+          within "#actions" do
+            expect(page).to have_content("Inbox")
+            expect(page).to have_selector("a[href='/#{Refinery::Core.backend_route}/<%= plural_name %>']")
+           <% if include_spam? %>
+            expect(page).to have_content("Spam")
+            expect(page).to have_selector("a[href='/#{Refinery::Core.backend_route}/<%= plural_name %>/spam']")
+          <% end %>
+            expect(page).to have_content("Update who gets notified")
+            expect(page).to have_selector("a[href*='/#{Refinery::Core.backend_route}/<%= plural_name %>/settings/<%= singular_name %>_notification_recipients/edit']")
+            expect(page).to have_content("Edit confirmation email")
+            expect(page).to have_selector("a[href*='/#{Refinery::Core.backend_route}/<%= plural_name %>/settings/<%= singular_name %>_confirmation_message/edit']")
+          end
+        end
+      end
+
+
+       <% if include_spam? %>
+
         describe "mark as ham" do
+          before { FactoryGirl.create(:<%= singular_name %>, :<%= title.name %> => "UniqueTitleOne") }
 
           it "should succeed" do
             visit refinery.<%= namespacing.underscore %>_admin_<%= plural_name %>_path
 
             within ".actions" do
-              click_link "Mark as ham"
+              click_link ::I18n.t('mark_as_spam', :scope => "refinery.<%= namespacing.underscore %>.admin.<%= plural_name %>.<%= singular_name %>")
             end
 
-            fail("Implement this test")
+            Refinery::<%= namespacing %>::<%= class_name %>.count.should == 1
+            Refinery::<%= namespacing %>::<%= class_name %>.ham.count.should == 0
+            Refinery::<%= namespacing %>::<%= class_name %>.spam.count.should == 1
+
+
+            visit refinery.spam_<%= namespacing.underscore %>_admin_<%= plural_name %>_path
+
+            within ".actions" do
+              click_link ::I18n.t('mark_as_ham', :scope => "refinery.<%= namespacing.underscore %>.admin.<%= plural_name %>.<%= singular_name %>")
+            end
+
+            Refinery::<%= namespacing %>::<%= class_name %>.count.should == 1
+            Refinery::<%= namespacing %>::<%= class_name %>.ham.count.should == 1
+            Refinery::<%= namespacing %>::<%= class_name %>.spam.count.should == 0
+        end
         end
 
         describe "mark as spam" do
@@ -40,13 +122,18 @@ module Refinery
           it "should succeed" do
             visit refinery.<%= namespacing.underscore %>_admin_<%= plural_name %>_path
 
+            Refinery::<%= namespacing %>::<%= class_name %>.count.should == 1
+            Refinery::<%= namespacing %>::<%= class_name %>.ham.count.should == 1
+            Refinery::<%= namespacing %>::<%= class_name %>.spam.count.should == 0
+
             within ".actions" do
-              click_link "Mark as spam"
+              click_link ::I18n.t('mark_as_spam', :scope => "refinery.<%= namespacing.underscore %>.admin.<%= plural_name %>.<%= singular_name %>")
+
             end
 
-            fail("Implement this test")
-
-    end
+            Refinery::<%= namespacing %>::<%= class_name %>.count.should == 1
+            Refinery::<%= namespacing %>::<%= class_name %>.ham.count.should == 0
+            Refinery::<%= namespacing %>::<%= class_name %>.spam.count.should == 1
           end
         end
       <% end %>

--- a/core/lib/generators/refinery/form/templates/spec/features/refinery/namespace/admin/plural_name_spec.rb.erb
+++ b/core/lib/generators/refinery/form/templates/spec/features/refinery/namespace/admin/plural_name_spec.rb.erb
@@ -63,6 +63,19 @@ module Refinery
             Refinery::<%= namespacing %>::<%= class_name %>.count.should == 0
           end
         end
+
+          describe "destroy from <%= singular_name %> show page" do
+          before { FactoryGirl.create(:<%= singular_name %>, :<%= title.name %> => "UniqueTitleOne") }
+
+          it "should succeed" do
+            visit refinery.<%= namespacing.underscore %>_admin_<%= singular_name %>_path( :id => '1')
+
+            click_link "Remove this <%= singular_name.titleize.downcase %> forever"
+
+            page.should have_content("'UniqueTitleOne' was successfully removed.")
+            Refinery::<%= namespacing %>::<%= class_name %>.count.should == 0
+          end
+        end
 <% end %>
       end
     end

--- a/core/lib/generators/refinery/form/templates/spec/features/refinery/namespace/admin/plural_name_spec.rb.erb
+++ b/core/lib/generators/refinery/form/templates/spec/features/refinery/namespace/admin/plural_name_spec.rb.erb
@@ -1,0 +1,68 @@
+# encoding: utf-8
+require "spec_helper"
+
+module Refinery
+  module <%= namespacing %>
+    describe "Admin" do
+      describe "<%= plural_name %>" do
+        refinery_login_with :refinery_user
+<% if (title = attributes.detect { |a| a.type.to_s == "string" }).present? %>
+
+       describe "<%= plural_name %> list" do
+          before do
+            FactoryGirl.create(:<%= singular_name %>, :<%= title.name %> => "UniqueTitleOne")
+            FactoryGirl.create(:<%= singular_name %>, :<%= title.name %> => "UniqueTitleTwo")
+          end
+
+          it "shows two items" do
+            visit refinery.<%= namespacing.underscore %>_admin_<%= plural_name %>_path
+            page.should have_content("UniqueTitleOne")
+            page.should have_content("UniqueTitleTwo")
+          end
+        end
+
+        describe "mark as ham" do
+
+          it "should succeed" do
+            visit refinery.<%= namespacing.underscore %>_admin_<%= plural_name %>_path
+
+            within ".actions" do
+              click_link "Mark as ham"
+            end
+
+            fail("Implement this test")
+        end
+
+        describe "mark as spam" do
+          before { FactoryGirl.create(:<%= singular_name %>, :<%= title.name %> => "A <%= title.name %>") }
+
+          it "should succeed" do
+            visit refinery.<%= namespacing.underscore %>_admin_<%= plural_name %>_path
+
+            within ".actions" do
+              click_link "Mark as spam"
+            end
+
+            fail("Implement this test")
+
+          end
+        end
+
+        describe "destroy" do
+          before { FactoryGirl.create(:<%= singular_name %>, :<%= title.name %> => "UniqueTitleOne") }
+
+          it "should succeed" do
+            visit refinery.<%= namespacing.underscore %>_admin_<%= plural_name %>_path
+
+            click_link "Remove this <%= singular_name.titleize.downcase %> forever"
+
+            page.should have_content("'UniqueTitleOne' was successfully removed.")
+            Refinery::<%= namespacing %>::<%= class_name %>.count.should == 0
+          end
+        end
+<% end %>
+      end
+    end
+  end
+end
+end

--- a/core/lib/generators/refinery/form/templates/spec/features/refinery/namespace/admin/plural_name_spec.rb.erb
+++ b/core/lib/generators/refinery/form/templates/spec/features/refinery/namespace/admin/plural_name_spec.rb.erb
@@ -21,6 +21,7 @@ module Refinery
           end
         end
 
+      <% if include_spam? %>
         describe "mark as ham" do
 
           it "should succeed" do
@@ -45,8 +46,10 @@ module Refinery
 
             fail("Implement this test")
 
+    end
           end
         end
+      <% end %>
 
         describe "destroy" do
           before { FactoryGirl.create(:<%= singular_name %>, :<%= title.name %> => "UniqueTitleOne") }
@@ -64,5 +67,4 @@ module Refinery
       end
     end
   end
-end
 end

--- a/core/lib/generators/refinery/form/templates/spec/features/refinery/namespace/admin/settings_spec.rb.erb
+++ b/core/lib/generators/refinery/form/templates/spec/features/refinery/namespace/admin/settings_spec.rb.erb
@@ -1,0 +1,56 @@
+# encoding: utf-8
+require "spec_helper"
+
+module Refinery
+  module <%= namespacing %>
+  describe "Settings" do
+    refinery_login_with :refinery_user
+
+    <% if (title = attributes.detect { |a| a.type.to_s == "string"  }).present? %>
+
+    describe "update who gets notified" do
+      before do
+        Rails.cache.clear
+        Refinery::<%= namespacing %>::Setting.notification_recipients
+      end
+
+      it "sets receiver", :js => true do
+        visit refinery.<%= plural_name %>_admin_<%= plural_name %>_path
+
+        click_link ::I18n.t('update_notified', scope: 'refinery.<%= namespacing.underscore %>.admin.<%= plural_name %>.submenu')
+
+        within_frame "dialog_iframe" do
+          fill_in ::I18n.t('settings_value_name', scope: 'refinery.<%= namespacing.underscore %>.admin.settings.notification_recipients_form'), :with => "phil@refinerycms.com"
+          click_button "submit_button"
+        end
+
+        expect(page).to have_content("Notification Recipients was successfully updated.")
+      end
+    end
+
+    describe "updating confirmation email copy" do
+      before do
+        Rails.cache.clear
+        Refinery::<%= namespacing %>::Setting.confirmation_message
+        Refinery::<%= namespacing %>::Setting.confirmation_subject
+      end
+
+      it "sets subject and message", :js => true do
+        visit refinery.<%= plural_name %>_admin_<%= plural_name %>_path
+
+        click_link ::I18n.t('edit_confirmation_email', scope: 'refinery.<%= namespacing.underscore %>.admin.<%= plural_name %>.submenu')
+
+        within_frame "dialog_iframe" do
+          fill_in ::I18n.t('subject', scope: 'refinery.<%= namespacing.underscore %>.admin.settings.confirmation_email_form'), :with => "subject"
+          fill_in ::I18n.t('message', scope: 'refinery.<%= namespacing.underscore %>.admin.settings.confirmation_email_form'), :with => "message"
+
+          click_button "submit_button"
+        end
+
+        expect(page).to have_content("Confirmation Message was successfully updated.")
+      end
+    end
+    <% end %>
+  end
+  end
+end

--- a/core/lib/generators/refinery/form/templates/spec/features/refinery/namespace/singular_name_spec.rb.erb
+++ b/core/lib/generators/refinery/form/templates/spec/features/refinery/namespace/singular_name_spec.rb.erb
@@ -12,7 +12,7 @@ module Refinery
       describe "Create <%= singular_name %>" do
 
         before do
-          visit refinery.<%= plural_name %>_new_<%= singular_name %>_path
+          visit refinery.new_<%= plural_name %>_<%= singular_name %>_path
         end
 
         it "should create a new item" do

--- a/core/lib/generators/refinery/form/templates/spec/features/refinery/namespace/singular_name_spec.rb.erb
+++ b/core/lib/generators/refinery/form/templates/spec/features/refinery/namespace/singular_name_spec.rb.erb
@@ -1,0 +1,35 @@
+# encoding: utf-8
+require "spec_helper"
+
+module Refinery
+  module <%= namespacing %>
+    describe "<%= plural_name %>" do
+
+      before(:each) do
+        Refinery::<%= namespacing %>::Engine::load_seed
+      end
+
+      describe "Create <%= singular_name %>" do
+
+        before do
+          visit refinery.<%= plural_name %>_new_<%= singular_name %>_path
+        end
+
+        it "should create a new item" do
+          <% attributes.each do |a| -%>
+            <% if a.type == :string -%>
+                   fill_in "<%= singular_name %>_<%= a.name %>", :with => "Test"
+                 <% elsif a.type == :text -%>
+                   fill_in "<%= singular_name %>_<%= a.name %>", :with => "Test"
+                 <% end -%>
+               <% end -%>
+               click_button ::I18n.t('.refinery.<%= plural_name %>.<%= plural_name %>.new.send')
+
+               page.should have_content("Thank You")
+               Refinery::<%= namespacing %>::<%= class_name %>.count.should == 1
+        end
+      end
+    end
+  end
+end
+

--- a/core/lib/generators/refinery/form/templates/spec/models/refinery/namespace/setting_spec.rb
+++ b/core/lib/generators/refinery/form/templates/spec/models/refinery/namespace/setting_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+module Refinery
+  module <%= namespacing %>
+    describe Setting, :type => :model do
+      describe ".confirmation_message=" do
+        it "delegates to Refinery::Setting#set" do
+          expect(Refinery::Setting).to receive(:set).
+            with(:<%= singular_name %>_confirmation_message, "some value")
+
+          Refinery::<%= namespacing %>::Setting.confirmation_message = "some value"
+        end
+      end
+
+      describe ".confirmation_subject=" do
+        it "delegates to Refinery::Setting#set" do
+          expect(Refinery::Setting).to receive(:set).
+            with(:<%= singular_name %>_confirmation_subject, "some value")
+
+          Refinery::<%= namespacing %>::Setting.confirmation_subject = "some value"
+        end
+      end
+
+      describe ".notification_recipients=" do
+        it "delegates to Refinery::Setting#set" do
+          expect(Refinery::Setting).to receive(:set).
+            with(:<%= singular_name %>_notification_recipients, "some value")
+
+          Refinery::<%= namespacing %>::Setting.notification_recipients = "some value"
+        end
+      end
+    end
+  end
+end

--- a/core/lib/generators/refinery/form/templates/spec/models/refinery/namespace/singular_name_spec.rb.erb
+++ b/core/lib/generators/refinery/form/templates/spec/models/refinery/namespace/singular_name_spec.rb.erb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+module Refinery
+  module <%= namespacing %>
+    describe <%= class_name %> do
+      describe "validations" do
+        subject do
+          FactoryGirl.create(:<%= singular_name %><% if (title = attributes.detect { |a| a.type.to_s == "string" }).present? -%>,
+          :<%= title.name %> => "Refinery CMS"<% end %>)
+        end
+
+        it { should be_valid }
+        its(:errors) { should be_empty }
+<% if title -%>
+        its(:<%= title.name %>) { should == "Refinery CMS" }
+<% end -%>
+      end
+    end
+  end
+end

--- a/core/lib/generators/refinery/form/templates/spec/requests/refinery/plural_name/plural_name_requests_spec.rb
+++ b/core/lib/generators/refinery/form/templates/spec/requests/refinery/plural_name/plural_name_requests_spec.rb
@@ -3,9 +3,11 @@ require "spec_helper"
 module Refinery
   module <%= namespacing %>
 
-    Refinery::<%= namespacing %>::Engine::load_seed
-
     describe "<%= namespacing %> request specs" do
+
+      before(:each) do
+        Refinery::<%= namespacing %>::Engine.load_seed
+      end
 
       it "successfully gets the index path as redirection" do
         get("/<%= plural_name %>")

--- a/core/lib/generators/refinery/form/templates/spec/requests/refinery/plural_name/plural_name_requests_spec.rb
+++ b/core/lib/generators/refinery/form/templates/spec/requests/refinery/plural_name/plural_name_requests_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+module Refinery
+  module <%= namespacing %>
+    describe "<%= plural_name %> request specs" do
+
+      # routes { Refinery::Core::Engine.routes }
+
+      it "redirects the index path to new" do
+subject { get "/<%= plural_name %>" }
+
+        expect(response).to redirect_to(:wq
+                                        "/<%= plural_name %>/new")
+
+      end
+
+    end
+  end
+end

--- a/core/lib/generators/refinery/form/templates/spec/requests/refinery/plural_name/plural_name_requests_spec.rb
+++ b/core/lib/generators/refinery/form/templates/spec/requests/refinery/plural_name/plural_name_requests_spec.rb
@@ -2,16 +2,27 @@ require "spec_helper"
 
 module Refinery
   module <%= namespacing %>
-    describe "<%= plural_name %> request specs" do
 
-      # routes { Refinery::Core::Engine.routes }
+    Refinery::<%= namespacing %>::Engine::load_seed
 
-      it "redirects the index path to new" do
-subject { get "/<%= plural_name %>" }
+    describe "<%= namespacing %> request specs" do
 
-        expect(response).to redirect_to(:wq
-                                        "/<%= plural_name %>/new")
+      it "successfully gets the index path as redirection" do
+        get("/<%= plural_name %>")
+        expect(response).to be_redirect
+        expect(response).to redirect_to("/<%= plural_name %>/new")
+      end
 
+      it "successfully gets the new path" do
+        get("/<%= plural_name %>/new")
+        expect(response).to be_success
+        expect(response).to render_template(:new)
+      end
+
+      it "successfully gets the thank_you path" do
+        get("/<%= plural_name %>/thank_you")
+        expect(response).to be_success
+        expect(response).to render_template(:thank_you)
       end
 
     end

--- a/core/lib/generators/refinery/form/templates/spec/routing/refinery/plural_name/admin/plural_name_routing_spec.rb
+++ b/core/lib/generators/refinery/form/templates/spec/routing/refinery/plural_name/admin/plural_name_routing_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+
+describe "<%= plural_name %> admin routing" do
+
+  routes { Refinery::Core::Engine.routes }
+
+  it "can route to new" do
+    expect( :get => "/refinery/<%= plural_name %>/new" ).to route_to(
+      :controller => "refinery/<%= plural_name %>/admin/<%= plural_name %>",
+      :action => "new",
+      :locale => :en
+    )
+
+  end
+
+  it "can route to create" do
+    expect( :post => "/refinery/<%= plural_name %>" ).to be_routable
+  end
+
+  it "can route to show" do
+    expect( :get => "/refinery/<%= plural_name %>/1" ).to route_to(
+      :controller => "refinery/<%= plural_name %>/admin/<%= plural_name %>",
+      :action => "show",
+      :id => '1',
+      :locale => :en
+    )
+  end
+
+  it "can route to edit" do
+    expect( :get => "/refinery/<%= plural_name %>/1/edit" ).to route_to(
+      :controller => "refinery/<%= plural_name %>/admin/<%= plural_name %>",
+      :action => "edit",
+      :id => "1",
+      :locale => :en
+    )
+  end
+
+  it "does not route to update" do
+    expect( :update => "/refinery/<%= plural_name %>/1" ).not_to be_routable
+  end
+
+  it "does route to delete" do
+    expect( :delete => "/refinery/<%= plural_name %>/1" ).to route_to(
+      :controller => "refinery/<%= plural_name %>/admin/<%= plural_name %>",
+      :action => "destroy",
+      :id => '1',
+      :locale => :en
+    )
+  end
+
+end

--- a/core/lib/generators/refinery/form/templates/spec/routing/refinery/plural_name/plural_name_routing_spec.rb
+++ b/core/lib/generators/refinery/form/templates/spec/routing/refinery/plural_name/plural_name_routing_spec.rb
@@ -4,8 +4,15 @@ describe "<%= namespacing %> front-end routing" do
 
   routes { Refinery::Core::Engine.routes }
 
+  it "can route to index" do
+    expect( :get => "/<%= plural_name %>" ).to route_to(
+      :controller => "refinery/<%= plural_name %>/<%= plural_name %>",
+      :action => "index",
+      :locale => :en
+    )
+  end
+
   it "can route to new" do
-    expect( :get => "/<%= plural_name %>/new" ).to be_routable
     expect( :get => "/<%= plural_name %>/new" ).to route_to(
       :controller => "refinery/<%= plural_name %>/<%= plural_name %>",
       :action => "new",
@@ -14,7 +21,6 @@ describe "<%= namespacing %> front-end routing" do
   end
 
   it "can route to create" do
-    expect( :post => "/<%= plural_name %>" ).to be_routable
     expect( :post => "/<%= plural_name %>" ).to route_to(
       :controller => "refinery/<%= plural_name %>/<%= plural_name %>",
       :action => "create",
@@ -26,14 +32,6 @@ describe "<%= namespacing %> front-end routing" do
     expect( :get => "/<%= plural_name %>/thank_you" ).to route_to(
       :controller => "refinery/<%= plural_name %>/<%= plural_name %>",
       :action => "thank_you",
-      :locale => :en
-    )
-  end
-
-  it "does not route to index" do
-    expect( :get => "/<%= plural_name %>" ).not_to route_to(
-      :controller => "refinery/<%= plural_name %>/<%= plural_name %>",
-      :action => "index",
       :locale => :en
     )
   end

--- a/core/lib/generators/refinery/form/templates/spec/routing/refinery/plural_name/plural_name_routing_spec.rb
+++ b/core/lib/generators/refinery/form/templates/spec/routing/refinery/plural_name/plural_name_routing_spec.rb
@@ -1,0 +1,65 @@
+require "spec_helper"
+
+describe "<%= namespacing %> front-end routing" do
+
+  routes { Refinery::Core::Engine.routes }
+
+  it "can route to new" do
+    expect( :get => "/<%= plural_name %>/new" ).to be_routable
+    expect( :get => "/<%= plural_name %>/new" ).to route_to(
+      :controller => "refinery/<%= plural_name %>/<%= plural_name %>",
+      :action => "new",
+      :locale => :en
+    )
+  end
+
+  it "can route to create" do
+    expect( :post => "/<%= plural_name %>" ).to be_routable
+    expect( :post => "/<%= plural_name %>" ).to route_to(
+      :controller => "refinery/<%= plural_name %>/<%= plural_name %>",
+      :action => "create",
+      :locale => :en
+    )
+  end
+
+  it "routes to thank_you" do
+    expect( :get => "/<%= plural_name %>/thank_you" ).to route_to(
+      :controller => "refinery/<%= plural_name %>/<%= plural_name %>",
+      :action => "thank_you",
+      :locale => :en
+    )
+  end
+
+  it "does not route to index" do
+    expect( :get => "/<%= plural_name %>" ).not_to route_to(
+      :controller => "refinery/<%= plural_name %>/<%= plural_name %>",
+      :action => "index",
+      :locale => :en
+    )
+  end
+
+  it "does not route to show" do
+    expect( :get => "/<%= plural_name %>/1" ).not_to route_to(
+      :controller => "refinery/<%= plural_name %>/<%= plural_name %>",
+      :action => "show",
+      :locale => :en
+    )
+  end
+
+  it "does not route to edit" do
+    expect( :get => "/<%= plural_name %>/1/edit" ).not_to route_to(
+      :controller => "refinery/<%= plural_name %>/<%= plural_name %>",
+      :action => "edit",
+      :locale => :en
+    )
+  end
+
+  it "does not route to update" do
+    expect( :update => "/<%= plural_name %>/1" ).not_to be_routable
+  end
+
+  it "does not route to delete" do
+    expect( :delete => "/<%= plural_name %>/1" ).not_to be_routable
+  end
+
+end

--- a/core/lib/generators/refinery/form/templates/spec/spec_helper.rb
+++ b/core/lib/generators/refinery/form/templates/spec/spec_helper.rb
@@ -1,0 +1,33 @@
+# Configure Rails Environment
+ENV["RAILS_ENV"] ||= 'test'
+
+if File.exist?(dummy_path = File.expand_path('../dummy/config/environment.rb', __FILE__))
+  require dummy_path
+elsif File.dirname(__FILE__) =~ %r{vendor/extensions}
+  # Require the path to the refinerycms application this is vendored inside.
+  require File.expand_path('../../../../../config/environment', __FILE__)
+else
+  puts "Could not find a config/environment.rb file to require. Please specify this in #{File.expand_path(__FILE__)}"
+end
+
+require 'rspec/rails'
+require 'capybara/rspec'
+
+Rails.backtrace_cleaner.remove_silencers!
+
+RSpec.configure do |config|
+  config.mock_with :rspec
+  config.treat_symbols_as_metadata_keys_with_true_values = true
+  config.filter_run :focus => true
+  config.run_all_when_everything_filtered = true
+  config.infer_spec_type_from_file_location!
+  config.expose_current_running_example_as :example
+end
+
+# Requires supporting files with custom matchers and macros, etc,
+# in ./support/ and its subdirectories including factories.
+([Rails.root.to_s] | ::Refinery::Plugins.registered.pathnames).map{|p|
+  Dir[File.join(p, 'spec', 'support', '**', '*.rb').to_s]
+}.flatten.sort.each do |support_file|
+  require support_file
+end

--- a/core/lib/generators/refinery/form/templates/spec/support/factories/refinery/plural_name.rb.erb
+++ b/core/lib/generators/refinery/form/templates/spec/support/factories/refinery/plural_name.rb.erb
@@ -1,0 +1,7 @@
+<% if (title = attributes.detect { |a| a.type.to_s == "string" }).present? %>
+FactoryGirl.define do
+  factory :<%= singular_name %>, :class => Refinery::<%= namespacing %>::<%= class_name %> do
+    sequence(:<%= title.name %>) { |n| "refinery#{n}" }
+  end
+end
+<% end %>

--- a/core/lib/generators/refinery/form/templates/tasks/rspec.rake
+++ b/core/lib/generators/refinery/form/templates/tasks/rspec.rake
@@ -1,0 +1,6 @@
+require 'rspec/core/rake_task'
+
+desc "Run specs"
+RSpec::Core::RakeTask.new do |t|
+  t.pattern = "./spec"
+end

--- a/core/lib/generators/refinery/form/templates/tasks/testing.rake
+++ b/core/lib/generators/refinery/form/templates/tasks/testing.rake
@@ -1,0 +1,8 @@
+namespace :refinery do
+  namespace :testing do
+    # Put any code in here that you want run when you test this extension against a dummy app.
+    # For example, the call to require your gem and start your generator.
+    task :setup_extension do
+    end
+  end
+end


### PR DESCRIPTION
I closed out the previous pull request -- this is now my latest branch. 

The forms had a number of problems and you couldn't generate a working one.

- Fixed a number of bugs
- Added a bunch of specs and fixed a few deprecation warnings on rspec.
- Create/delete functionality seems to be working well
- After previous discussion about the index/new route I reinstated the index action instead of a redirect route. It's by far the simplest solution -- the :index route simply redirects to :new in the controller.
- Forms can be created with all sorts of parameters and the specs (e.g. for creating an item) don't cover all the different field types that can be added to a model. 
- Spam filter feature is broken. If you turn it on via the generator option there will be ~6 failing tests and I don't know what will or won't work!

I'd be happy to work on fixing the spam filter in, but there's a few details about that I really don't understand. e.g.: How can we identify which fields are going to be used for spam filtering? The spam filter seems to have to be customised for any particular model, so perhaps in the case of the form the generator should create only the minimum setup? I don't know what that is!

Chris