### PR TITLE
Width factor scaling fails when geometry width is not supplied.

### DIFF
--- a/images/app/models/refinery/thumbnail_dimensions.rb
+++ b/images/app/models/refinery/thumbnail_dimensions.rb
@@ -57,7 +57,7 @@ module Refinery
       hf_height = geometry.height.round
 
       # Take the highest value that doesn't exceed either axis limit.
-      use_wf = wf_width <= geometry.width && wf_height <= geometry.height
+      use_wf = wf_width > 0 && wf_width <= geometry.width && wf_height <= geometry.height
       if use_wf && hf_width <= geometry.width && hf_height <= geometry.height
         use_wf = wf_width * wf_height > hf_width * hf_height
       end

--- a/images/spec/models/refinery/thumbnail_dimensions_spec.rb
+++ b/images/spec/models/refinery/thumbnail_dimensions_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+module Refinery
+  describe ThumbnailDimensions, type: :model do
+    subject(:dimensions) { described_class.new(geometry, 500, 375) }
+
+    describe '#scale' do
+      context 'when no width is supplied' do
+        let(:geometry) { 'x225>' }
+
+        it 'scales by height factor' do
+          expect(dimensions.width).to eq 300
+          expect(dimensions.height).to eq 225
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
See test for an example.