### PR TITLE
Rspec issue in Engine generator

### DIFF
--- a/core/lib/generators/refinery/engine/templates/Gemfile
+++ b/core/lib/generators/refinery/engine/templates/Gemfile
@@ -31,6 +31,8 @@ group :development, :test do
       gem 'therubyracer', '~> 0.11.4'
     end
   end
+
+  gem 'rspec-its'
 end
 
 # Gems used only for assets and not required

--- a/core/lib/generators/refinery/engine/templates/spec/features/refinery/namespace/admin/plural_name_spec.rb.erb
+++ b/core/lib/generators/refinery/engine/templates/spec/features/refinery/namespace/admin/plural_name_spec.rb.erb
@@ -5,6 +5,9 @@ describe Refinery do
   describe "<%= namespacing %>" do
     describe "Admin" do
       describe "<%= plural_name %>" do
+
+        extend Refinery::Testing::FeatureMacros::Authentication
+
         refinery_login_with :refinery
 <% if (title = attributes.detect { |a| a.type.to_s == "string" }).present? %>
         describe "<%= plural_name %> list" do


### PR DESCRIPTION
Re: https://github.com/refinery/refinerycms/issues/2836

I believe I have fixed three small bugs I discovered as part of trying to resolve the above issue:
1)  commit 9487762: refinery_login_as function wasn't found: add `extend Refinery::Testing::FeatureMacros::Authenication` to the features/admin spec generator.
2) commit df6f299: add `rspec-its` gem to the engine Gemfile template
3) commit 9487762: Correct the symbol name for refinery_user for login

Now, my tests are still failing because it can't `visit refinery.some_admin_path`:

```
 Refinery Bleeees Admin bleeees destroy should succeed
     Failure/Error: visit refinery.bleeees_admin_bleeees_path
     NameError:
       undefined local variable or method `refinery' for #<RSpec::ExampleGroups::Refinery::Bleeees::Admin::Bleeees::Destroy:0x00000008268fb0>
```
Any assistance to nail this next issue down would be very welcome!
cheers,
Chris

--

NOTE:

Re: 1) I am surprised this was needed as it wasn't in previous versions. I think there is a better way. E.g., the file `core/spec/support/refinery.rb` which does the `extend` as default for all feature specs. Presumably this support file could be added to the Engine generator... I believe that or something similar would probably be a better fix. Comments?

Can you shed any light on what might have changed to break the engine specs?