### PR TITLE
Add page_parts factory

### DIFF
--- a/pages/spec/factories/page_parts.rb
+++ b/pages/spec/factories/page_parts.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :page_part, class: Refinery::PagePart do
+    title 'Body'
+    slug 'side_body'
+  end
+end

--- a/pages/spec/factories/pages.rb
+++ b/pages/spec/factories/pages.rb
@@ -1,5 +1,11 @@
 FactoryGirl.define do
-  factory :page, :class => Refinery::Page do
+  factory :page, class: Refinery::Page do
     sequence(:title, "a") { |n| "Test title #{n}" }
+
+    factory :page_with_page_part do
+      after(:create) do |page|
+        page.parts << FactoryGirl.create(:page_part)
+      end
+    end
   end
 end


### PR DESCRIPTION
This should fix failling specs in https://travis-ci.org/refinery/refinerycms-page-images/builds/118346622

Capybara can not switch tabs because there is no page part.

Bonus : I've seen that Poltergeist now consider `opacity` for visibility  : https://github.com/teampoltergeist/poltergeist/pull/675