### PR TITLE
Update Resolve Digital website link to use HTTPS

### DIFF
--- a/core/license.md
+++ b/core/license.md
@@ -1,6 +1,6 @@
 # MIT License
  
-Copyright (c) 2005 [Resolve Digital](http://resolve.digital)
+Copyright (c) 2005 [Resolve Digital](https://resolve.digital)
  
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/images/license.md
+++ b/images/license.md
@@ -1,6 +1,6 @@
 # MIT License
  
-Copyright (c) 2005 [Resolve Digital](http://resolve.digital)
+Copyright (c) 2005 [Resolve Digital](https://resolve.digital)
  
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/license.md
+++ b/license.md
@@ -1,6 +1,6 @@
 # MIT License
  
-Copyright (c) 2005 [Resolve Digital](http://resolve.digital)
+Copyright (c) 2005 [Resolve Digital](https://resolve.digital)
  
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pages/license.md
+++ b/pages/license.md
@@ -1,6 +1,6 @@
 # MIT License
  
-Copyright (c) 2005 [Resolve Digital](http://resolve.digital)
+Copyright (c) 2005 [Resolve Digital](https://resolve.digital)
  
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/resources/license.md
+++ b/resources/license.md
@@ -1,6 +1,6 @@
 # MIT License
  
-Copyright (c) 2005 [Resolve Digital](http://resolve.digital)
+Copyright (c) 2005 [Resolve Digital](https://resolve.digital)
  
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The Resolve Digital website now runs on HTTPS. Link directly to avoid the redirect.