### PR TITLE
Use remove on resource-picker, not delete

### DIFF
--- a/core/app/assets/stylesheets/refinery/_icons.scss
+++ b/core/app/assets/stylesheets/refinery/_icons.scss
@@ -41,6 +41,7 @@
 .info_icon            {@include icon('info-circle');}
 .page_icon            {@include icon('file-o',$icon_page_colour)}
 .preview_icon         {@include icon('eye', $icon_preview_colour)}
+.remove_icon          {@include icon('unlink', $icon_delete_colour);}
 .reorder_done_icon    {@include icon('thumbs-o-up')}
 .reorder_h_icon       {@include icon('exchange');}
 .reorder_icon         {@include icon('unsorted');}

--- a/core/app/views/refinery/admin/_resource_picker.html.erb
+++ b/core/app/views/refinery/admin/_resource_picker.html.erb
@@ -21,7 +21,7 @@
     </span>
     <div id='resource_actions'>
       <%= action_icon :download, "#{resource.url if resource}", t('.download_current'), id: "current_resource_#{field}" %>
-      <%= action_icon :delete, '#', t('.remove_current'), :id => "remove_resource_#{field}"   %>
+      <%= action_icon :remove, '#', t('.remove_current'), :id => "remove_resource_#{field}"%>
     </div>
   </div>
 </div>


### PR DESCRIPTION
The action ‘delete’ uses the delete method.
Action 'remove' here triggers javascript and leaves the unlinking of the resource until ‘Save’ happens.
Using an unlink icon instead of the standard delete. 
![remove action using unlink icon](https://cloud.githubusercontent.com/assets/397118/7549115/adefcabe-f65b-11e4-8161-244b55e557fa.png)
