### PR TITLE
Migrate rspec-rails ~> 3.0.

### DIFF
--- a/authentication/spec/controllers/refinery/admin/users_controller_spec.rb
+++ b/authentication/spec/controllers/refinery/admin/users_controller_spec.rb
@@ -67,14 +67,14 @@ describe Refinery::Admin::UsersController, :type => :controller do
 
     let(:additional_user) { FactoryGirl.create :refinery_user }
     it "updates a user" do
-      Refinery::User.stub_chain(:includes, :find) { additional_user }
+      allow(Refinery::User).to receive_message_chain(:includes, :find) { additional_user }
       patch "update", :id => additional_user.id.to_s, :user => {:username => 'bobby'}
       expect(response).to be_redirect
     end
 
     context "when specifying plugins" do
       it "won't allow to remove 'Users' plugin from self" do
-        Refinery::User.stub_chain(:includes, :find) { logged_in_user }
+        allow(Refinery::User).to receive_message_chain(:includes, :find) { logged_in_user }
         patch "update", :id => logged_in_user.id.to_s, :user => {:plugins => ["some plugin"]}
 
         expect(flash[:error]).to eq("You cannot remove the 'Users' plugin from the currently logged in account.")
@@ -82,7 +82,7 @@ describe Refinery::Admin::UsersController, :type => :controller do
 
       it "will update to the plugins supplied" do
         expect(logged_in_user).to receive(:update_attributes).with({"plugins" => %w(refinery_users some_plugin)})
-        Refinery::User.stub_chain(:includes, :find) { logged_in_user }
+        allow(Refinery::User).to receive_message_chain(:includes, :find) { logged_in_user }
         patch "update", :id => logged_in_user.id.to_s, :user => {:plugins => %w(refinery_users some_plugin)}
       end
     end

--- a/authentication/spec/lib/refinery/authentication/configuration_spec.rb
+++ b/authentication/spec/lib/refinery/authentication/configuration_spec.rb
@@ -12,7 +12,7 @@ module Refinery
 
         context 'when set in configuration' do
           it 'returns name set by Refinery::Authentication.config' do
-            Refinery::Authentication.stub(:email_from_name).and_return('support')
+            allow(Refinery::Authentication).to receive(:email_from_name).and_return('support')
             expect(Refinery::Authentication.email_from_name).to eq('support')
           end
         end

--- a/core/spec/lib/refinery/application_controller_spec.rb
+++ b/core/spec/lib/refinery/application_controller_spec.rb
@@ -13,7 +13,7 @@ module Refinery
       Rails.application.reload_routes!
     end
 
-    controller do
+    controller(ActionController::Base) do
       include ::Refinery::ApplicationController
 
       def index

--- a/images/spec/models/refinery/image_spec.rb
+++ b/images/spec/models/refinery/image_spec.rb
@@ -54,7 +54,7 @@ module Refinery
         it "doesn't allow to replace it with image which has different file name" do
           created_image.image = Refinery.roots('refinery/images').join("spec/fixtures/beach-alternate.jpeg")
           expect(created_image).not_to be_valid
-          expect(created_image.error_on(:image_name).size).to be >= 1
+          expect(created_image.errors.messages[:image_name].size).to be >= 1
         end
 
         it "allows to replace it with image which has the same file name" do

--- a/resources/spec/lib/resources_spec.rb
+++ b/resources/spec/lib/resources_spec.rb
@@ -26,7 +26,7 @@ describe Refinery::Resources do
     end
 
     before(:each) do
-      Refinery::Core.stub(:dragonfly_custom_backend_class => DummyBackend1)
+      allow(Refinery::Core).to receive_messages(:dragonfly_custom_backend_class => DummyBackend1)
     end
 
     after(:each) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,12 +23,12 @@ I18n.locale = :en
 
 RSpec.configure do |config|
   config.mock_with :rspec
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.filter_run :focus => true
   config.filter_run :js => true if ENV['JS'] == 'true'
   config.filter_run :js => nil if ENV['JS'] == 'false'
   config.run_all_when_everything_filtered = true
-  config.include ActionView::TestCase::Behavior, :example_group => { :file_path => %r{spec/presenters} }
+  config.include ActionView::TestCase::Behavior, :file_path => %r{spec/presenters}
+  config.infer_spec_type_from_file_location!
 end
 
 # Requires supporting files with custom matchers and macros, etc,

--- a/testing/refinerycms-testing.gemspec
+++ b/testing/refinerycms-testing.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'refinerycms-core',        version
   s.add_dependency 'database_cleaner',        '~> 1.3.0'
   s.add_dependency 'factory_girl_rails',      '~> 4.4.1'
-  s.add_dependency 'rspec-rails',             '~> 2.13'
+  s.add_dependency 'rspec-rails',             '~> 3.0'
   s.add_dependency 'capybara',                '~> 2.4.3'
   s.add_dependency 'selenium-webdriver',      '~> 2.43'
 


### PR DESCRIPTION
There's still one deprecation. I'll try to handle it in upstream.

```
Deprecation Warnings:

Filtering by an `:example_group` subhash is deprecated. Use the subhash to filter directly instead. Called from /home/ryba/.rvm/gems/ruby-2.1.3/gems/generator_spec-0.9.2/lib/generator_spec.rb:9:in `block in <top (required)>'.
```
