### PR TITLE
Removed spring from Gemfile, moved poltergeist and quiet_assets to groups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'refinerycms-i18n', git: 'https://github.com/refinery/refinerycms-i18n', branch: 'master'
-gem 'quiet_assets'
-gem 'spring'
-gem 'spring-commands-rspec'
-gem 'poltergeist'
+gem 'quiet_assets', group: :development
 
 # Add support for refinerycms-acts-as-indexed
 gem 'refinerycms-acts-as-indexed', ['~> 2.0', '>= 2.0.0']
@@ -39,6 +36,7 @@ group :test do
   gem 'generator_spec', '~> 0.9.3'
   gem 'launchy'
   gem 'coveralls', require: false
+  gem 'poltergeist'
 end
 
 # Load local gems according to Refinery developer preference.


### PR DESCRIPTION
Spring still works just fine for me if I put it in `.gemfile` which
is a file that we have for installing gems according to each developer's
preference.  If I completely uninstall Spring from my system then it
still works to invoke every command that asks for Spring due to
Spring rescuring from `LoadError`.

If I then place Spring back in `.gemfile` it will figure out that it
is now present and will load, speeding up subsequent invocations.
