### PR TITLE
Allow a user to have 0 plugins

### DIFF
--- a/authentication/app/controllers/refinery/admin/users_controller.rb
+++ b/authentication/app/controllers/refinery/admin/users_controller.rb
@@ -131,6 +131,7 @@ module Refinery
       end
 
       def user_params
+        params[:user][:plugins] ||= []
         params.require(:user).permit(
           :email, :password, :password_confirmation, :remember_me, :username,
           :login, :full_name, plugins: []

--- a/authentication/spec/features/refinery/admin/users_spec.rb
+++ b/authentication/spec/features/refinery/admin/users_spec.rb
@@ -55,6 +55,19 @@ describe "User admin page", :type => :feature do
       expect(page).to have_content("cmsrefinery (cms@refinerycms.com)")
     end
 
+    it "can give a user access to 0 plugins" do
+      test_user = FactoryGirl.create(:refinery_user)
+
+      visit refinery.edit_admin_user_path(test_user)
+
+      all(:css, 'ul#plugins input[type=checkbox]').each { |e| e.set(false) }
+
+      click_button "Save"
+
+      test_user.reload
+      expect(test_user.plugins.count).to eql(0)
+    end
+
     let(:dotty_user) { FactoryGirl.create(:refinery_user, :username => 'user.name.with.lots.of.dots') }
     it "accepts a username with a '.' in it" do
       dotty_user # create the user


### PR DESCRIPTION
Rails is smart, when you unselect all checkboxes from a form it will post the checkboxes as `nil`. Strong parameters however expects you to send something of type `[]` instead of `nil` and blocks this parameter by filtering it out. When you update a active record model with out containing a key for `plugins` however it will not remove the existing plugins. This all works fine as long as you have at least 1 plugin, but when you want the user to have no plugins, this fails. Personally I think this is a strong_parameters bug. Have been fixing it in many projects.

This fixes #2973

@parndt would you like a feature spec to go along with this ?