### PR TITLE
Make the functioning of resource-picker more explicit 

### DIFF
--- a/core/app/assets/javascripts/refinery/admin.js.erb
+++ b/core/app/assets/javascripts/refinery/admin.js.erb
@@ -424,7 +424,7 @@ var link_dialog = {
       e.preventDefault();
       if((resource_selected = $('#existing_resource_area_content ul li.linked a')).length > 0) {
         resourceUrl = parseURL(resource_selected.attr('href'));
-        relevant_href = <%= absolute_page_links ? "resource_selected.attr('href')" : "resourceUrl.pathname" %>;
+        relevant_href = <%= absolute_page_links ? "resource_selected.attr('href')" : "resourceUrl.pathname" %> + "?" + resourceUrl.options;
 
         <% unless absolute_page_links %>
         // Add any alternate resource stores that need a absolute URL in the regex below

--- a/core/app/assets/stylesheets/refinery/_icons.scss
+++ b/core/app/assets/stylesheets/refinery/_icons.scss
@@ -46,6 +46,7 @@
 .reorder_h_icon       {@include icon('exchange');}
 .reorder_icon         {@include icon('unsorted');}
 .reorder_icon.loading {@include icon('spinner')}
+.replace_icon         {@include icon('clipboard')}
 .search_icon          {@include icon('search')}
 .settings_icon        {@include icon('gear')}
 .sortdown_icon        {@include icon('sort-down')}

--- a/core/app/views/refinery/admin/_resource_picker.html.erb
+++ b/core/app/views/refinery/admin/_resource_picker.html.erb
@@ -1,4 +1,5 @@
 <%
+# add and replace use the same url
   insert_link = refinery.insert_admin_resources_path({
                   :dialog => true,
                   :update_resource => "current_resource_#{field}",
@@ -8,46 +9,71 @@
                   :current_link => "#{resource.url if resource}",
                   :height => 480,
                   :conditions => local_assigns[:conditions]
-                })
- %>
+                });
+# if there is no resource attached show the add resource field
+  add_resource_id = "#new_resource_link_#{field}"
+  replace_resource_id = "#current_resource_link_#{field}"
+  manage_resource_id = "#current_resource_container_#{field}"
+  add_class = resource ? 'hidden' : ''
+  manage_class = resource ? '' :  'hidden'
+%>
 <%= f.hidden_field field %>
 
 <div>
-  <%= action_icon :add, insert_link, t('.name'), id: "current_resource_link_#{field}" unless resource %>
+  <%= action_label :add, insert_link, t('.no_resource_selected'), {id: add_resource_id, class: add_class } %>
 
-  <div id="current_resource_container_<%= field %>" style="margin-top: 10px;<%= ' display: none;' unless resource %>">
+  <div id="<%= manage_resource_id%>"  class="<%= manage_class %>" >
     <span class="current_resource" id="<%="current_resource_text_#{field}"%>">
       <%= "#{resource.title} (#{resource.file_name})" if resource %>
     </span>
     <div id='resource_actions'>
-      <%= action_icon :download, "#{resource.url if resource}", t('.download_current'), id: "current_resource_#{field}" %>
       <%= action_icon :remove, '#', t('.remove_current'), :id => "remove_resource_#{field}"%>
+      <%= action_icon :replace, insert_link, t('.name_replace'), id: replace_resource_id %>
+      <%= action_icon :download, "#{resource.url if resource}", t('.download_current'), id: "current_resource_#{field}" %>
     </div>
   </div>
 </div>
 
 <% content_for :javascripts do %>
   <script>
+  // when a resource is attached or replaced
     resource_changed_<%= field %> = function(callback_args) {
-      $('#remove_resource_<%= field %>').show();
-      $('#current_resource_container_<%= field %>').show();
-      $('#no_resource_selected_<%= field %>').hide();
+      var manage_fields = document.getElementById('<%=manage_resource_id%>'),
+          add_field     = document.getElementById('<%=add_resource_id%>'),
+          replace_field = document.getElementById('<%=replace_resource_id%>'),
+          new_href = $(add_field).attr('href').replace(/current_link=([^&])*&/, 'current_link=' + callback_args.href + '&');
+
+    // 1. ensure correct fields are visible
+      $(manage_fields).removeClass('hidden');
+      $(add_field).addClass('hidden');
+
+    // 2. close and remove the dialog
       $('iframe#dialog_iframe').dialog('close');
       $('iframe#dialog_iframe').remove().parents('.ui-dialog').remove();
+
+    // 3. propagate the callback parameters to the form
       $('#<%= f.object_name.gsub(/\]\[|[^-a-zA-Z0-9:.]/, '_').sub(/_$/, '') %>_<%= field %>').val(callback_args.id);
-      $('#current_resource_link_<%= field %>').attr('href', $('#current_resource_link_<%= field %>').attr('href').replace(/current_link=([^&])*&/, 'current_link=' + callback_args.href + '&'));
+      $(replace_field).attr('href', $(replace_field).attr('href').replace(/current_link=([^&])*&/, 'current_link=' + callback_args.href + '&'));
       $('#current_resource_<%= field %>').attr('href', callback_args.href);
       $('#current_resource_text_<%= field %>').html(callback_args.html);
     };
 
