### PR TITLE
Move Globalize and Friendly_id dependencies in core 

### DIFF
--- a/authentication/refinerycms-authentication.gemspec
+++ b/authentication/refinerycms-authentication.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'refinerycms-core',  version
   s.add_dependency 'actionmailer',      rails_version
   s.add_dependency 'devise',            ['~> 3.0', '>= 3.2.4']
-  s.add_dependency 'friendly_id',       '>= 5.0.0.rc1'
 
   s.required_ruby_version = Refinery::Version.required_ruby_version
 end

--- a/core/refinerycms-core.gemspec
+++ b/core/refinerycms-core.gemspec
@@ -33,5 +33,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'coffee-rails',                ['~> 4.0', '>= 4.0.0']
   s.add_dependency 'jquery-rails',                '>= 2.3.0'
   s.add_dependency 'jquery-ui-rails',             '~> 5.0.0'
+  s.add_dependency 'friendly_id',                 '~> 5.1.0'
+  s.add_dependency 'globalize',                   ['>= 4.0.0', '< 5.2']
   s.add_dependency 'decorators',                  '~> 2.0.0'
 end

--- a/pages/refinerycms-pages.gemspec
+++ b/pages/refinerycms-pages.gemspec
@@ -19,8 +19,6 @@ Gem::Specification.new do |s|
   s.files             = `git ls-files`.split("\n")
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
-  s.add_dependency 'friendly_id',                 '~> 5.1.0'
-  s.add_dependency 'globalize',                   ['>= 4.0.0', '< 5.2']
   s.add_dependency 'awesome_nested_set',          '~> 3.0.0'
   s.add_dependency 'seo_meta',                    '~> 2.0.0.rc.1'
   s.add_dependency 'refinerycms-core',            version


### PR DESCRIPTION
If we require will_paginate and decorators in core, i think we should require globalize and friendly_id in core too, it will be better for us to update engines.

We will have to remove those dependencies in our engines.