### PR TITLE
Add "required" html attribute in add_whitelist_attributes config

### DIFF
--- a/pages/lib/refinery/pages/configuration.rb
+++ b/pages/lib/refinery/pages/configuration.rb
@@ -24,7 +24,7 @@ module Refinery
     self.layout_template_whitelist = ["application"]
     self.add_whitelist_elements = %w[ source track ]
     # Note: "data-" attributes are whitelisted by default. See https://github.com/refinery/refinerycms/pull/3187
-    self.add_whitelist_attributes = %w[ kind srclang placeholder controls ]
+    self.add_whitelist_attributes = %w[ kind srclang placeholder controls required ]
 
 
     class << self


### PR DESCRIPTION
It fixes #3226 

Before: 
![before-contact_-_company_name_et_pages_rb_ _refinerycms-inquiries](https://cloud.githubusercontent.com/assets/1678530/17236250/b5834dd6-5515-11e6-87f0-103cd029d2cf.jpg)

After:
![after-contact_-_company_name_et_pages_rb_ _refinerycms-inquiries](https://cloud.githubusercontent.com/assets/1678530/17236256/bbbf8dd6-5515-11e6-9523-acc22664ecb4.jpg)