+
     $(document).ready(function(e) {
       $('#remove_resource_<%= field %>').click(function(e) {
+        //When a resource is detached/removed from the parent object
+        var manage_fields = document.getElementById('<%=manage_resource_id%>'),
+            add_field = document.getElementById('<%=add_resource_id%>');
+
+        // 1. ensure correct fields are visible
+
+        $(add_field).removeClass('hidden');
+        $(manage_fields).addClass('hidden');
+
+        // 2. clear out values
         $('#<%= f.object_name %>_<%= field %>').val('');
-        $('#current_resource_container_<%= field %>').hide();
         $('#current_resource_text_<%= field %>').html('');
-        $('#no_resource_selected_<%= field %>').show();
-        $('#current_resource_link_<%= field %>').attr('href', $('#current_resource_link_<%= field %>').attr('href').replace(/current_link=([^&])*&/, 'current_link=&'));
-        $(this).hide();
+        $(add_field).attr('href', $(add_field).attr('href').replace(/current_link=([^&])*&/, 'current_link=&'));
         e.preventDefault();
       });
     });

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -44,12 +44,13 @@ en:
       locale_picker:
         language: Language
       resource_picker:
-        download_current: Download current file
+        download_current: Download this file
         opens_in_new_window: Opens in a new window
-        remove_current: "Remove current file"
-        no_resource_selected: 'There is currently no file selected, click here to add one.'
+        remove_current: "Detach this file"
+        no_resource_selected: 'There is no file attached, click here to add one.'
         name: Add File
-        current: Current File
+        name_replace: Replace File
+        current: This File
       search:
         button_text: Search
         results_for_html: "Search results for &#8216;<em>%{query}</em>&#8217;"

--- a/core/spec/features/refinery/admin/resource_picker_spec.rb
+++ b/core/spec/features/refinery/admin/resource_picker_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+module Refinery
+  describe "resource_picker", :type => :feature do
+    refinery_login_with :refinery_user
+
+    context 'No resource present' do
+      it 'shows the add icon and message' do
+        pending "implementation"
+      end
+
+      it "doesn't show the manage resources icons" do
+        pending "implementation"
+      end
+
+      it 'adds a resource' do
+        pending "implementation"
+      end
+    end
+
+    context 'Resource present' do
+      it "doesn't show the add icon and message" do
+        pending "implementation"
+      end
+
+      it "shows the link and management icons for the resource" do
+        pending "implementation"
+      end
+
+      it 'detaches the resource from the object' do
+        pending "implementation"
+      end
+
+      it 'replaces the resource with another resource' do
+        pending "implementation"
+      end
+
+      it 'allows the resource to be downloaded (but why?)' do
+        pending "implementation"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Make the functioning of resource-picker more explicit in code and user view
1. In `admin.js.erb` `init_resources_submit` add the sha parameter to the url returned
   to the caller (resource_picker). Otherwise downloading of a just selected resource fails.
2. Rework to allow for explicit resource replacement
   The view/user should now be in either 
   a. the state where no resource is attached to the
   parent object and they can _add_ a resource. (Only the Add icon/message is visible)
   or 
   b. the state where a resource has been attached to the parent object. 
   Options to _replace, detach or download_ the resource are available.
3. Simplify EN strings, use terms attach/detach/remove/this file
4. Set up skeleton spec for resource_picker.
   (I haven't quite worked out how to do the initial setup.)
5.  Define a replace_icon for use with resource_picker

![Add only shows if there is no resource attached](https://cloud.githubusercontent.com/assets/397118/7588349/22290c8e-f8ef-11e4-9219-266938e44641.png)

![Resource mnaagement icons only appear if there is a resource to manage.](https://cloud.githubusercontent.com/assets/397118/7588350/222d0a5a-f8ef-11e4-9321-e3657faf103e.png)
