### PR TITLE
Update to include Rails 4 template

### DIFF
--- a/doc/guides/1 - Getting Started/2 - Getting Started.textile
+++ b/doc/guides/1 - Getting Started/2 - Getting Started.textile
@@ -95,7 +95,13 @@ These application templates are another very easy way to install Refinery, and a
 $ rails new rickrockstar -m http://refinerycms.com/t/2.1.0
 </shell>
 
-TIP. As *Refinery CMS is not compatible with Rails 4* you may also need to specify the Rails version in case you are not using an RVM gemset:
+If you want to use Rails 4.1.x with Refinery now, install using this template:
+
+<shell>
+$ rails new app_name -m http://refinerycms.com/t/edge
+</shell>
+
+TIP. As *Refinery CMS versions prior to 2.1.5 are not compatible with Rails 4* you may also need to specify the Rails version in case you are not using an RVM gemset:
 
 <shell>
 $ rails _3.2.15_ new rickrockstar -m http://refinerycms.com/t/2.1.0

--- a/doc/guides/1 - Getting Started/2 - Getting Started.textile
+++ b/doc/guides/1 - Getting Started/2 - Getting Started.textile
@@ -101,7 +101,7 @@ If you want to use Rails 4.1.x with Refinery now, install using this template:
 $ rails new app_name -m http://refinerycms.com/t/edge
 </shell>
 
-TIP. As *Refinery CMS versions prior to 2.1.5 are not compatible with Rails 4* you may also need to specify the Rails version in case you are not using an RVM gemset:
+TIP. As *Refinery CMS versions prior to 3.0.0 are not compatible with Rails 4* you may also need to specify the Rails version in case you are not using an RVM gemset:
 
 <shell>
 $ rails _3.2.15_ new rickrockstar -m http://refinerycms.com/t/2.1.0


### PR DESCRIPTION
The README includes the updated reference to the edge template but this document does not.

I can update the language if there's a better way to say this, but this may save new users some frustration if they're following the guide and it bombs while running bundle install.