### PR TITLE
Add SanitizeHelper to TitleSectionPresenter

### DIFF
--- a/pages/app/presenters/refinery/pages/title_section_presenter.rb
+++ b/pages/app/presenters/refinery/pages/title_section_presenter.rb
@@ -4,6 +4,8 @@ module Refinery
     # a title. These are much like normal sections except they are wrapped in
     # a h1 tag rather than a div.
     class TitleSectionPresenter < SectionPresenter
+      include ActionView::Helpers::SanitizeHelper
+
     private
 
       def wrap_content_in_tag(content)


### PR DESCRIPTION
Recent change #3117 to TitleSectionPresenter has caused a NoMethodError in Refinery::Pages#show

    undefined method `sanitize' for #<Refinery::Pages::TitleSectionPresenter:0x007fdcf6620c70>

We need to include the SanitizeHelper in `title_section_presenter.rb`.