### PR TITLE
Redirect to root_path unless admin_root_path

### DIFF
--- a/core/lib/refinery/admin/base_controller.rb
+++ b/core/lib/refinery/admin/base_controller.rb
@@ -27,7 +27,7 @@ module Refinery
         current_refinery_user.plugins.map { |plugin|
           user_plugin = Refinery::Plugins.active.find_by_name(plugin.name)
           user_plugin.url if user_plugin && !user_plugin.hide_from_menu && user_plugin.url.present?
-        }.compact.first
+        }.compact.first || refinery.root_path
       end
 
       protected


### PR DESCRIPTION
If just a user tries to navigate to admin#index it receives 'Cannot redirect to nil!'. I propose to redirect to root path.