### PR TITLE
Fixes issue #2685

### DIFF
--- a/core/lib/generators/refinery/engine/templates/db/migrate/1_create_namespace_plural_name.rb.erb
+++ b/core/lib/generators/refinery/engine/templates/db/migrate/1_create_namespace_plural_name.rb.erb
@@ -3,7 +3,8 @@ class Create<%= namespacing %><%= class_name.pluralize %> < ActiveRecord::Migrat
   def up
     create_table :refinery_<%= "#{namespacing.underscore}_" if table_name != namespacing.underscore.pluralize -%><%= table_name %> do |t|
 <%
-  attributes.each do |attribute|
+  # We modify the attributes, so first we duplicate them.
+  attributes.dup.each do |attribute|
     # turn image or resource into what it was supposed to be which is an integer reference to an image or resource.
     if attribute.type.to_s =~ /^(image|resource)$/
       attribute.type = 'integer'

--- a/core/lib/generators/refinery/form/templates/db/migrate/1_create_plural_name.rb.erb
+++ b/core/lib/generators/refinery/form/templates/db/migrate/1_create_plural_name.rb.erb
@@ -3,7 +3,8 @@ class Create<%= class_name.pluralize %> < ActiveRecord::Migration
   def up
     create_table :refinery_<%= table_name %> do |t|
 <%
-  attributes.each do |attribute|
+  # We modify the attributes, so first we duplicate them.
+  attributes.dup.each do |attribute|
     # turn image or resource into what it was supposed to be which is an integer reference to an image or resource.
     case attribute.type
     when :image, :resource


### PR DESCRIPTION
In some instances, files are loaded in a different order and, given the database migrations were modifying the properties of the attributes, it was setting them back to `integer` and `photo_id` instead of `image` and `photo`, so an image picker would not be displayed where it should be.