### PR TITLE
Add refinerycms-i18n to gemfile template for engines

### DIFF
--- a/core/lib/generators/refinery/engine/templates/Gemfile
+++ b/core/lib/generators/refinery/engine/templates/Gemfile
@@ -10,6 +10,8 @@ git 'https://github.com/refinery/refinerycms.git', :branch => 'master' do
   end
 end
 
+gem 'refinerycms-i18n', :git => 'https://github.com/refinery/refinerycms-i18n', :branch => 'master'
+
 # Database Configuration
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter'

--- a/core/lib/generators/refinery/engine/templates/Gemfile
+++ b/core/lib/generators/refinery/engine/templates/Gemfile
@@ -10,7 +10,7 @@ git 'https://github.com/refinery/refinerycms.git', :branch => 'master' do
   end
 end
 
-gem 'refinerycms-i18n', :git => 'https://github.com/refinery/refinerycms-i18n', :branch => 'master'
+gem 'refinerycms-i18n', git: 'https://github.com/refinery/refinerycms-i18n', branch: 'master'
 
 # Database Configuration
 platforms :jruby do


### PR DESCRIPTION
To fix issue https://github.com/refinery/refinerycms/issues/2835

This adds the dependency to an engine's Gemfile.

Manually tested with a dummy app.