### PR TITLE
Fix issue 3025

### DIFF
--- a/pages/app/views/refinery/admin/pages/_page.html.erb
+++ b/pages/app/views/refinery/admin/pages/_page.html.erb
@@ -11,7 +11,9 @@
   <li class='clearfix record items' id="<%= dom_id(page) -%>">
   <div class='clearfix'>
     <% if page.children.present? %>
-      <span class="item toggle <%= 'expanded' if Refinery::Pages.auto_expand_admin_tree %>" title="<%= t('expand_collapse')%>"></span>
+      <span class="item icon toggle <%= 'expanded' if Refinery::Pages.auto_expand_admin_tree %>"
+        title="<%= t('expand_collapse', scope: 'refinery.admin.pages')%>">
+      </span>
     <% else %>
       <span class="item"></span>
     <% end %>


### PR DESCRIPTION
1. call translation string with scope
2. Add class ‘icon’ to page branches

Class 'icon' isn't the *semantic* class for this, however it is what the javascript in `tree.js` and `sortable_list.js` are looking for.  As I'm not sure who else uses these it's probably unsafe to change `.icon` into `.branch` or `.parent`.