### PR TITLE
ApplicationHelper does not work with existing Rails 4.2.1 application

### DIFF
--- a/core/app/controllers/refinery/admin_controller.rb
+++ b/core/app/controllers/refinery/admin_controller.rb
@@ -3,7 +3,6 @@
 module Refinery
   class AdminController < ::ActionController::Base
     include ::Refinery::ApplicationController
-    helper ApplicationHelper
     helper Refinery::Core::Engine.helpers
     include Refinery::Admin::BaseController
 


### PR DESCRIPTION
I get "uninitialized constant Refinery::AdminController::ApplicationHelper (NameError)" when I try to run any rails commands adding refinerycms to an existing application.

Where that ApplicationHelper comes from?