### PR TITLE
Specify the correct new_page_part_params.

### DIFF
--- a/pages/app/controllers/refinery/admin/page_parts_controller.rb
+++ b/pages/app/controllers/refinery/admin/page_parts_controller.rb
@@ -23,7 +23,7 @@ module Refinery
 
       protected
         def new_page_part_params
-          params.permit(:title, :slug, :body)
+          params.except(:part_index).permit(:title, :slug, :body, :locale)
         end
 
     end


### PR DESCRIPTION
Allow locale, which is reasonable.
Exclude part_index which is used internally

Fixes #3110