### PR TITLE
Added Refinery::Pages.config.friendly_id_reserved_words which fixes #2847

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'poltergeist', github: 'teampoltergeist/poltergeist'
 gem 'refinerycms-acts-as-indexed', ['~> 2.0', '>= 2.0.0']
 
 # Add the default visual editor, for now.
-gem 'refinerycms-wymeditor', ['~> 1.0', '>= 1.0.5']
+gem 'refinerycms-wymeditor', ['~> 1.0', '>= 1.0.6']
 
 # Database Configuration
 unless ENV['TRAVIS']

--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -19,15 +19,11 @@ module Refinery
     end
 
     class FriendlyIdOptions
-      def self.reserved_words
-        %w(index new session login logout users refinery admin images)
-      end
-
       def self.options
         # Docs for friendly_id https://github.com/norman/friendly_id
         friendly_id_options = {
           use: [:reserved],
-          reserved_words: self.reserved_words
+          reserved_words: Refinery::Pages.friendly_id_reserved_words
         }
         if ::Refinery::Pages.scope_slug_by_parent
           friendly_id_options[:use] << :scoped
@@ -349,7 +345,9 @@ module Refinery
 
       def self.protected_slug_string(slug_string)
         sluggified = slug_string.to_slug.normalize!
-        sluggified << "-page" if Pages.marketable_urls && FriendlyIdOptions.reserved_words.include?(sluggified)
+        if Pages.marketable_urls && Refinery::Pages.friendly_id_reserved_words.include?(sluggified)
+          sluggified << "-page"
+        end
         sluggified
       end
     end

--- a/pages/lib/generators/refinery/pages/templates/config/initializers/refinery/pages.rb.erb
+++ b/pages/lib/generators/refinery/pages/templates/config/initializers/refinery/pages.rb.erb
@@ -14,6 +14,10 @@ Refinery::Pages.configure do |config|
   # Configure whether to enable marketable_urls
   # config.marketable_urls = <%= Refinery::Pages.marketable_urls.inspect %>
 
+  # You can specify reserved words that won't be used as page slugs.
+  # This only applies when marketable_urls is enabled.
+  # config.friendly_id_reserved_words = <%= Refinery::Pages.friendly_id_reserved_words.inspect %>
+
   # Configure how many pages per page should be displayed when a dialog is presented that contains a links to pages
   # config.pages_per_dialog = <%= Refinery::Pages.pages_per_dialog.inspect %>
 

--- a/pages/lib/refinery/pages/configuration.rb
+++ b/pages/lib/refinery/pages/configuration.rb
@@ -7,7 +7,8 @@ module Refinery
                     :default_parts, :use_custom_slugs, :scope_slug_by_parent,
                     :cache_pages_backend, :cache_pages_full, :layout_template_whitelist,
                     :use_layout_templates, :page_title, :absolute_page_links, :types,
-                    :auto_expand_admin_tree, :show_title_in_body
+                    :auto_expand_admin_tree, :show_title_in_body,
+                    :friendly_id_reserved_words
 
     self.pages_per_dialog = 14
     self.pages_per_admin_index = 20
@@ -44,5 +45,8 @@ module Refinery
     self.absolute_page_links = false
     self.types = Types.registered
     self.auto_expand_admin_tree = true
+    self.friendly_id_reserved_words = %w(
+      index new session login logout users refinery admin images
+    )
   end
 end

--- a/pages/lib/refinery/pages/engine.rb
+++ b/pages/lib/refinery/pages/engine.rb
@@ -55,7 +55,7 @@ module Refinery
           included_routes = Rails.application.routes.named_routes.routes.reject{ |name, route| route.defaults[:allow_slug] }
           route_paths = included_routes.map { |name, route| route.path.spec }
           route_paths.reject! { |path| path.to_s =~ %r{^/(rails|refinery)}}
-          Refinery::Page.friendly_id_config.reserved_words |= route_paths.map { |path|
+          Refinery::Pages.friendly_id_reserved_words |= route_paths.map { |path|
             path.to_s.gsub(%r{^/}, '').to_s.split('(').first.to_s.split(':').first.to_s.split('/')
           }.flatten.reject { |w| w =~ %r{_|\.} }.uniq
         end

--- a/pages/spec/models/refinery/page_url_spec.rb
+++ b/pages/spec/models/refinery/page_url_spec.rb
@@ -298,7 +298,7 @@ module Refinery
     end
 
     context "should add url suffix" do
-      let(:reserved_word) { subject.class.friendly_id_config.reserved_words.last }
+      let(:reserved_word) { subject.class.friendly_id_config.reserved_words.sample }
       let(:page_with_reserved_title) {
         subject.class.create!(:title => reserved_word, :deletable => true)
       }

--- a/templates/refinery/edge.rb
+++ b/templates/refinery/edge.rb
@@ -21,7 +21,7 @@ gem 'quiet_assets', :group => :development
 gem 'refinerycms-acts-as-indexed', ['~> 2.0', '>= 2.0.0']
 
 # Add support for refinerycms-wymeditor
-gem 'refinerycms-wymeditor', ['~> 1.0', '>= 1.0.5']
+gem 'refinerycms-wymeditor', ['~> 1.0', '>= 1.0.6']
 
 gem 'seo_meta', git: 'https://github.com/parndt/seo_meta', branch: 'master'
 

--- a/templates/refinery/installer.rb
+++ b/templates/refinery/installer.rb
@@ -20,7 +20,7 @@ gem 'refinerycms', '~> #{VERSION_BAND}'
 
 # Optionally, specify additional Refinery CMS Extensions here:
 gem 'refinerycms-acts-as-indexed', ['~> 1.0', '>= 1.0.0']
-gem 'refinerycms-wymeditor', ['~> 1.0', '>= 1.0.5']
+gem 'refinerycms-wymeditor', ['~> 1.0', '>= 1.0.6']
 #  gem 'refinerycms-blog', ['~> #{VERSION_BAND}', '>= #{MINOR_VERSION_BAND}']
 #  gem 'refinerycms-inquiries', ['~> #{VERSION_BAND}', '>= #{MINOR_VERSION_BAND}']
 #  gem 'refinerycms-search', ['~> #{VERSION_BAND}', '>= #{MINOR_VERSION_BAND}']


### PR DESCRIPTION
A corresponding commit will be opened for refinerycms-wymeditor once this is merged that will use this new API rather than alias_method_chain