### PR TITLE
Speed up page reordering

### DIFF
--- a/core/lib/refinery/crud.rb
+++ b/core/lib/refinery/crud.rb
@@ -291,7 +291,7 @@ module Refinery
                   if @current_#{singular_name}.respond_to?(:move_to_root)
                     if previous.present?
                       @current_#{singular_name}.move_to_right_of(#{class_name}.find_by_id(previous))
-                    else
+                    elsif !@current_#{singular_name}.root?
                       @current_#{singular_name}.move_to_root
                     end
                   else
@@ -313,10 +313,14 @@ module Refinery
 
             def update_child_positions(_node, #{singular_name})
               list = _node['children']['0']
+              child_positions_changed = false
               list.sort_by {|k, v| k.to_i}.map { |item| item[1] }.each_with_index do |child, index|
                 child_id = child['id'].split(/#{singular_name}\_?/).reject(&:empty?).first
                 child_#{singular_name} = #{class_name}.where(:id => child_id).first
-                child_#{singular_name}.move_to_child_of(#{singular_name})
+                child_positions_changed ||= #{singular_name}.children[index] != child_#{singular_name}
+                if child_positions_changed
+                  child_#{singular_name}.move_to_child_of(#{singular_name})
+                end
 
                 if child['children'].present?
                   update_child_positions(child, child_#{singular_name})


### PR DESCRIPTION
Updated version of #2746, fixed issue with AR cache.

`update_positions` and `update_child_positions` methods perform a lot of useless UPDATE queries. Pull request adds few checks to prevent this. Fixes #2702 and #2631 

Some benchmarking (315 pages, https://gist.github.com/vladimir-tikhonov/7aea6077be29c38ab6f7):
**Before:**

> Click 'Reorder Pages' and then immediately 'Done Reordering Pages': **21981.7ms**
> Click 'Reorder Pages', mix pages for 5 seconds and  'Done Reordering Pages': **21779.1ms**

**After:**

> Click 'Reorder Pages' and then immediately 'Done Reordering Pages': **644.8ms**
> Click 'Reorder Pages', mix pages for 5 seconds and  'Done Reordering Pages': **2878.9ms**
