### PR TITLE
Generate strong params for engine admin controller.

### DIFF
--- a/core/lib/generators/refinery/engine/templates/app/controllers/refinery/namespace/admin/plural_name_controller.rb.erb
+++ b/core/lib/generators/refinery/engine/templates/app/controllers/refinery/namespace/admin/plural_name_controller.rb.erb
@@ -7,6 +7,16 @@ module Refinery
                 :title_attribute => '<%= title.name %>'<% end -%><% if plural_name == singular_name -%>,
                 :redirect_to_url => :refinery_<%= namespacing.underscore %>_admin_<%= singular_name %>_index_path<% end %>
 
+        private
+
+        # Only allow a trusted parameter "white list" through.
+        def <%= "#{singular_table_name}_params" %>
+          <%- if attributes_names.empty? -%>
+          params[:<%= singular_table_name %>]
+          <%- else -%>
+          params.require(:<%= singular_table_name %>).permit(<%= attributes_names.map { |name| ":#{name}" }.join(', ') %>)
+          <%- end -%>
+        end
       end
     end
   end


### PR DESCRIPTION
Closes #2753.

For

`bin/rails g refinery:engine ryba maslo banan salam`

```ruby
module Refinery
  module Rybas
    module Admin
      class RybasController < ::Refinery::AdminController

        crudify :'refinery/rybas/ryba',
                :title_attribute => 'maslo'

        private

        # Only allow a trusted parameter "white list" through.
        def ryba_params
          params.require(:ryba).permit(:maslo, :banan, :salam)
        end
      end
    end
  end
end
```

Tested in dummy app and it works! Copied directly from [rails](https://github.com/rails/rails/blob/4b0c8a9467008573c3667641ff533fe611e3df6c/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb#L59-L66).