### PR TITLE
Improve execjs error message

### DIFF
--- a/templates/refinery/demo.rb
+++ b/templates/refinery/demo.rb
@@ -5,7 +5,9 @@ begin
   require 'execjs'
   ::ExecJS::RuntimeUnavailable
 rescue LoadError
-  abort "ExecJS is not installed. Please re-start the installer after running:\ngem install execjs"
+  abort <<-ERROR
+\033[31m[ABORTING]\033[0m ExecJS is not installed. Please re-start the installer after running:\ngem install execjs
+ERROR
 end
 
 if File.read("#{destination_root}/Gemfile") !~ /assets.+coffee-rails/m

--- a/templates/refinery/edge.rb
+++ b/templates/refinery/edge.rb
@@ -7,7 +7,9 @@ begin
     gsub_file 'Gemfile', "# gem 'therubyracer'", "gem 'therubyracer'"
   end
 rescue LoadError
-  abort "ExecJS is not installed. Please re-start the installer after running:\ngem install execjs"
+  abort <<-ERROR
+\033[31m[ABORTING]\033[0m ExecJS is not installed. Please re-start the installer after running:\ngem install execjs
+ERROR
 end
 
 if File.read("#{destination_root}/Gemfile") !~ /assets.+coffee-rails/m

--- a/templates/refinery/installer.rb
+++ b/templates/refinery/installer.rb
@@ -6,7 +6,9 @@ MINOR_VERSION_BAND = '3.0.0'
 begin
   require 'execjs'
 rescue LoadError
-  abort "ExecJS is not installed. Please re-start the installer after running:\ngem install execjs"
+  abort <<-ERROR
+\033[31m[ABORTING]\033[0m ExecJS is not installed. Please re-start the installer after running:\ngem install execjs
+ERROR
 end
 
 if File.read("#{destination_root}/Gemfile") !~ /assets.+coffee-rails/m


### PR DESCRIPTION
Beginners on Refinery CMS often forget to install `execjs`gem in order to properly create their application.

This PR improves the ERROR message and should reduce the number of questions on gitter and github.

![refinery-without-execjs_ _bricesanchez_macbook-pro-de-alexandra_ _zsh_ _158x26](https://cloud.githubusercontent.com/assets/1678530/16440183/68b42f56-3d8d-11e6-8384-4704c2e8ff3f.png)
