### PR TITLE
Added better support for `:at` Rails mount option.

### DIFF
--- a/core/lib/generators/refinery/cms/cms_generator.rb
+++ b/core/lib/generators/refinery/cms/cms_generator.rb
@@ -219,10 +219,11 @@ gem 'pg'
         mount = %Q{
   # This line mounts Refinery's routes at the root of your application.
   # This means, any requests to the root URL of your application will go to Refinery::PagesController#home.
-  # If you would like to change where this extension is mounted, simply change the :at option to something different.
+  # If you would like to change where this extension is mounted, simply change the
+  # configuration option `mounted_path` to something different in config/initializers/refinery/core.rb
   #
   # We ask that you don't use the :as option here, as Refinery relies on it being the default of "refinery"
-  mount Refinery::Core::Engine, at: '/'
+  mount Refinery::Core::Engine, at: Refinery::Core.mounted_path
 
 }
 

--- a/core/lib/generators/refinery/core/templates/config/initializers/refinery/core.rb.erb
+++ b/core/lib/generators/refinery/core/templates/config/initializers/refinery/core.rb.erb
@@ -40,7 +40,11 @@ Refinery::Core.configure do |config|
   # Register extra stylesheet for backend (optional options)
   # config.register_stylesheet "custom", :media => 'screen'
 
-  # Specify a different backend path than the default of /refinery.
+  # Specify a different backend path than the default of <%= Refinery::Core.backend_route.inspect %>.
   # Make sure you clear the `tmp/cache` directory after changing this setting.
   # config.backend_route = <%= Refinery::Core.backend_route.inspect %>
+
+  # Specify a different Refinery::Core::Engine mount path than the default of <%= Refinery::Core.mounted_path.inspect %>.
+  # Make sure you clear the `tmp/cache` directory after changing this setting.
+  # config.mounted_path = <%= Refinery::Core.mounted_path.inspect %>
 end

--- a/core/lib/generators/refinery/dummy/templates/rails/routes.rb
+++ b/core/lib/generators/refinery/dummy/templates/rails/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  mount Refinery::Core::Engine, :at => "/"
+  mount Refinery::Core::Engine, :at => Refinery::Core.mounted_path
 end

--- a/core/lib/refinery/core/configuration.rb
+++ b/core/lib/refinery/core/configuration.rb
@@ -4,7 +4,7 @@ module Refinery
 
     config_accessor :rescue_not_found, :s3_backend, :base_cache_key, :site_name,
                     :google_analytics_page_code, :authenticity_token_on_frontend,
-                    :dragonfly_secret, :javascripts, :stylesheets,
+                    :dragonfly_secret, :javascripts, :stylesheets, :mounted_path,
                     :s3_bucket_name, :s3_region, :s3_access_key_id,
                     :s3_secret_access_key, :force_ssl, :backend_route,
                     :dragonfly_custom_backend_class, :dragonfly_custom_backend_opts,
@@ -25,6 +25,7 @@ module Refinery
     self.s3_secret_access_key = ENV['S3_SECRET']
     self.force_ssl = false
     self.backend_route = "refinery"
+    self.mounted_path = "/"
     self.dragonfly_custom_backend_class = ''
     self.dragonfly_custom_backend_opts = {}
     self.visual_editor_javascripts = []
@@ -52,8 +53,9 @@ module Refinery
         config.backend_route.to_s.gsub(%r{\A/}, '')
       end
 
+      # See https://github.com/refinery/refinerycms/issues/2740
       def backend_path
-        "/#{backend_route}"
+        [mounted_path.gsub(%r{/\z}, ''), backend_route].join("/")
       end
 
       def clear_javascripts!

--- a/core/spec/lib/refinery/core_spec.rb
+++ b/core/spec/lib/refinery/core_spec.rb
@@ -219,4 +219,13 @@ describe Refinery do
       end
     end
   end
+
+  describe "backend_path" do
+    let(:root_path) { "/custom/path" }
+
+    it "should take into account the mount point" do
+      allow(Refinery::Core).to receive(:mounted_path).and_return(root_path)
+      expect(Refinery::Core.backend_path).to eq("#{root_path}/refinery")
+    end
+  end
 end

