### PR TITLE
Avoid N+1 queries: add `default_scope` to `Refinery::Page` to include `:translations`

### DIFF
--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -9,6 +9,7 @@ module Refinery
     extend FriendlyId
 
     translates :title, :menu_title, :custom_slug, :slug, :include => :seo_meta
+    default_scope { includes(:translations) }
 
     class Translation
       is_seo_meta


### PR DESCRIPTION
Installed [Bullet](https://github.com/flyerhzm/bullet) and besides a few bugs of my own, one of the first things it began complaining about was some of the Refinery::Page.by_slug lookups I was doing, since they'd generate a query followed by a second query for the translation lookup from Globalize.

While I was able to resolve this sometimes, it proved nearly impossible when looking up .children to also do the include. In fact, the extra query seemed to happen every time I looked up a page.

So I found an answer [on StackOverflow](http://stackoverflow.com/questions/4337086/rails-3-includes-translations-globalize3-activerecord) I figured I'd report this as a pull request. I don't expect this to get automatically merged, as I haven't the time to consider any implications of this. But it works for my project as follows, in a decorator:

```ruby
Refinery::Page.class_eval do
  default_scope { includes(:translations) }
end
```