### PR TITLE
Upgrade for Dragonfly 1.0

### DIFF
--- a/doc/guides/2 - Refinery Basics/9 - Resources.textile
+++ b/doc/guides/2 - Refinery Basics/9 - Resources.textile
@@ -15,9 +15,10 @@ You can do this by making use of the after_inclusion hook refinery provides:
 <ruby>
 # config/application.rb
 # refinery change content-disipotion
-Refinery::Core::Engine.after_inclusion do
-  Refinery::Resource # force autoload
-  ::Dragonfly[:refinery_resources].content_disposition = nil
+  Refinery::Core::Engine.after_inclusion do
+    Refinery::Resource # force autoload
+    ::Dragonfly.app(:refinery_resources).response_header('Content-Disposition', nil)
+  end
 end
 </ruby>
 


### PR DESCRIPTION
Dragonfly::App[:refinery_resources] is deprecated - use Dragonfly.app (for the default app) or Dragonfly.app(:refinery_resources) (for extra named apps) instead.
Also, `content_disposition=` is no longer available in Dragonfly 1.0, we should use `response_header=` instead, see: https://github.com/markevans/dragonfly/wiki/Upgrading-from-0.9-to-1.0#misc-config-options
