### PR TITLE
Use admin_update_page_path to avoid encoded URLs

### DIFF
--- a/pages/app/controllers/refinery/admin/pages_controller.rb
+++ b/pages/app/controllers/refinery/admin/pages_controller.rb
@@ -108,7 +108,7 @@ module Refinery
         nested_url = page.nested_url
         {
           new_refinery_edit_page_path: refinery.admin_edit_page_path(nested_url),
-          new_refinery_page_path: refinery.admin_page_path(nested_url),
+          new_refinery_page_path: refinery.admin_update_page_path(nested_url),
           new_page_path: refinery.pages_admin_preview_page_path(nested_url)
         }
       end


### PR DESCRIPTION
Fixes #3179
Makes use of #2709

## Before merge

- [x] Confirmation that it fixes #3179 from @peaceand
- [x] Test case