### PR TITLE
Lock sprockets-rails to ~> 2.3.3

### DIFF
--- a/core/refinerycms-core.gemspec
+++ b/core/refinerycms-core.gemspec
@@ -34,5 +34,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'jquery-rails',                '>= 2.3.0'
   s.add_dependency 'jquery-ui-rails',             '~> 5.0.0'
   s.add_dependency 'decorators',                  '~> 2.0.0'
+  s.add_dependency 'sprockets-rails',             '~> 2.3.3'
   s.add_dependency 'zilch-authorisation'
 end


### PR DESCRIPTION
Speakingurl block refinerycms start if you have sprockets-rails 3.0.0.

I've send a PR to this gem : https://github.com/pid/speakingurl/pull/70
