### PR TITLE
Remove z-index for .locale_marker

### DIFF
--- a/core/app/assets/stylesheets/refinery/_icons.scss
+++ b/core/app/assets/stylesheets/refinery/_icons.scss
@@ -77,7 +77,6 @@
       line-height: 1em;
       position: absolute;
       top: 9px;
-      z-index: 10;
     }
 }
 


### PR DESCRIPTION
Before:
<img width="1135" alt="refinery-z-index-bug-locale" src="https://cloud.githubusercontent.com/assets/1678530/9306688/dacdbcde-44c7-11e5-8a61-1554f370bd86.png">

After: 
<img width="1082" alt="refinery-z-index-fix-locale" src="https://cloud.githubusercontent.com/assets/1678530/9306692/e793eff6-44c7-11e5-9e5b-90e2ca1f1ac1.png">
