### PR TITLE
Introduce Refinery::Generators::NamedBase to solve various problems.

### DIFF
--- a/core/lib/generators/refinery/engine/engine_generator.rb
+++ b/core/lib/generators/refinery/engine/engine_generator.rb
@@ -1,9 +1,9 @@
-require 'rails/generators/named_base'
 require 'refinery/extension_generation'
+require 'refinery/generators/named_base'
 require 'refinery/generators/generated_attribute'
 
 module Refinery
-  class EngineGenerator < Rails::Generators::NamedBase
+  class EngineGenerator < Refinery::Generators::NamedBase
     source_root Pathname.new(File.expand_path('../templates', __FILE__))
 
     include Refinery::ExtensionGeneration
@@ -31,13 +31,6 @@ module Refinery
     end
 
     protected
-
-    def parse_attributes! #:nodoc:
-      self.attributes = (attributes || []).map do |attr|
-        Refinery::Generators::GeneratedAttribute.parse(attr)
-      end
-    end
-
 
     def generator_command
       'rails generate refinery:engine'

--- a/core/lib/generators/refinery/engine/templates/app/views/refinery/namespace/admin/plural_name/_form.html.erb
+++ b/core/lib/generators/refinery/engine/templates/app/views/refinery/namespace/admin/plural_name/_form.html.erb
@@ -12,23 +12,23 @@
               :current_locale => Globalize.locale %>
 <% end -%>
 <% attributes.each_with_index do |attribute, index| -%>
-<% if attribute.type.to_s == 'image' -%>
+<% if attribute.refinery_type == :image -%>
   <div class='field'>
     <%%= f.label :<%= attribute.name %> -%>
     <%%= render '/refinery/admin/image_picker',
                :f => f,
-               :field => :<%= "#{attribute.name}_id".gsub("_id_id", "_id") %>,
-               :image => @<%= singular_name %>.<%= attribute.name.gsub("_id", "") %>,
+               :field => :<%= attribute.column_name %>,
+               :image => @<%= singular_name %>.<%= attribute.name %>,
                :toggle_image_display => false -%>
   </div>
 
-<% elsif attribute.type.to_s == 'resource' -%>
+<% elsif attribute.refinery_type == :resource -%>
   <div class='field'>
     <%%= f.label :<%= attribute.name %> -%>
     <%%= render '/refinery/admin/resource_picker',
                :f => f,
-               :field => :<%= "#{attribute.name}_id".gsub("_id_id", "_id") %>,
-               :resource => @<%= singular_name %>.<%= attribute.name.gsub("_id", "") %> -%>
+               :field => :<%= attribute.column_name %>,
+               :resource => @<%= singular_name %>.<%= attribute.name %> -%>
   </div>
 
 <% elsif attribute.field_type.to_s == "text_area" and !generated_text_areas -%>

--- a/core/lib/generators/refinery/engine/templates/app/views/refinery/namespace/plural_name/show.html.erb
+++ b/core/lib/generators/refinery/engine/templates/app/views/refinery/namespace/plural_name/show.html.erb
@@ -7,11 +7,11 @@
   <section>
     <h1><%= attribute.name.titleize %></h1>
     <p>
-<% if attribute.type.to_s == 'image' -%>
-      <%%= image_fu @<%= singular_name %>.<%= attribute.name %>, nil %>
-<% elsif attribute.type.to_s == 'resource' -%>
+<% if attribute.refinery_type == :image -%>
+      <%%= image_fu @<%= singular_name %>.<%= attribute.name.gsub('_id', '') %>, nil %>
+<% elsif attribute.refinery_type == :resource -%>
       <%% if @<%= singular_name %>.<%= attribute.name %>.present? %>
-        <%%= link_to <%= "'#{attribute.name}'" %>, @<%= singular_name %>.<%= attribute.name %>.url %>
+        <%%= link_to <%= "'#{attribute.name}'" %>, @<%= singular_name %>.<%= attribute.name.gsub('_id', '') %>.url %>
       <%% else %>
         <%= attribute.name %>
       <%% end %>

--- a/core/lib/generators/refinery/engine/templates/db/migrate/1_create_namespace_plural_name.rb.erb
+++ b/core/lib/generators/refinery/engine/templates/db/migrate/1_create_namespace_plural_name.rb.erb
@@ -2,15 +2,8 @@ class Create<%= namespacing %><%= class_name.pluralize %> < ActiveRecord::Migrat
 
   def up
     create_table :refinery_<%= "#{namespacing.underscore}_" if table_name != namespacing.underscore.pluralize -%><%= table_name %> do |t|
