### PR TITLE
Add warning when content has been sanitized

### DIFF
--- a/pages/app/presenters/refinery/pages/section_presenter.rb
+++ b/pages/app/presenters/refinery/pages/section_presenter.rb
@@ -1,3 +1,5 @@
+require 'diffy'
+
 module Refinery
   module Pages
     # Knows how to build the html for a section. A section is part of the visible html, that has
@@ -63,11 +65,24 @@ module Refinery
       attr_writer :id, :fallback_html, :hidden
 
       def wrap_content_in_tag(content)
-        content = sanitize(content,
+        content_tag(:section, content_tag(:div, sanitize_content(content), :class => 'inner'), :id => id)
+      end
+
+      def sanitize_content(input)
+        output = sanitize(input,
           tags: Refinery::Pages::whitelist_elements,
           attributes: Refinery::Pages::whitelist_attributes
         )
-        content_tag(:section, content_tag(:div, content, :class => 'inner'), :id => id)
+
+        if input != output
+          warning = "\n-- SANITIZED CONTENT WARNING --\n"
+          warning << "Refinery::Pages::SectionPresenter#wrap_content_in_tag\n"
+          warning << "HTML attributes and/or elements content has been sanitized\n"
+          warning << "#{::Diffy::Diff.new(input, output).to_s(:color)}\n"
+          warn warning
+        end
+
+        return output
       end
     end
   end

--- a/pages/refinerycms-pages.gemspec
+++ b/pages/refinerycms-pages.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'refinerycms-core',            version
   s.add_dependency 'babosa',                      '!= 0.3.6'
   s.add_dependency 'speakingurl-rails',           '~> 8.0.0'
+  s.add_dependency 'diffy',                       '~> 3.1.0'
 
   s.required_ruby_version = Refinery::Version.required_ruby_version
 end

--- a/pages/spec/presenters/refinery/pages/section_presenter_spec.rb
+++ b/pages/spec/presenters/refinery/pages/section_presenter_spec.rb
@@ -97,6 +97,26 @@ module Refinery
           end
         end
 
+        describe "#sanitize_content" do
+          before do
+            @errors = StringIO.new
+            @old_err = $stderr
+            $stderr = @errors
+          end
+
+          after(:each) { $stderr = @old_err }
+
+          it "shows a sanitized content warning" do
+            section = SectionPresenter.new
+            section.override_html = %Q{<dummy></dummy>}
+            section.wrapped_html(true)
+            @errors.rewind
+            expect(@errors.read).to eq(
+              %Q{\n-- SANITIZED CONTENT WARNING --\nRefinery::Pages::SectionPresenter#wrap_content_in_tag\nHTML attributes and/or elements content has been sanitized\n\e[31m-<dummy></dummy>\e[0m\n\\ No newline at end of file\n\n}
+            )
+          end
+        end
+
         describe "if allowed to use fallback html" do
           it "wont show a section with no fallback or override" do
             section = SectionPresenter.new


### PR DESCRIPTION
At this time, it's not easy to know and understand what happens when content has been sanitized in `SectionPresenter`, it will be great to have a WARNING in the console in order to be able to add missing HTML elements or attributes in the whitelist.

![pr-3170-console](https://cloud.githubusercontent.com/assets/1678530/14988603/94e3fc88-1122-11e6-818c-b2002f8d8683.jpg)

What do you think about this implementation ?