### PR TITLE
Fixed sitemap generation for multiple frontend locales

### DIFF
--- a/core/app/views/refinery/sitemap/index.xml.builder
+++ b/core/app/views/refinery/sitemap/index.xml.builder
@@ -17,6 +17,8 @@ xml.urlset "xmlns" => "http://www.sitemaps.org/schemas/sitemap/0.9" do
          filter.around_generate({}) do
            raw_url
          end
+       else
+         raw_url
        end
      end
 

--- a/core/app/views/refinery/sitemap/index.xml.builder
+++ b/core/app/views/refinery/sitemap/index.xml.builder
@@ -8,10 +8,16 @@ xml.urlset "xmlns" => "http://www.sitemaps.org/schemas/sitemap/0.9" do
      # exclude sites that are external to our own domain.
      page_url = if page.url.is_a?(Hash)
        # This is how most pages work without being overriden by link_url
-       page.url.merge({:only_path => false})
+       page.url.merge({:only_path => false, locale: locale})
      elsif page.url.to_s !~ /^http/
        # handle relative link_url addresses.
-       [request.protocol, request.host_with_port, page.url].join
+       raw_url = [request.protocol, request.host_with_port, page.url].join
+       if (@locales.size > 1) && defined?(RoutingFilter::RefineryLocales)
+         filter = RoutingFilter::RefineryLocales.new
+         filter.around_generate({}) do
+           raw_url
+         end
+       end
      end
 
      # Add XML entry only if there is a valid page_url found above.


### PR DESCRIPTION
Fixes to sitemap/index.xml.builder for correct generation when multiple frontend locales are activated. 
More info in this https://github.com/refinery/refinerycms/issues/3215 issue.