### PR TITLE
Core now requires rails 4.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@
 * Deprecated `part_with_title` method in `Refinery#Page` and `title_matches?` method in `Refinery#PagePart`. [#2875](https://github.com/refinery/refinerycms/pull/2875). [Brice Sanchez](https://github.com/bricesanchez) & [Philip Arndt](https://github.com/parndt) & [Josef Šimánek](https://github.com/simi)
 * Added ability to customize and translate filename. [#2966](https://github.com/refinery/refinerycms/pull/2966). [Brice Sanchez](https://github.com/bricesanchez)
 * Added ability to translate images title and alt attributes. [#2965](https://github.com/refinery/refinerycms/pull/2965). [Brice Sanchez](https://github.com/bricesanchez)
+* Decouple Refinery CMS from Devise. [#2940](https://github.com/refinery/refinerycms/pull/2940). [Philip Arndt](https://github.com/parndt)
 
 * [See full list](https://github.com/refinery/refinerycms/compare/2-1-stable...master)
 

--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@
 * Added ability to customize and translate filename. [#2966](https://github.com/refinery/refinerycms/pull/2966). [Brice Sanchez](https://github.com/bricesanchez)
 * Added ability to translate images title and alt attributes. [#2965](https://github.com/refinery/refinerycms/pull/2965). [Brice Sanchez](https://github.com/bricesanchez)
 * Decouple Refinery CMS from Devise. [#2940](https://github.com/refinery/refinerycms/pull/2940). [Philip Arndt](https://github.com/parndt)
+* Refinery CMS Core now requires Rails >= 4.2.3. [#3034](https://github.com/refinery/refinerycms/pull/3034). [Brice Sanchez](https://github.com/bricesanchez)
 
 * [See full list](https://github.com/refinery/refinerycms/compare/2-1-stable...master)
 

--- a/core/refinerycms-core.gemspec
+++ b/core/refinerycms-core.gemspec
@@ -2,7 +2,7 @@
 require File.expand_path('../../core/lib/refinery/version', __FILE__)
 
 version = Refinery::Version.to_s
-rails_version = ['>= 4.1.5', '< 5.0']
+rails_version = ['>= 4.2.3', '< 5.0']
 
 Gem::Specification.new do |s|
   s.platform          = Gem::Platform::RUBY

--- a/doc/guides/1 - Getting Started/2 - Getting Started.textile
+++ b/doc/guides/1 - Getting Started/2 - Getting Started.textile
@@ -101,7 +101,7 @@ TIP. As *the latest stable version of Refinery CMS is not compatible with Rails 
 $ rails _3.2.15_ new rickrockstar -m http://refinerycms.com/t/2.1.0
 </shell>
 
-TIP. If you want to create a Rails 4 application with refinerycms, you'll have to use the edge version. This works with Rails 4.1.10, 4.2.0 and 4.2.1:
+TIP. If you want to create a Rails 4 application with refinerycms, you'll have to use the edge version. This works with Rails 4.2.3:
 
 <shell>
 $ rails new rickrockstar -m http://refinerycms.com/t/edge

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Refinery CMS
 
-__An open source content management system for Rails 4.1+__
+__An open source content management system for Rails 4.2+__
 
 More information at [http://refinerycms.com](http://refinerycms.com)
 
@@ -28,7 +28,7 @@ If you're new to Refinery, start with this guide:
 
 * __[Getting Started](http://refinerycms.com/guides/getting-started)__
 
-If you want to use Rails 4.1.x with Refinery now, install using this template:
+If you want to use Rails 4.2.x with Refinery now, install using this template:
 
     rails new app_name -m http://refinerycms.com/t/edge
 
@@ -45,7 +45,7 @@ Unlike other content managers, Refinery is truly __aimed at the end user__ makin
 * Sticks to __"the Rails way"__ as much as possible; we don't force you to learn new templating languages.
 * Uses [jQuery](http://jquery.com/) for fast and concise Javascript.
 
-![Refinery Pages UI](http://refinerycms.com/system/images/0000/0576/dashboard.png)
+### Demo
 
 Wanna see Refinery for yourself? [Try the demo](http://demo.refinerycms.com/refinery).
 

--- a/refinerycms.gemspec
+++ b/refinerycms.gemspec
@@ -7,8 +7,8 @@ Gem::Specification.new do |s|
   s.platform          = Gem::Platform::RUBY
   s.name              = %q{refinerycms}
   s.version           = version
-  s.description       = %q{A Ruby on Rails CMS that supports Rails 4.1. It's easy to extend and sticks to 'the Rails way' where possible.}
-  s.summary           = %q{A Ruby on Rails CMS that supports Rails 4.1}
+  s.description       = %q{A Ruby on Rails CMS that supports Rails 4.2. It's easy to extend and sticks to 'the Rails way' where possible.}
+  s.summary           = %q{A Ruby on Rails CMS that supports Rails 4.2}
   s.email             = %q{info@refinerycms.com}
   s.homepage          = %q{http://refinerycms.com}
   s.rubyforge_project = %q{refinerycms}


### PR DESCRIPTION
@parndt With this PR, you have to change the Github repo description : 
`An extendable Ruby on Rails CMS that supports Rails 3.2 and 4.2 http://refinerycms.com/guides/`

And the update the informations on the official website : 
http://www.refinerycms.com/
`Ruby on Rails CMS that supports Rails 3.2 and 4.2`
`Supports Rails 4.2 `

http://www.refinerycms.com/download
`gem install rails --version 4.2.3`