### PR TITLE
Optimised queries for Page#nested_url and Page#path

### DIFF
--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -215,15 +215,14 @@ module Refinery
       self.destroy
     end
 
-    # Used for the browser title to get the full path to this page
-    # It automatically prints out this page title and all of its parent page
-    # titles joined by a PATH_SEPARATOR
-    def path(reversed: true)
+    # Returns the full path to this page.
+    # This automatically prints out this page title and all parent page titles.
+    # The result is joined by the path_separator argument.
+    def path(path_separator: ' - ', ancestors_first: true)
       return title if root?
 
-      titles = self_and_ancestors.reverse.map(&:title)
-      titles.reverse! if reversed
-      titles.join(' - ')
+      chain = ancestors_first ? self_and_ancestors : self_and_ancestors.reverse
+      chain.map(&:title).join(path_separator)
     end
 
     def url

--- a/pages/spec/models/refinery/page_url_spec.rb
+++ b/pages/spec/models/refinery/page_url_spec.rb
@@ -36,12 +36,12 @@ module Refinery
         expect(page.path).to eq(page_title)
       end
 
-      it 'and all of its parent page titles, reversed' do
+      it 'and all of its parent page titles, ancestors first' do
         expect(created_child.path).to eq([page_title, child_title].join(' - '))
       end
 
       it 'or normally ;-)' do
-        expect(created_child.path(:reversed => false)).to eq([child_title, page_title].join(' - '))
+        expect(created_child.path(ancestors_first: false)).to eq([child_title, page_title].join(' - '))
       end
 
       it 'returns its url' do


### PR DESCRIPTION
This makes use of ancestors instead of iterating through all parents.
This means one database query, not several.

We still have too many queries but this should speed things up quite a lot - which should make @simi happier.

Potentially fixes #2087
