### PR TITLE
Limit propagation of new part name/link for  #2917

### DIFF
--- a/core/app/assets/javascripts/refinery/admin.js.erb
+++ b/core/app/assets/javascripts/refinery/admin.js.erb
@@ -609,7 +609,7 @@ var page_options = {
               // Add a new tab for the new content section.
               $('#page_part_editors').append(data);
 
-              page_options.tabs.find("ul").append("<li><a href='#page_part_new_"+$('#new_page_part_index').val()+"'>"+part_title+"</a></li>");
+              $("ul#page_parts").append("<li><a href='#page_part_new_"+$('#new_page_part_index').val()+"'>"+part_title+"</a></li>");
               page_options.tabs.tabs("refresh");
 
               // this is here because of https://github.com/refinery/refinerycms/issues/2060

--- a/core/app/assets/javascripts/refinery/admin.js.erb
+++ b/core/app/assets/javascripts/refinery/admin.js.erb
@@ -609,7 +609,7 @@ var page_options = {
               // Add a new tab for the new content section.
               $('#page_part_editors').append(data);
 
-              $("ul#page_parts").append("<li><a href='#page_part_new_"+$('#new_page_part_index').val()+"'>"+part_title+"</a></li>");
+              page_options.tabs.find("ul#page_parts").append("<li><a href='#page_part_new_"+$('#new_page_part_index').val()+"'>"+part_title+"</a></li>");
               page_options.tabs.tabs("refresh");
 
               // this is here because of https://github.com/refinery/refinerycms/issues/2060


### PR DESCRIPTION
Between creation of new page part and save of page with new part, the
other editor tabs would have the link to the new page part added to
their content area.

This fix ensures the link is only added to the page tabs.