### PR TITLE
Refactored image_fu helper to only use geometry when not nil.

### DIFF
--- a/core/app/helpers/refinery/image_helper.rb
+++ b/core/app/helpers/refinery/image_helper.rb
@@ -21,14 +21,15 @@ module Refinery
     # and we wanted to display a thumbnail cropped to 200x200 then we can use image_fu like this:
     # <%= image_fu @model.image, '200x200' %> or with no thumbnail: <%= image_fu @model.image %>
     def image_fu(image, geometry = nil, options = {})
-      if image.present?
-        dimensions = (image.thumbnail_dimensions(geometry) rescue {})
+      return nil if image.blank?
 
-        image_tag(image.thumbnail(:geometry => geometry,
-                                  :strip => options[:strip]).url, {
-          :alt => image.respond_to?(:title) ? image.title : image.image_name,
-        }.merge(dimensions).merge(options))
-      end
+      thumbnail_args = options.slice(:strip)
+      thumbnail_args[:geometry] = geometry if geometry
+
+      image_tag_args = (image.thumbnail_dimensions(geometry) rescue {})
+      image_tag_args[:alt] = image.respond_to?(:title) ? image.title : image.image_name
+
+      image_tag(image.thumbnail(thumbnail_args).url, image_tag_args.merge(options))
     end
   end
 end


### PR DESCRIPTION
This was causing issues with the rickrockstar example on at least Refinery v2.1.5.  I'm fixing this in master and then back-porting it and releasing Refinery v2.1.6.

What was happening is that when using the following:

``` erb
<%= image_fu @event.photo, nil %>
```

We were seeing the following error:

```
Started GET "/system/images/W1siZiIsIjIwMTQvMTIvMTMvMDlfMzdfMDlfOTQxX2x1bWJlcmphY2sucG5nIl0sWyJwIiwidGh1bWIiLG51bGxdLFsicCIsInN0cmlwIl1d/lumberjack.png" for 127.0.0.1 at 2014-12-13 09:45:46 +1300

ArgumentError (Didn't recognise the geometry string ):
```

This is worked around by simply not supplying a geometry string when nil is requested as geometry, because we simply don't need to try to do any thumbnailing.