-<%
-  attributes.each do |attribute|
-    # turn image or resource into what it was supposed to be which is an integer reference to an image or resource.
-    if attribute.type.to_s =~ /^(image|resource)$/
-      attribute.type = 'integer'
-      attribute.name = "#{attribute.name}_id".gsub("_id_id", "_id")
-    end
--%>
-      t.<%= attribute.type %> :<%= attribute.name %>
+<% attributes.each do |attribute| -%>
+      t.<%= attribute.type %> :<%= attribute.column_name %>
 <% end -%>
       t.integer :position
 

--- a/core/lib/generators/refinery/form/form_generator.rb
+++ b/core/lib/generators/refinery/form/form_generator.rb
@@ -1,8 +1,8 @@
 require 'refinery/extension_generation'
-require 'rails/generators/migration'
+require 'refinery/generators/named_base'
 
 module Refinery
-  class FormGenerator < Rails::Generators::NamedBase
+  class FormGenerator < Refinery::Generators::NamedBase
     source_root Pathname.new(File.expand_path('../templates', __FILE__))
 
     include Refinery::ExtensionGeneration
@@ -20,6 +20,5 @@ module Refinery
     def generator_command
       'rails generate refinery:form'
     end
-
   end
 end

--- a/core/lib/generators/refinery/form/templates/app/controllers/refinery/namespace/admin/plural_name_controller.rb.erb
+++ b/core/lib/generators/refinery/form/templates/app/controllers/refinery/namespace/admin/plural_name_controller.rb.erb
@@ -3,7 +3,7 @@ module Refinery
     module Admin
       class <%= class_name.pluralize %>Controller < Refinery::AdminController
 
-        crudify :'refinery/<%= namespacing.underscore %>/<%= singular_name %>', <% if (title = attributes.detect { |a| a.type.to_s == "string" }).present? %>
+        crudify :'refinery/<%= namespacing.underscore %>/<%= singular_name %>', <% if (title = attributes.detect { |a| a.refinery_type.to_s == "string" }).present? %>
                 :title_attribute => "<%= title.name %>", <% end %>
                 :order => "created_at DESC"
 <% if @includes_spam -%>

--- a/core/lib/generators/refinery/form/templates/app/models/refinery/namespace/singular_name.rb.erb
+++ b/core/lib/generators/refinery/form/templates/app/models/refinery/namespace/singular_name.rb.erb
@@ -4,7 +4,7 @@ module Refinery
 <% if table_name == namespacing.underscore.pluralize -%>
       self.table_name = 'refinery_<%= plural_name %>'
 <% end -%>
-<% if (text_fields = attributes.map { |a| a.name if a.type == :text }.compact.uniq).any? && text_fields.detect{ |a| a.to_s == 'message' }.nil? -%>
+<% if (text_fields = attributes.map { |a| a.name if a.refinery_type == :text }.compact.uniq).any? && text_fields.detect{ |a| a.to_s == 'message' }.nil? -%>
 
       alias_attribute :message, :<%= text_fields.first %>
 <% elsif text_fields.empty? -%>
@@ -15,7 +15,7 @@ module Refinery
         "Override def message in vendor/extensions/<%= namespacing.underscore %>/app/models/refinery/<%= namespacing.underscore %>/<%= singular_name %>.rb"
       end
 <% end -%>
-<% unless (string_fields = attributes.map { |a| a.name if a.type == :string }.compact.uniq).empty? || string_fields.detect { |f| f.to_s == 'name' } -%>
+<% unless (string_fields = attributes.map { |a| a.name if a.refinery_type == :string }.compact.uniq).empty? || string_fields.detect { |f| f.to_s == 'name' } -%>
 
       alias_attribute :name, :<%= string_fields.first %>
 <% end -%>
@@ -39,7 +39,7 @@ module Refinery
 
       belongs_to :<%= a.name %>, :class_name => 'Refinery::Resource'
 <% end -%>
-<% attributes.select{ |a| /radio|select/ === a.type.to_s }.uniq.each do |a| %>
+<% attributes.select{ |a| /radio|select/ === a.refinery_type.to_s }.uniq.each do |a| %>
       <%= a.name.pluralize.upcase %> = []
 <% end -%>
     end

--- a/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/plural_name/new.html.erb
+++ b/core/lib/generators/refinery/form/templates/app/views/refinery/namespace/plural_name/new.html.erb
@@ -8,9 +8,9 @@
                  :include_object_name => true  %>
 <% string_fields = string_attributes.map(&:name) -%>
 <% attributes.each do |attribute| %>
