### PR TITLE
Add page_options

### DIFF
--- a/pages/app/presenters/refinery/pages/menu_presenter.rb
+++ b/pages/app/presenters/refinery/pages/menu_presenter.rb
@@ -1,4 +1,3 @@
-require 'active_support/core_ext/string'
 require 'active_support/configurable'
 require 'action_view/helpers/tag_helper'
 require 'action_view/helpers/url_helper'

--- a/pages/app/views/refinery/admin/pages/_form_advanced_options.html.erb
+++ b/pages/app/views/refinery/admin/pages/_form_advanced_options.html.erb
@@ -78,7 +78,9 @@
       <%= f.label :show_in_menu, t('.show_in_menu_description'),
                   :class => "stripped" %>
     </div>
-
+    <% Refinery::Pages.page_options.collect do |options| %>
+      <%=  render partial: options.partial, locals:{f: f} %>
+    <%  end   %>
     <%= render 'form_extra_fields_for_more_options', :f => f %>
   </div>
 

--- a/pages/lib/refinery/pages.rb
+++ b/pages/lib/refinery/pages.rb
@@ -8,6 +8,7 @@ module Refinery
     require 'refinery/pages/tab'
     require 'refinery/pages/type'
     require 'refinery/pages/types'
+    require 'refinery/pages/page_options'
 
     # Load configuration last so that everything above is available to it.
     require 'refinery/pages/configuration'

--- a/pages/lib/refinery/pages/page_options.rb
+++ b/pages/lib/refinery/pages/page_options.rb
@@ -1,0 +1,31 @@
+module Refinery
+  module Pages
+
+    def self.page_options
+      @page_options ||= []
+    end
+
+    class PageOptions
+
+      attr_accessor :name, :partial
+
+      def self.register(&block)
+        options = self.new
+
+        yield options
+
+        raise ArgumentError, "A page_option MUST have a name!: #{options.inspect}" if options.name.blank?
+        raise ArgumentError, "A page_option MUST have a partial!: #{options.inspect}" if options.partial.blank?
+
+        options
+      end
+
+      protected
+
+      def initialize
+        Refinery::Pages.page_options << self
+      end
+
+    end
+  end
+end

--- a/pages/spec/controllers/refinery/admin/pages_controller_spec.rb
+++ b/pages/spec/controllers/refinery/admin/pages_controller_spec.rb
@@ -49,5 +49,18 @@ module Refinery
          end
        end
     end
+
+    describe 'additional page options' do
+      context 'when an extra page option has been registered' do
+        before do
+          allow(Refinery::Pages).to receive(:page_options).and_return({name:'test', partial: 'test_option'})
+        end
+        subject { get 'refinery/pages/home/edit'}
+        it 'should render the partial' do
+          expect(response).to render_template(partial: 'test_option')
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Visiting an old topic with a different approach, I think.  Allowing extensions to add their own fields to the Page advanced options form. The current option of using a partial `_form_extra_fields_for_more_options.html.erb` may cause conflicts between different engines.
One might do this when the extension adds fields to the page using a decorator.

Add a page_option which will allow extensions to add extra options to
_form_advanced_options.  
**Example**

``` ruby
module Refinery
  module Myextension
    class Engine < Rails::Engine

      def self.register_page_options(options)
        options.name = 'myextension'
        options.partial = '/refinery/myextension/admin/pages/page_options'
      end
......

      config.after_initialize do
        Refinery.register_extension(Refinery::Myextension)
        Refinery::Pages::PageOptions.register do |option|
          register_page_options option
        end
      end
```

The partial in `/refinery/myextension/admin/pages/page_options` would appear in the Advanced Options section of the Page edit form.
