### PR TITLE
Pages form fields after...

### DIFF
--- a/pages/app/views/refinery/admin/pages/_form.html.erb
+++ b/pages/app/views/refinery/admin/pages/_form.html.erb
@@ -10,7 +10,9 @@
     <%= f.text_field :title, :class => "larger widest" %>
   </div>
 
-  <%= render 'form_fields_after_title', :f => f %>
+  <% if lookup_context.template_exists?('form_fields_after_title', 'refinery/admin/pages', true) %>
+    <%= render 'form_fields_after_title', :f => f %>
+  <% end %>
 
   <div class='field'>
     <%= render 'form_page_parts', :f => f %>

--- a/pages/app/views/refinery/admin/pages/_form_advanced_options.html.erb
+++ b/pages/app/views/refinery/admin/pages/_form_advanced_options.html.erb
@@ -77,6 +77,10 @@
       <%= f.check_box :show_in_menu %>
       <%= f.label :show_in_menu, t('.show_in_menu_description'),
                   :class => "stripped" %>
+
+      <% if lookup_context.template_exists?('form_fields_after_show_in_menu', 'refinery/admin/pages', true) %>
+        <%= render 'form_fields_after_show_in_menu', :f => f %>
+      <% end %>
     </div>
   </div>
 

--- a/pages/app/views/refinery/admin/pages/_form_fields_after_title.html.erb
+++ b/pages/app/views/refinery/admin/pages/_form_fields_after_title.html.erb
@@ -1,1 +1,0 @@
-<%# Intentionally empty, useful override point to add extra fields. %>


### PR DESCRIPTION
When i add more custom menus, i'd to override the all _form_advanced_options instead of just adding a partial like form_fields_after_title.

BTW, I've change the way we render those partials, no more empty partial :)