### PR TITLE
Add some missing Dutch translations and a generic one.

### DIFF
--- a/images/config/locales/de.yml
+++ b/images/config/locales/de.yml
@@ -5,6 +5,8 @@ de:
         title: Bilder
         description: Verwaltet Bilder
     admin:
+      locale_picker:
+        language: Sprache
       images:
         delete: Dieses Bild für immer löschen
         edit: Dieses Bild bearbeiten

--- a/images/config/locales/en.yml
+++ b/images/config/locales/en.yml
@@ -5,6 +5,8 @@ en:
         title: Images
         description: Manage images
     admin:
+      locale_picker:
+        language: Language
       images:
         delete: Remove this image forever
         edit: Edit this image

--- a/images/config/locales/es.yml
+++ b/images/config/locales/es.yml
@@ -6,6 +6,8 @@ es:
         description: Gestionar imágenes
         article: femenino
     admin:
+      locale_picker:
+        language: Lenguajes
       images:
         delete: Borrar esta imagen para siempre
         edit: Editar esta imagen
@@ -16,6 +18,10 @@ es:
           replace_image: " reemplazarla con esta otra..."
           current_image: Imagen actual
           maximum_image_size: El peso máximo para una imagen son %{bytes}.
+          image_title: Título
+          image_title_help: Información extra acerca de la imágen
+          image_alt: Alt
+          image_alt_help: Texto para usar en caso de que la imágen no sea visible.
         actions:
           create_new_image: Crear nueva imagen
         records:

--- a/images/config/locales/nl.yml
+++ b/images/config/locales/nl.yml
@@ -5,6 +5,8 @@ nl:
         title: Afbeeldingen
         description: Afbeeldingen beheren
     admin:
+      locale_picker:
+        language: Taal
       images:
         delete: Deze afbeelding definitief verwijderen
         edit: Deze afbeelding bewerken
@@ -15,6 +17,10 @@ nl:
           replace_image: " vervangen door deze..."
           current_image: Huidige afbeelding
           maximum_image_size: De maximale afbeeldingssgrootte is %{bytes}.
+          image_title: Titel
+          image_title_help: Extra informatie over de afbeelding
+          image_alt: Alternatief
+          image_alt_help: Text indien afbeelding niet kan worden getoond.
         actions:
           create_new_image: Nieuwe afbeelding toevoegen
         records:


### PR DESCRIPTION
Fixed some missing translations in the Dutch language for the title & alt attributes of images.

Also noticed the missing "locale_picker.language" in English and German, so fixed that to.

 

