### PR TITLE
Add frontend and backend routes method

### DIFF
--- a/core/config/routes.rb
+++ b/core/config/routes.rb
@@ -11,3 +11,5 @@ Refinery::Core::Engine.routes.draw do
 
   get '/sitemap.xml' => 'sitemap#index', :defaults => { :format => 'xml' }
 end
+
+Refinery::Core::Engine.draw_routes

--- a/core/lib/refinery/core/engine.rb
+++ b/core/lib/refinery/core/engine.rb
@@ -26,6 +26,35 @@ module Refinery
         end
       end
 
+      def self.frontend_routes(&block)
+        @frontend_routes ||= []
+        unless @frontend_routes.include?(block)
+          @frontend_routes << block
+        end
+      end
+
+      def self.backend_routes(&block)
+        @backend_routes ||= []
+        unless @backend_routes.include?(block)
+          @backend_routes << block
+        end
+      end
+
+      def self.draw_routes(&block)
+        @frontend_routes ||= []
+        @backend_routes ||= []
+        eval_block(block) if block_given?
+        @frontend_routes.each { |r| eval_block(&r) }
+        @backend_routes.each { |r| eval_block(&r) }
+        # # Clear out routes so that they aren't drawn twice.
+        @frontend_routes = []
+        @backend_routes = []
+      end
+
+      def eval_block(&block)
+        Refinery::Core::Engine.routes.eval_block(block)
+      end
+
       config.autoload_paths += %W( #{config.root}/lib )
 
       # Include the refinery controllers and helpers dynamically


### PR DESCRIPTION
Hello all !

In following of our conversation in the goal to translate engine routes. 
I submit this PR in order to add the feature of frontend and backend routes in routes.rb

Now i can do this :

```ruby 
Refinery::Core::Engine.frontend_routes do
  # Frontend routes
  namespace :inquiries, :path => '' do
    # localized do
      get Refinery::Inquiries.page_path_new, :to => 'inquiries#new', :as => 'new_inquiry'

      resources :contact, :path => Refinery::Inquiries.post_path, :only => [:create],
                :as => :inquiries, :controller => 'inquiries'

      resources :contact, :path => '', :only => [], :as => :inquiries, :controller => 'inquiries' do
        get :thank_you, :path => Refinery::Inquiries.page_path_thank_you, :on => :collection
      end
    # end
  end
end

Refinery::Core::Engine.backend_routes do
  # Admin routes
  namespace :inquiries, :path => '' do
    namespace :admin, :path => Refinery::Core.backend_route do
      resources :inquiries, :only => [:index, :show, :destroy] do
        get :spam, :on => :collection
        get :toggle_spam, :on => :member
      end

      scope :path => 'inquiries' do
        resources :settings, :only => [:edit, :update]
      end
    end
  end
end
```

I'm really inspired of Spree : https://github.com/spree/spree/blob/b66ea0229646062acb7b6f89ac2447f5ffc862fb/core/lib/spree/core/routes.rb

It's backward compatible.

Now, i try to find a way to add the localized method of route_translator on frontend_routes. If you know how to do it, please help us! :+1:  : https://github.com/enriclluelles/route_translator/issues/75