### PR TITLE
Update default_parts syntax to support both title and slug

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 ## 3.1.0 [unreleased]
 
+* Updated Refinery::Pages.default_parts= config to require both a title and a slug attribute for each part. [#3069](https://github.com/refinery/refinerycms/pull/3069). [Brice Sanchez](https://github.com/bricesanchez)
+
 * [See full list](https://github.com/refinery/refinerycms/compare/3-0-stable...master)
 
 

--- a/doc/guides/2 - Refinery Basics/1 - Changing Page Parts.textile
+++ b/doc/guides/2 - Refinery Basics/1 - Changing Page Parts.textile
@@ -20,7 +20,7 @@ settings are commented out, including the following:
 
 <ruby>
   # Configure global page default parts
-  # config.default_parts = ["Body", "Side Body"]
+  # config.default_parts = [{ title: "Body", slug: "body" }, { title: "Side Body", slug: "side_body" }]
 </ruby>
 
 Edit this code to have the names of the default page parts you want, click +Save+

--- a/pages/app/controllers/refinery/admin/pages_controller.rb
+++ b/pages/app/controllers/refinery/admin/pages_controller.rb
@@ -12,7 +12,7 @@ module Refinery
       def new
         @page = Page.new(new_page_params)
         Pages.default_parts_for(@page).each_with_index do |page_part, index|
-          @page.parts << PagePart.new(:title => page_part, :slug => page_part, :position => index)
+          @page.parts << PagePart.new(:title => page_part[:title], :slug => page_part[:slug], :position => index)
         end
       end
 

--- a/pages/db/migrate/20151103211604_fix_slug_format_in_refinery_page_parts.rb
+++ b/pages/db/migrate/20151103211604_fix_slug_format_in_refinery_page_parts.rb
@@ -1,0 +1,12 @@
+class FixSlugFormatInRefineryPageParts < ActiveRecord::Migration
+  def change
+    begin
+      ::Refinery::PagePart.all.each do |pp|
+        pp.slug = pp.slug.downcase.gsub(" ", "_")
+        pp.save!
+      end
+    rescue NameError
+      warn "Refinery::PagePart was not defined!"
+    end
+  end
+end

--- a/pages/lib/refinery/pages/configuration.rb
+++ b/pages/lib/refinery/pages/configuration.rb
@@ -16,7 +16,7 @@ module Refinery
     self.marketable_urls = true
     self.approximate_ascii = false
     self.strip_non_ascii = false
-    self.default_parts = ["Body", "Side Body"]
+    self.default_parts = [{ title: "Body", slug: "body" }, { title: "Side Body", slug: "side_body" }]
     self.use_custom_slugs = false
     self.scope_slug_by_parent = true
     self.cache_pages_backend = false
@@ -25,6 +25,21 @@ module Refinery
     class << self
       def layout_template_whitelist
         Array(config.layout_template_whitelist).map(&:to_s)
+      end
+
+      def default_parts
+        if config.default_parts.all? { |v| v.is_a? String }
+          new_syntax = config.default_parts.map do |part|
+            { title: part, slug: part.downcase.gsub(" ", "_") }
+          end
+          Refinery.deprecate(
+            "Change Refinery::Pages.default_parts= from #{config.default_parts.inspect} to #{new_syntax.inspect}",
+            when: "3.2.0"
+          )
+          new_syntax
+        else
+          config.default_parts
+        end
       end
     end
     self.use_layout_templates = false

--- a/pages/spec/features/refinery/admin/pages_spec.rb
+++ b/pages/spec/features/refinery/admin/pages_spec.rb
@@ -744,8 +744,8 @@ module Refinery
           page = Refinery::Page.create! :title => "test"
           Refinery::Pages.default_parts.each_with_index do |default_page_part, index|
             page.parts.create(
-              title: default_page_part,
-              slug: default_page_part,
+              title: default_page_part[:title],
+              slug: default_page_part[:slug],
               body: "<header class='regression'>test</header>",
               position: index
             )
@@ -807,7 +807,7 @@ module Refinery
           page = Refinery::Page.last
           # we need page parts so that there's a visual editor
           Refinery::Pages.default_parts.each_with_index do |default_page_part, index|
-            page.parts.create(:title => default_page_part, :body => nil, :position => index)
+            page.parts.create(:title => default_page_part[:title], :slug => default_page_part[:slug], :body => nil, :position => index)
           end
           page
         end


### PR DESCRIPTION
We seen that default parts doesn't generate a good format of slugs in page parts.

It generated a slug like `Side Body` instead of `side_body`

This is my proposal of fix.