### PR TITLE
Prevent crash if a user has no plugin's yet and you want to assign some.

### DIFF
--- a/authentication/app/models/refinery/user.rb
+++ b/authentication/app/models/refinery/user.rb
@@ -56,14 +56,8 @@ module Refinery
       return unless persisted?
       plugin_names = string_plugin_names(plugin_names)
 
-      if plugins.empty?
-        plugin_names.each_with_index do |plugin_name, index|
-          plugins.create(:name => plugin_name, :position => index)
-        end
-      else
-        filtered_names = filter_existing_plugins_for(plugin_names)
-        create_plugins_for(filtered_names)
-      end
+      filtered_names = filter_existing_plugins_for(plugin_names)
+      create_plugins_for(filtered_names)
     end
 
     def authorized_plugins

--- a/authentication/app/models/refinery/user.rb
+++ b/authentication/app/models/refinery/user.rb
@@ -134,7 +134,7 @@ module Refinery
     end
 
     def plugin_position
-      plugins.select(:position).map{ |p| p.position.to_i}.max + 1
+      plugins.select(:position).map{ |p| p.position.to_i}.max.to_i + 1
     end
 
     def filter_existing_plugins_for(plugin_names)

--- a/authentication/spec/models/refinery/user_spec.rb
+++ b/authentication/spec/models/refinery/user_spec.rb
@@ -191,6 +191,14 @@ module Refinery
             user.plugins = plugin_list
             expect(user.plugins.collect(&:name)).to eq(plugin_list)
           end
+
+          it "assigns them to user with unique positions" do
+            expect(user.plugins).to eq([])
+
+            plugin_list = ["refinery_one", "refinery_two", "refinery_three"]
+            user.plugins = plugin_list
+            expect(user.plugins.pluck(:position)).to match_array([1,2,3])
+          end
         end
 
         context "when plugins are already assigned" do


### PR DESCRIPTION
If a user is created in the database without any plugins, you can login etc but you don't have rights to any plugins. If later you try to add permissions to these plugins the application crashes because `max` yields `nil` instead of 0. 

This tiny change fixes this.

I can add a spec for this behavior if needed.

Probably also makes this code obsolete:
https://github.com/refinery/refinerycms/blob/master/authentication/app/models/refinery/user.rb#L59-L63