### PR TITLE
Revert "Added a little hack for WYMeditor image dialog paging."

### DIFF
--- a/images/app/views/refinery/admin/images/insert.html.erb
+++ b/images/app/views/refinery/admin/images/insert.html.erb
@@ -44,11 +44,6 @@
       }).create();
 
       $('input[type=radio][value=upload_image]:checked').click();
-      <% if params[:page] && params[:wymeditor] %>
-      if(parent && parent.wym && typeof(parent.WYMeditor) !== 'undefined') {
-        parent.WYMeditor.INIT_DIALOG(parent.wym);
-      }
-      <% end %>
     });
   </script>
 <% end %>


### PR DESCRIPTION
This reverts commit 0ca6dbaeaf6566ac4991323ac4a1b613fd6b7fed.

The commit was introduced because of issue refinery/refinerycms#2639

However, I don't believe it is needed.  Instead this alternate fix should do the job:  https://github.com/asgeo1/refinerycms-wymeditor/commit/a2106da63deae94e510ea030e258d87a724b0c4b

Which was submitted in a PR for this issue: parndt/refinerycms-wymeditor#16

You just need to make sure you're using the latest version of `refinerycms-wymeditor` gem.
