### PR TITLE
#2996 Add spinner as hidden icon

### DIFF
--- a/core/app/assets/javascripts/refinery/interface.js.coffee.erb
+++ b/core/app/assets/javascripts/refinery/interface.js.coffee.erb
@@ -21,7 +21,7 @@
     $("form.edit_image .form-actions").css "margin-top": margin_top if margin_top > 0
 
   $(".form-actions .form-actions-left input:submit#submit_button").click (e) ->
-    $("<span class='fa fa-circle-o-notch fa-spin' />").appendTo $(this).parent()
+    $(this).nextAll('#spinner').removeClass('hidden_icon').addClass('unhidden_icon')
 
   $(".form-actions.form-actions-dialog .form-actions-left a.close_dialog").click (e) ->
     titlebar_close_button = $('.ui-dialog-titlebar-close')

--- a/core/app/assets/stylesheets/refinery/_icons.scss
+++ b/core/app/assets/stylesheets/refinery/_icons.scss
@@ -39,6 +39,10 @@
 .folder_icon          {@include icon('folder',$icon_folder_colour)}
 .go_icon              {@include icon('caret-square-o-right');}
 .info_icon            {@include icon('info-circle');}
+.loading_icon         {
+  @include icon('spinner');
+  @extend .fa-spin
+}
 .page_icon            {@include icon('file-o',$icon_page_colour)}
 .preview_icon         {@include icon('eye', $icon_preview_colour)}
 .remove_icon          {@include icon('unlink', $icon_delete_colour);}
@@ -57,6 +61,9 @@
 .switch_view_list_icon {@include icon('list')}
 .upload_icon          {@include icon('upload');}
 .user_comment_icon    {@include icon('comment-o');}
+
+.hidden_icon  {display:none}
+.unhidden_icon {display: inline-block}
 
 // stacked icon/text used for locales
 .locale_marker {

--- a/core/app/views/refinery/admin/_form_actions.html.erb
+++ b/core/app/views/refinery/admin/_form_actions.html.erb
@@ -57,6 +57,7 @@
                 :class => "close_dialog button") unless hide_cancel %>
 
     <%= local_assigns[:after_cancel_button] -%>
+    <i id='spinner' class='loading_icon hidden_icon'></i>
   </div>
   <div class='form-actions-right'>
     <%= local_assigns[:before_delete_button] -%>


### PR DESCRIPTION
This is a fix for #2996 
Make the loading spinner icon a hidden element in forms.
When the insert element is clicked unhide the spinner.