### PR TITLE
Clear before_inclusion_procs and after_inclusion_procs after calling them

### DIFF
--- a/core/lib/refinery/core/engine.rb
+++ b/core/lib/refinery/core/engine.rb
@@ -17,12 +17,12 @@ module Refinery
         # a before_inclusion and after_inclusion step that calls procs registered by the
         # Refinery::Engine#before_inclusion and Refinery::Engine#after_inclusion class methods
         def refinery_inclusion!
-          before_inclusion_procs.each(&:call)
+          before_inclusion_procs.each(&:call).clear
 
           Refinery.include_once(::ApplicationController, Refinery::ApplicationController)
           ::ApplicationController.send :helper, Refinery::Core::Engine.helpers
 
-          after_inclusion_procs.each(&:call)
+          after_inclusion_procs.each(&:call).clear
         end
       end
 


### PR DESCRIPTION
This prevents a bug where supplied procs were run over and over again,
resulting in e.g. plugins being registered multiple times.