### PR TITLE
Set hide_cancel to false for existing_resource

### DIFF
--- a/resources/app/views/refinery/admin/resources/_existing_resource.html.erb
+++ b/resources/app/views/refinery/admin/resources/_existing_resource.html.erb
@@ -21,6 +21,6 @@
 
   <%= render '/refinery/admin/form_actions', :f => nil,
              :submit_button_text => t('.button_text'),
-             :hide_cancel => true,
+             :hide_cancel => false,
              :hide_delete => true if @app_dialog or @resources.any? %>
 </div>


### PR DESCRIPTION
It fixes the close action of the dialog in the https://github.com/anitagraham/refinerycms-page-resources extension. 

See : https://github.com/anitagraham/refinerycms-page-resources/pull/1