### PR TITLE
Specify that we are expecting action_name to be insert

### DIFF
--- a/resources/app/views/refinery/admin/resources/_existing_resource.html.erb
+++ b/resources/app/views/refinery/admin/resources/_existing_resource.html.erb
@@ -20,6 +20,7 @@
   <%= will_paginate @resources, :params => params.dup.merge(:action => "insert") %>
 
   <%= render '/refinery/admin/form_actions', :f => nil,
+             :action_name => "insert",
              :submit_button_text => t('.button_text'),
              :hide_cancel => false,
              :hide_delete => true if @app_dialog or @resources.any? %>


### PR DESCRIPTION
This prevents a crash issue where it tries to access attributes on the form (which is nil) because the action_name was resolving as create.