### PR TITLE
Apply fix to controller macros suggested by parndt

### DIFF
--- a/core/spec/controllers/refinery/admin/dummy_controller_spec.rb
+++ b/core/spec/controllers/refinery/admin/dummy_controller_spec.rb
@@ -2,6 +2,14 @@ require "spec_helper"
 
 module Refinery
   module Admin
+    class Engine < ::Rails::Engine
+      isolate_namespace Refinery::Admin
+    end
+
+    Engine.routes.draw do
+      resources :dummy
+    end
+
     class DummyController < Refinery::AdminController
       def index
         render :nothing => true
@@ -13,6 +21,8 @@ end
 module Refinery
   module Admin
     describe DummyController, :type => :controller do
+      routes { Refinery::Admin::Engine.routes }
+
       context "as refinery user" do
         refinery_login_with :refinery
 

--- a/core/spec/lib/refinery/crud_spec.rb
+++ b/core/spec/lib/refinery/crud_spec.rb
@@ -10,6 +10,16 @@ ActiveRecord::Schema.define do
 end
 
 module Refinery
+  class CrudDummyEngine < ::Rails::Engine
+    isolate_namespace Refinery
+  end
+
+  CrudDummyEngine.routes.draw do
+    resources :crud_dummy do
+      post :update_positions, on: :collection
+    end
+  end
+
   class CrudDummy < ActiveRecord::Base
     acts_as_nested_set
   end
@@ -21,6 +31,8 @@ end
 
 module Refinery
   describe CrudDummyController, :type => :controller do
+
+    routes{ CrudDummyEngine.routes }
 
     describe "#update_positions" do
       context "with existing dummies" do

--- a/testing/lib/refinery/testing/controller_macros/methods.rb
+++ b/testing/lib/refinery/testing/controller_macros/methods.rb
@@ -2,34 +2,11 @@ module Refinery
   module Testing
     module ControllerMacros
       module Methods
-        def get(action, options = {})
-          process_refinery_action(action, 'GET', options)
-        end
 
-        # Executes a request simulating POST HTTP method and set/volley the response
-        def post(action, options = {})
-          process_refinery_action(action, 'POST', options)
-        end
+        extend ActiveSupport::Concern
 
-        # Executes a request simulating PUT HTTP method and set/volley the response
-        def put(action, options = {})
-          process_refinery_action(action, 'PUT', options)
-        end
-
-        # Executes a request simulating PATCH HTTP method and set/volley the response
-        def patch(action, options = {})
-          process_refinery_action(action, 'PATCH', options)
-        end
-
-        # Executes a request simulating DELETE HTTP method and set/volley the response
-        def delete(action, options = {})
-          process_refinery_action(action, 'DELETE', options)
-        end
-
-        private
-
-        def process_refinery_action(action, http_method = 'GET', options)
-          process(action, http_method, options.merge(:use_route => :refinery))
+        included do
+          routes { Refinery::Core::Engine.routes }
         end
       end
     end


### PR DESCRIPTION
- to remove deprecation warnings in rspec run

Sending pull request in order to testing this in the Travis CI build -- 

it may fix https://github.com/refinery/refinerycms/issues/2927 -- my tests seem to pass.