### PR TITLE
Login using :refinery_user 

### DIFF
--- a/core/lib/generators/refinery/engine/templates/spec/features/refinery/namespace/admin/plural_name_spec.rb.erb
+++ b/core/lib/generators/refinery/engine/templates/spec/features/refinery/namespace/admin/plural_name_spec.rb.erb
@@ -5,7 +5,9 @@ describe Refinery do
   describe "<%= namespacing %>" do
     describe "Admin" do
       describe "<%= plural_name %>", type: :feature do
-        refinery_login_with :refinery
+
+        refinery_login_with :refinery_user
+
 <% if (title = attributes.detect { |a| a.type.to_s == "string" }).present? %>
         describe "<%= plural_name %> list" do
           before do


### PR DESCRIPTION
Previously this had the wrong symbol, ":refinery".

The important commit is 86844aa -- if you can just cherry pick that one then this will be OK, otherwise I'll re-do the pull request from a common base.

