### PR TITLE
bump sass-rails dependency to >=4.0, <5.1 for Foundation 5.5+ compat

### DIFF
--- a/core/refinerycms-core.gemspec
+++ b/core/refinerycms-core.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'actionpack',                  rails_version
   s.add_dependency 'truncate_html',               '~> 0.9'
   s.add_dependency 'will_paginate',               '~> 3.0.2'
-  s.add_dependency 'sass-rails',                  '~> 4.0.0'
+  s.add_dependency 'sass-rails',                  '>= 4.0', '< 5.1'
   s.add_dependency 'coffee-rails',                '~> 4.0.0'
   s.add_dependency 'jquery-rails',                '>= 2.3.0'
   s.add_dependency 'jquery-ui-rails',             '~> 5.0.0'


### PR DESCRIPTION
Changes sass-rails dependency in core to add compatibility for 5.0+ which is required for the Foundation 5.5+ framework and maybe others.
