### PR TITLE
Allow spec retry count to be environment specific, and 0 by default.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: ruby
 cache: bundler
 bundler_args: --without development
-before_script: "bin/rake refinery:testing:dummy_app"
+before_script:
+  - export RETRY_COUNT=3
+  - bin/rake refinery:testing:dummy_app
 script:
-  - "bin/rspec $EXTENSION/spec"
+  - bin/rspec $EXTENSION/spec
 env:
   - DB=postgresql EXTENSION=core
   - DB=postgresql EXTENSION=pages

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,17 @@ require File.expand_path("../dummy/config/environment", __FILE__)
 
 require 'rspec/rails'
 require 'capybara/rspec'
-require 'rspec/retry'
+
+if ENV['RETRY_COUNT']
+  require 'rspec/retry'
+  RSpec.configure do |config|
+    # rspec-retry
+    config.verbose_retry = true
+    config.default_sleep_interval = 0.33
+    config.clear_lets_on_failure = true
+    config.default_retry_count = ENV["RETRY_COUNT"]
+  end
+end
 
 Rails.backtrace_cleaner.remove_silencers!
 
@@ -32,12 +42,6 @@ RSpec.configure do |config|
   config.before(:each) do
     ::I18n.default_locale = I18n.locale = Globalize.locale = :en
   end
-
-  # rspec-retry
-  config.verbose_retry = true
-  config.default_sleep_interval = 0.33
-  config.clear_lets_on_failure = true
-  config.default_retry_count = 3
 
   unless ENV['FULL_BACKTRACE']
     config.backtrace_exclusion_patterns = %w(


### PR DESCRIPTION
Examples:

    RETRY_COUNT=2 bundle exec rspec pages/spec

or:

    export RETRY_COUNT=1
    bundle exec rspec pages/spec

Locally retries are not very required, as this is more of a CI feature.