### PR TITLE
If link_url set, Page.url (refinery.url_for) prefixes locale to URLs despite Refinery::I18n.url_filter_enabled = false

### DIFF
--- a/pages/lib/refinery/pages/url.rb
+++ b/pages/lib/refinery/pages/url.rb
@@ -10,7 +10,7 @@ module Refinery
         def url
           current_url = page.link_url
 
-          if current_url =~ %r{^/} &&
+          if Refinery::I18n.url_filter_enabled? && current_url =~ %r{^/} &&
             Refinery::I18n.current_frontend_locale != Refinery::I18n.default_frontend_locale
             current_url = "/#{Refinery::I18n.current_frontend_locale}#{current_url}"
           end


### PR DESCRIPTION
This was a fun one, since sometimes it worked and sometimes it didn't. Eventually I realised that when it worked, a hash was returned and when it didn't, a string was returned, with a locale prefix. A-ha, checking the database it showed that when the string was returned, link_url was set. A bit of googling led me to link_url_localised? which eventually brought me to Refinery::Pages::Url::Localized (thank you changelog!) and finally to the spot where the check needed to be added.

It's been one heck of a whirlwind trying to get Refinery going under the latest stable Rails 4.2. I hit the Dragonfly SHA1 DDoS validation bug (probably need a rake task or migration to upgrade prior content to use sha1 hashes but for now I turned it off), I hit a bug, long-standing, where the admin panel seems to prefer loading content by ID number instead of how refinery blog prefers it (FriendlyID) so I had to force the blog to use ID numbers instead in admin panel (worked fine in front end), I also had to work around a few other smaller issues, and make sure I was loading off the git repo for basically every module out there, with the right 4-2-stable branches if they existed. Oh and there's a bug in the blogs module again where I had to disable the default blocks or every blog front-end page would error out with a Rails bug. I was so confused by this one I tried setting up a fresh copy, but encountered the same error. Luckily, I never liked the blocks layout approach anyway.

In the process of doing all of this, I cleaned up quite a bit of localization code. And the site feels a lot faster than it used to, though I haven't measured yet.