### PR TITLE
Remove #page_parts_controls width

### DIFF
--- a/core/app/assets/stylesheets/refinery/layout.css.scss
+++ b/core/app/assets/stylesheets/refinery/layout.css.scss
@@ -1070,7 +1070,6 @@ ul#page_parts, ul#page_parts_controls {
 }
 ul#page_parts_controls {
   float: right;
-  width: 7%;
   margin-right: 3px;
 }
 ul#page_parts_controls li {


### PR DESCRIPTION
Fix overflow of this tag when there is a lot of page parts tabs.

This problem is here since we moved the section tabs to the left

Before : 
![refinery-page-parts-before](https://cloud.githubusercontent.com/assets/1678530/5858646/d5cf1982-a222-11e4-9c98-ca256b8eb089.png)

After : 
![refinery-page-part-after](https://cloud.githubusercontent.com/assets/1678530/5858654/db3f713c-a222-11e4-99bb-fd57670981a3.png)
