### PR TITLE
Fix use of named parameters in Page#path

### DIFF
--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -220,7 +220,7 @@ module Refinery
     # Returns the full path to this page.
     # This automatically prints out this page title and all parent page titles.
     # The result is joined by the path_separator argument.
-    def path(path_separator: ' - ', ancestors_first: true)
+    def path(path_separator = ' - ', ancestors_first = true)
       return title if root?
 
       chain = ancestors_first ? self_and_ancestors : self_and_ancestors.reverse


### PR DESCRIPTION
Hi @parndt,

This is causing breakage in 1.9.3

```
/Users/mdesilva/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/activesupport-4.1.8/lib/active_support/dependencies.rb:443:in `load': /Users/mdesilva/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/bundler/gems/refinerycms-f453944e17ab/pages/app/models/refinery/page.rb:223: syntax error, unexpected tLABEL, expecting ')' (SyntaxError)
    def path(path_separator: ' - ', ancestors_first: true)
                            ^
/Users/mdesilva/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/bundler/gems/refinerycms-f453944e17ab/pages/app/models/refinery/page.rb:223: syntax error, unexpected ',', expecting keyword_end
    def path(path_separator: ' - ', ancestors_first: true)
                                   ^
/Users/mdesilva/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/bundler/gems/refinerycms-f453944e17ab/pages/app/models/refinery/page.rb:329: class definition in method body
```

However, in Ruby 2+ this doesn't seem to cause any issues, due to support for keyword args.

Thoughts...?