-      <div class='field <%= attribute.name %>_field <%= attribute.type %>_field'>
+      <div class='field <%= attribute.name %>_field <%= attribute.refinery_type %>_field'>
         <%%= f.<%= 'required_' if string_fields.any? && attribute.name == string_fields.first %>label :<%= attribute.name %> %>
-<% case attribute.type
+<% case attribute.refinery_type
    when :string -%>
         <%%= f.text_field :<%= attribute.name %> %>
 <% when :text -%>

--- a/core/lib/generators/refinery/form/templates/db/migrate/1_create_plural_name.rb.erb
+++ b/core/lib/generators/refinery/form/templates/db/migrate/1_create_plural_name.rb.erb
@@ -2,20 +2,8 @@ class Create<%= class_name.pluralize %> < ActiveRecord::Migration
 
   def up
     create_table :refinery_<%= table_name %> do |t|
-<%
-  attributes.each do |attribute|
-    # turn image or resource into what it was supposed to be which is an integer reference to an image or resource.
-    case attribute.type
-    when :image, :resource
-      attribute.type = 'integer'
-      attribute.name = "#{attribute.name}_id"
-    when :radio, :select
-      attribute.type = 'string'
-    when :checkbox
-      attribute.type = 'boolean'
-    end
--%>
-      t.<%= attribute.type %> :<%= attribute.name %>
+<% attributes.each do |attribute| -%>
+      t.<%= attribute.type %> :<%= attribute.column_name %>
 <% end -%>
 
       t.timestamps

--- a/core/lib/refinery/extension_generation.rb
+++ b/core/lib/refinery/extension_generation.rb
@@ -68,15 +68,15 @@ module Refinery
     end
 
     def string_attributes
-      @string_attributes ||= attributes.select { |a| /string|text/ === a.type.to_s}.uniq
+      @string_attributes ||= attributes.select { |a| /string|text/ === a.refinery_type.to_s}.uniq
     end
 
     def image_attributes
-      @image_attributes ||= attributes.select { |a| a.type == :image }.uniq
+      @image_attributes ||= attributes.select { |a| a.refinery_type == :image }.uniq
     end
 
     def resource_attributes
-      @resource_attributes ||= attributes.select { |a| a.type == :resource }.uniq
+      @resource_attributes ||= attributes.select { |a| a.refinery_type == :resource }.uniq
     end
 
     protected

--- a/core/lib/refinery/generators/generated_attribute.rb
+++ b/core/lib/refinery/generators/generated_attribute.rb
@@ -3,10 +3,51 @@ require 'rails/generators/generated_attribute'
 module Refinery
   module Generators
     class GeneratedAttribute < Rails::Generators::GeneratedAttribute
+      attr_accessor :refinery_type
+
       class << self
         def reference?(type)
           [:references, :belongs_to, :image, :resource].include? type
         end
+      end
+
+      def initialize(name, type=nil, index_type=false, attr_options={})
+        super
+        self.refinery_type  = type
+        self.type           = refinerize_type(type)
+      end
+
+      def reference?
+        self.class.reference?(refinery_type)
+      end
+
+      private
+
+      def refinerize_type(type)
+        if refinery_engine_type?(type)
+          :integer
+        elsif  refinery_form_type?(type)
+          if type == :checkbox
+            :boolean
+          else
+            :string
+          end
+        else
+          type
+        end
+      end
+
+      def refinerize_name(name, type)
+        refinery_engine_type?(type) ? "#{name}_id".gsub("_id_id", "_id") : name
+      end
+
+      def refinery_form_type?(type)
+        [:radio, :select, :checkbox].include? type
+        
+      end
+
+      def refinery_engine_type?(type)
+        [:image, :resource].include? type
       end
     end
   end

--- a/core/lib/refinery/generators/named_base.rb
+++ b/core/lib/refinery/generators/named_base.rb
@@ -1,0 +1,16 @@
+require 'rails/generators/named_base'
+
+module Refinery
+  module Generators
+    class NamedBase < Rails::Generators::NamedBase
+
+      protected
+
+      def parse_attributes! #:nodoc:
+        self.attributes = (attributes || []).map do |attr|
+          Refinery::Generators::GeneratedAttribute.parse(attr)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We're using custom types in generators. Let's define custom type and define it in ruby instead of overwriting in erb's.

closes #2658, #2948