--- a/pages/lib/refinery/pages/url.rb
+++ b/pages/lib/refinery/pages/url.rb
@@ -15,7 +15,13 @@ module Refinery
             current_url = "/#{Refinery::I18n.current_frontend_locale}#{current_url}"
           end
 
-          current_url
+          # See https://github.com/refinery/refinerycms/issues/2740
+          if current_url == '/'
+            Refinery::Core.mounted_path
+          else
+            [Refinery::Core.mounted_path, current_url.sub(%r{\A/}, '')].
+              join("/").sub("//", "/").sub(%r{/\z}, '')
+          end
         end
       end
 

--- a/pages/spec/features/refinery/pages_spec.rb
+++ b/pages/spec/features/refinery/pages_spec.rb
@@ -214,14 +214,13 @@ module Refinery
       end
     end
 
-    # Following specs are converted from one of the cucumber features.
-    # Maybe we should clean up this spec file a bit...
     describe "home page" do
       it "succeeds" do
-        visit "/"
+        visit refinery.root_path
 
         within ".selected" do
           expect(page).to have_content(home_page.title)
+          expect(page).not_to have_content(about_page.title)
         end
         expect(page).to have_content(about_page.title)
       end
@@ -229,10 +228,11 @@ module Refinery
 
     describe "content page" do
       it "succeeds" do
-        visit "/about"
+        visit refinery.marketable_page_path(about_page.url)
 
         expect(page).to have_content(home_page.title)
         within ".selected > a" do
+          expect(page).not_to have_content(home_page.title)
           expect(page).to have_content(about_page.title)
         end
       end

--- a/pages/spec/presenters/refinery/pages/menu_presenter_spec.rb
+++ b/pages/spec/presenters/refinery/pages/menu_presenter_spec.rb
@@ -3,6 +3,11 @@ require "spec_helper"
 module Refinery
   module Pages
     describe MenuPresenter do
+      let(:mounted_path) { "/" }
+      before do
+        allow(Core).to receive(:mounted_path).and_return(mounted_path)
+        Rails.application.reload_routes!
+      end
 
       let(:menu_presenter) do
         menu_items = []
@@ -46,11 +51,35 @@ module Refinery
       end
 
       describe "#to_html" do
+        let(:menu_items) {
+          Refinery::Menu.new(FactoryGirl.create(:page, :title => "Refinery CMS"))
+        }
+        let(:menu_presenter) { MenuPresenter.new(menu_items, view) }
         it "returns menu items wrapped in html" do
-          menu_items = Refinery::Menu.new(FactoryGirl.create(:page, :title => "Refinery CMS"))
+          expect(menu_presenter.to_html).to eq(
+            %Q{<nav class="menu clearfix" id="menu"><ul class="nav"><li class="first last"><a href="/refinery-cms">Refinery CMS</a></li></ul></nav>}
+          )
+        end
 
-          menu_presenter = MenuPresenter.new(menu_items, view)
-          expect(menu_presenter.to_html).to eq(%Q{<nav class="menu clearfix" id="menu"><ul class="nav"><li class="first last"><a href="/refinery-cms">Refinery CMS</a></li></ul></nav>})
+        context "takes mount point into account" do
+          let(:mounted_path) { "/subfolder"}
+
+          it "for normal pages" do
+            expect(menu_presenter.to_html).to eq(
+              %Q{<nav class="menu clearfix" id="menu"><ul class="nav"><li class="first last"><a href="#{mounted_path}/refinery-cms">Refinery CMS</a></li></ul></nav>}
+            )
+          end
+
+          context "when page has a link_url" do
+            let(:menu_items) {
+              Menu.new(FactoryGirl.create(:page, title: "Home", link_url: "/"))
+            }
+            it "the menu item URL includes the mounted path" do
+              expect(menu_presenter.to_html).to eq(
+                %Q{<nav class="menu clearfix" id="menu"><ul class="nav"><li class="first last"><a href="#{mounted_path}">Home</a></li></ul></nav>}
+              )
+            end
+          end
         end
       end
 


### PR DESCRIPTION
i.e. 
```ruby
mount Refinery::Core::Engine, at: '/some/subfolder'
```

Fixes #2740