### PR TITLE
Instead of being configurable, made xhr_paging always enabled.

### DIFF
--- a/authentication/app/controllers/refinery/admin/users_controller.rb
+++ b/authentication/app/controllers/refinery/admin/users_controller.rb
@@ -4,8 +4,7 @@ module Refinery
 
       crudify :'refinery/user',
               :order => 'username ASC',
-              :title_attribute => 'username',
-              :xhr_paging => true
+              :title_attribute => 'username'
 
       before_action :find_available_plugins, :find_available_roles,
                     :only => [:new, :create, :edit, :update]

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 * Removed `attr_accessible` in favour of strong parameters. [#2518](https://github.com/refinery/refinerycms/pull/2518). [Philip Arndt](https://github.com/parndt)
 * Removed the Dashboard extension, now the left most tab is selected when logging in. [#2727](https://github.com/refinery/refinerycms/pull/2727). [Philip Arndt](https://github.com/parndt)
 * Removed special 'Refinery Translator' role, introduced in 0.9.22, from the core. [#2730](https://github.com/refinery/refinerycms/pull/2730). [Philip Arndt](https://github.com/parndt)
+* Enabled XHR paging by default, no configuration is needed. [Philip Arndt](https://github.com/parndt)
 
 * [See full list](https://github.com/refinery/refinerycms/compare/2-1-stable...master)
 

--- a/core/app/views/refinery/admin/_javascripts.html.erb
+++ b/core/app/views/refinery/admin/_javascripts.html.erb
@@ -13,11 +13,3 @@
   <%= javascript_include_tag js %>
 <% end %>
 <%= yield :javascripts %>
-
-<% if controller.class.respond_to?(:xhr_pageable?) && !controller.class.xhr_pageable? %>
-  <script>
-    $(document).ready(function() {
-      $('.pagination_container .pagination a').off('click');
-    });
-  </script>
-<% end %>

--- a/core/lib/generators/refinery/engine/templates/app/controllers/refinery/namespace/admin/plural_name_controller.rb.erb
+++ b/core/lib/generators/refinery/engine/templates/app/controllers/refinery/namespace/admin/plural_name_controller.rb.erb
@@ -5,8 +5,7 @@ module Refinery
 
         crudify :'refinery/<%= namespacing.underscore %>/<%= singular_name %>'<% if (title = attributes.detect { |a| a.type.to_s =~ /string|text/ }).present? and title.name != 'title' -%>,
                 :title_attribute => '<%= title.name %>'<% end -%><% if plural_name == singular_name -%>,
-                :redirect_to_url => :refinery_<%= namespacing.underscore %>_admin_<%= singular_name %>_index_path<% end %>,
-                :xhr_paging => true
+                :redirect_to_url => :refinery_<%= namespacing.underscore %>_admin_<%= singular_name %>_index_path<% end %>
 
       end
     end

--- a/core/lib/refinery/crud.rb
+++ b/core/lib/refinery/crud.rb
@@ -34,7 +34,6 @@ module Refinery
         :search_conditions => '',
         :sortable => true,
         :title_attribute => "title",
-        :xhr_paging => false,
         :class_name => class_name,
         :singular_name => singular_name,
         :plural_name => plural_name
@@ -50,6 +49,7 @@ module Refinery
 
       def crudify(model_name, options = {})
         options = ::Refinery::Crud.default_options(model_name).merge(options)
+        Refinery.deprecate :xhr_paging, when: '3.1' if options[:xhr_paging]
         class_name = options[:class_name]
         singular_name = options[:singular_name]
         plural_name = options[:plural_name]
@@ -231,7 +231,7 @@ module Refinery
 
         # Methods that are only included when this controller is searchable.
         if options[:searchable]
-          if options[:paging] || options[:xhr_paging]
+          if options[:paging]
             module_eval %(
               def index
                 search_all_#{plural_name} if searching?
@@ -255,7 +255,7 @@ module Refinery
           end
 
         else
-          if options[:paging] || options[:xhr_paging]
+          if options[:paging]
             module_eval %(
               def index
                 paginate_all_#{plural_name}
@@ -335,13 +335,9 @@ module Refinery
         module_eval %(
           class << self
             def pageable?
-              #{options[:paging].to_s} || #{options[:xhr_paging].to_s}
+              #{options[:paging].to_s}
             end
             alias_method :paging?, :pageable?
-
-            def xhr_pageable?
-              #{options[:xhr_paging].to_s}
-            end
 
             def sortable?
               #{options[:sortable].to_s}

--- a/core/spec/features/refinery/admin/custom_assets_spec.rb
+++ b/core/spec/features/refinery/admin/custom_assets_spec.rb
@@ -9,18 +9,24 @@ module Refinery
     end
 
     context "javascripts" do
-      it "should be rendered when specified" do
+      before do
         ::Refinery::Core.config.register_javascript('custom_js')
+      end
+
+      it "should be rendered when specified" do
         visit Refinery::Core.backend_path
         expect(page.body.include?('custom_js.js')).to be
       end
     end
 
     context "stylesheets" do
-      it "should be rendered when specified" do
+      before do
         ::Refinery::Core.config.register_stylesheet('custom_css')
+      end
+
+      it "should be rendered when specified" do
         visit Refinery::Core.backend_path
-        expect(page.body.include?('custom_css.css')).to be
+        expect(page.body).to include('custom_css.css')
       end
     end
 

--- a/core/spec/features/refinery/admin/xhr_paging_spec.rb
+++ b/core/spec/features/refinery/admin/xhr_paging_spec.rb
@@ -1,53 +1,37 @@
 require "spec_helper"
 
 module Refinery
-  describe "Crudify", :type => :feature do
+  describe "Crudify", type: :feature do
     refinery_login_with :refinery_superuser
 
-    describe "xhr_paging", :js => true do
+    describe "xhr_paging", :js do
       # Refinery::Admin::UsersController specifies :order => 'username ASC' in crudify
       let(:first_user) { User.order('username ASC').first }
       let(:last_user) { User.order('username ASC').last }
+      let!(:user) { FactoryGirl.create :user }
       before do
-        FactoryGirl.create :user
-        expect(Admin::UsersController).to receive(:xhr_pageable?).
-                               at_least(1).times.and_return(xhr_pageable)
         allow(User).to receive(:per_page).and_return(1)
       end
 
-      describe 'when set to true' do
-        let(:xhr_pageable) { true }
-        it 'should perform ajax paging of index' do
-          visit refinery.admin_users_path
+      it 'performs ajax paging of index' do
+        visit refinery.admin_users_path
 
-          expect(page).to have_selector('li.record', :count => 1)
-          expect(page).to have_content(first_user.email)
+        expect(page).to have_selector('li.record', count: 1)
+        expect(page).to have_content(first_user.email)
 
-          within '.pagination' do
-            click_link '2'
-          end
+        # placeholder which would disappear in a full page refresh.
+        page.evaluate_script(
+          %{$('body').append('<i id="has_not_refreshed_entire_page"/>')}
+        )
 
-          expect(page.evaluate_script('jQuery.active')).to eq(1)
-          expect(page).to have_content(last_user.email)
+        within '.pagination' do
+          click_link '2'
         end
-      end
 
-      describe 'set to false' do
-        let(:xhr_pageable) { false }
-        it 'should not perform ajax paging of index' do
-          visit refinery.admin_users_path
-
-          expect(page).to have_selector('li.record', :count => 1)
-          expect(page).to have_content(first_user.email)
-
-          within '.pagination' do
-            click_link '2'
-          end
-
-          expect(page.evaluate_script('jQuery.active')).to eq(0)
-          expect(page).to have_content(last_user.email)
-
-        end
+        expect(page).to have_content(last_user.email)
+        expect(page.evaluate_script(
+          %{$('i#has_not_refreshed_entire_page').length}
+        )).to eq(1)
       end
     end
   end

--- a/resources/app/controllers/refinery/admin/resources_controller.rb
+++ b/resources/app/controllers/refinery/admin/resources_controller.rb
@@ -3,8 +3,7 @@ module Refinery
     class ResourcesController < ::Refinery::AdminController
 
       crudify :'refinery/resource',
-              :order => "updated_at DESC",
-              :xhr_paging => true
+              :order => "updated_at DESC"
 
       before_action :init_dialog
 


### PR DESCRIPTION
This option made no sense to be turned off because it makes for a better
user experience to prevent a full page reload when paging.
