### PR TITLE
Use `unshift` instead of `<<` when registering plugins.

### DIFF
--- a/authentication/spec/models/refinery/user_spec.rb
+++ b/authentication/spec/models/refinery/user_spec.rb
@@ -260,7 +260,7 @@ module Refinery
 
       it "adds registered plugins" do
         expect(first_user.plugins.collect(&:name)).to eq(
-          %w(refinery_users refinery_images refinery_files refinery_pages)
+          %w(refinery_pages refinery_files refinery_images refinery_users)
         )
       end
 

--- a/core/lib/refinery/plugin.rb
+++ b/core/lib/refinery/plugin.rb
@@ -16,7 +16,7 @@ module Refinery
       plugin.class_name ||= plugin.name.camelize
 
       # add the new plugin to the collection of registered plugins
-      ::Refinery::Plugins.registered << plugin
+      ::Refinery::Plugins.registered.unshift plugin
     end
 
     # Returns the internationalized version of the title

--- a/core/lib/refinery/plugins.rb
+++ b/core/lib/refinery/plugins.rb
@@ -9,7 +9,7 @@ module Refinery
       @plugins = Array.new(*args)
     end
 
-    def_delegators :@plugins, :<<, :each, :delete_if
+    def_delegators :@plugins, :<<, :each, :delete_if, :unshift
 
     def find_by_name(name)
       detect { |plugin| plugin.name == name }


### PR DESCRIPTION
Fixes #2899 and #2900

I made this change on GitHub so I'm as interested as everyone else to see the CI