### PR TITLE
ExtensionHooks: more flexible & granular customization of refinery

### DIFF
--- a/core/app/assets/javascripts/glass/extension_assets.js.erb
+++ b/core/app/assets/javascripts/glass/extension_assets.js.erb
@@ -1,0 +1,5 @@
+<%
+  Refinery::ExtensionHooks.backend_js_files.each do |path|
+    require_asset(path)
+  end
+%>

--- a/core/app/assets/javascripts/refinery/refinery.js.erb
+++ b/core/app/assets/javascripts/refinery/refinery.js.erb
@@ -10,4 +10,5 @@
  *= require jquery/jquery.browser
  *= require admin
  *= require refinery/core
+ *= require glass/extension_assets
 */

--- a/core/app/assets/stylesheets/glass/extension_assets.scss.erb
+++ b/core/app/assets/stylesheets/glass/extension_assets.scss.erb
@@ -1,0 +1,3 @@
+<% Refinery::ExtensionHooks.backend_stylesheets.each do |path| %>
+@import "<%= path %>";
+<% end %>

--- a/core/app/assets/stylesheets/refinery/refinery.scss
+++ b/core/app/assets/stylesheets/refinery/refinery.scss
@@ -51,3 +51,5 @@
 @import "glass/layout/interface";
 @import "glass/layout/pages";
 @import "glass/components/icons";
+
+@import "glass/extension_assets"

--- a/core/app/views/layouts/refinery/admin.html.erb
+++ b/core/app/views/layouts/refinery/admin.html.erb
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <%= render '/refinery/html_tag' %>
+  <%= render partial: 'refinery/extension_hooks' %>
   <% content_for :meta, tag(:meta, name: 'refinerycms', content: Refinery.version) %>
   <%= render 'refinery/admin/head' %>
   <body class="<%= action_name %> <%= I18n.locale %> cms-interface">

--- a/core/app/views/refinery/_customize_layout.html.erb
+++ b/core/app/views/refinery/_customize_layout.html.erb
@@ -1,0 +1,3 @@
+<%# Intentionally blank.  Allow for sites to add custom content into the layout %>
+<%# you can use content_for :custom_sidebar_header_link %>
+<%# you can also use `if admin` or `if curent_refinery_user.present?` to cover different cases %>

--- a/core/app/views/refinery/_extension_hooks.html.erb
+++ b/core/app/views/refinery/_extension_hooks.html.erb
@@ -1,0 +1,5 @@
+<% scope = :layout unless defined?(scope) %>
+<% Refinery::ExtensionHooks.html_partials(scope).each do |path| %>
+  <%= render partial: "refinery/customize_#{scope}", locals: {admin: true}  %>
+  <%= render path, locals: {admin: true} %>
+<% end %>

--- a/core/lib/refinery.rb
+++ b/core/lib/refinery.rb
@@ -17,6 +17,7 @@ module Refinery
   autoload :Version, 'refinery/version'
   autoload :Crud, 'refinery/crud'
   autoload :BasePresenter, 'refinery/base_presenter'
+  autoload :ExtensionHooks, 'refinery/extension_hooks'
 
   module Admin
     autoload :BaseController, 'refinery/admin/base_controller'

--- a/core/lib/refinery/extension_hooks.rb
+++ b/core/lib/refinery/extension_hooks.rb
@@ -1,0 +1,32 @@
+module Refinery
+  class ExtensionHooks
+
+    class << self
+      @@paths = {html_partials: {}}
+
+      def register_stylesheets(paths)
+        (@@paths[:backend_stylesheets] ||= []).concat(paths)
+      end
+
+      def backend_stylesheets
+        @@paths[:backend_stylesheets] || []
+      end
+
+      def register_js_files(paths)
+        (@@paths[:backend_js_files] ||= []).concat(paths)
+      end
+
+      def backend_js_files
+        @@paths[:backend_js_files] || []
+      end
+
+      def register_html_partials(paths, scope = :layout)
+        (@@paths[:html_partials][scope] ||= []).concat(paths)
+      end
+
+      def html_partials(scope = :layout)
+        @@paths[:html_partials][scope] || []
+      end
+    end
+  end
+end


### PR DESCRIPTION
I've been using a version of this for 2 years, and it has worked well.  I just refactored and improved upon it today for this PR.  With something like this, I can see us shrinking refinerycms-core as it allows us to easily move things into different extensions (like refinerycms-search).
## Custom js & css

Extensions can register js & css to be compiled in with:

```
Refinery::ExtensionHooks.register_stylesheets(  ['abc/foo'])
Refinery::ExtensionHooks.register_js_files(     ['abc/bar'])
```
## Customize the html
- App can override a `_cusomize_*` partial (e.g. `refinery/_customize_layout.html.erb` )
- Extension can register a partial (e.g. `Refinery::ExtensionHooks.register_html_partials(['refinery/customize_layout_foo'])`
- content_for blocks go in these files: (e.g. `content_for :head do` )
- yield & content_for? allow for customization (e.g. `yield :head` )
- an extension can add a scope 
  (e.g. `<%= render partial: 'refinery/extension_hooks', locals: {scope: :baz} %>` )
- Then other extensions can customize within that scope: (e.g. `Refinery::ExtensionHooks.register_html_partials(['refinery/customize_layout_stuff'], :baz)` )
