### PR TITLE
Specify ruby required version via Refinery::Version.required_ruby_version.

### DIFF
--- a/authentication/refinerycms-authentication.gemspec
+++ b/authentication/refinerycms-authentication.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'devise',            ['~> 3.0', '>= 3.2.4']
   s.add_dependency 'friendly_id',       '>= 5.0.0.rc1'
 
-  s.required_ruby_version = '>= 2.1.2'
+  s.required_ruby_version = Refinery::Version.required_ruby_version
 end

--- a/core/lib/refinery/version.rb
+++ b/core/lib/refinery/version.rb
@@ -11,6 +11,10 @@ module Refinery
       def to_s
         [@major, @minor, @tiny, @build].compact.join('.')
       end
+
+      def required_ruby_version
+        '>= 2.1.2'
+      end
     end
   end
 end

--- a/core/refinerycms-core.gemspec
+++ b/core/refinerycms-core.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.files             = `git ls-files`.split("\n")
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
-  s.required_ruby_version = '>= 2.1.2'
+  s.required_ruby_version = Refinery::Version.required_ruby_version
 
   s.add_dependency 'refinerycms-i18n',            '~> 3.0.0.dev'
   s.add_dependency 'awesome_nested_set',          '~> 3.0.0'

--- a/images/refinerycms-images.gemspec
+++ b/images/refinerycms-images.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'dragonfly-s3_data_store', '~> 1.0.0'
   s.add_dependency 'refinerycms-core',        version
 
-  s.required_ruby_version = '>= 2.1.2'
+  s.required_ruby_version = Refinery::Version.required_ruby_version
 end

--- a/pages/refinerycms-pages.gemspec
+++ b/pages/refinerycms-pages.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'refinerycms-core',            version
   s.add_dependency 'babosa',                      '!= 0.3.6'
 
-  s.required_ruby_version = '>= 2.1.2'
+  s.required_ruby_version = Refinery::Version.required_ruby_version
 end

--- a/refinerycms.gemspec
+++ b/refinerycms.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |s|
   s.add_dependency    'refinerycms-pages',          version
   s.add_dependency    'refinerycms-resources',      version
 
-  s.required_ruby_version = '>= 2.1.2'
+  s.required_ruby_version = Refinery::Version.required_ruby_version
 end

--- a/resources/refinerycms-resources.gemspec
+++ b/resources/refinerycms-resources.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'dragonfly-s3_data_store', '~> 1.0.0'
   s.add_dependency 'refinerycms-core',        version
 
-  s.required_ruby_version = '>= 2.1.2'
+  s.required_ruby_version = Refinery::Version.required_ruby_version
 end

--- a/testing/refinerycms-testing.gemspec
+++ b/testing/refinerycms-testing.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'capybara',                '~> 2.4.3'
   s.add_dependency 'selenium-webdriver',      '~> 2.43'
 
-  s.required_ruby_version = '>= 2.1.2'
+  s.required_ruby_version = Refinery::Version.required_ruby_version
 end


### PR DESCRIPTION
- use it in all gemspecs
