### PR TITLE
Prevent double border on file ressource picker

### DIFF
--- a/core/app/assets/stylesheets/refinery/_layout.scss
+++ b/core/app/assets/stylesheets/refinery/_layout.scss
@@ -1355,13 +1355,9 @@ input.button.close_dialog:active, a.button.close_dialog:active, #content a.butto
 }
 
 .nothing_selected {
-  border-bottom: 1px dotted #727272;
   width: auto;
   margin-bottom: 12px;
   display: inline-block;
-}
-.nothing_selected:hover {
-  border-bottom: 1px solid #727272;
 }
 #upgrade_wrapper li a {
   line-height: 20px;


### PR DESCRIPTION
Before :
![screen shot 2015-05-21 at 10 50 11 am](https://cloud.githubusercontent.com/assets/8159397/7751360/87642fa2-ffa7-11e4-9067-a1d651f8387e.png)

After :
![screen shot 2015-05-21 at 10 50 21 am](https://cloud.githubusercontent.com/assets/8159397/7751362/8c449dfe-ffa7-11e4-9d0f-6baa60cdf5d5.png)