### PR TITLE
Modify image grid to display 4 images in a row.

### DIFF
--- a/core/app/assets/stylesheets/refinery/_layout.scss
+++ b/core/app/assets/stylesheets/refinery/_layout.scss
@@ -1146,17 +1146,17 @@ ul#image_grid, .pagination_container > ul#image_grid {
 ul#image_grid li, .pagination_container > ul#image_grid li {
   position: relative;
   float: left;
-  margin: 0px 7px 12px 0px;
+  margin: 0px 12px 12px 0px;
   padding: 0px;
-  width: 124px;
+  width: 149px;
+  height: 186px;
+  max-width: 149px;
+  max-height: 186px;
   text-align: center;
-  height: 165px;
   overflow: hidden;
-  max-width: 124px;
-  max-height: 165px;
 }
-ul#image_grid li.image_4 {
-  margin-left: 1px;
+ul#image_grid li.image_3 {
+  margin-left: 0px;
   margin-right: 0px;
 }
 #records ul#image_grid li .actions {

--- a/images/app/views/refinery/admin/images/_grid_view.html.erb
+++ b/images/app/views/refinery/admin/images/_grid_view.html.erb
@@ -1,7 +1,7 @@
 <ul id="image_grid" class="<%= ['clearfix', 'pagination_frame', 'images_list', pagination_css_class].compact.join(' ') %>">
   <% @images.each_with_index do |image, index| -%>
-    <li id="image_<%= image.id %>" class="image_<%= index % 5 %>">
-      <%= image_fu image, '135x135#c', title: image.title %>
+    <li id="image_<%= image.id %>" class="image_<%= index % 4 %>">
+      <%= image_fu image, '149x149#c', title: image.title %>
       <span class="actions">
 
        <%= action_icon :preview, image.url, t('view_live_html', scope: 'refinery.admin.images') %>


### PR DESCRIPTION
Previously, trying to display five images horizontally proved too much for the grid view.

Before:
![screen shot 2016-03-28 at 14 50 41](https://cloud.githubusercontent.com/assets/10128/14069387/8b51e930-f4f5-11e5-8774-ca4d12a543ff.png)

After:
  
![screen shot 2016-03-28 at 14 56 01](https://cloud.githubusercontent.com/assets/10128/14069391/93007660-f4f5-11e5-8bb3-ed7fbfa5585f.png)
