### PR TITLE
Added expended option to pages extension

### DIFF
--- a/pages/app/controllers/refinery/admin/pages_controller.rb
+++ b/pages/app/controllers/refinery/admin/pages_controller.rb
@@ -100,7 +100,8 @@ module Refinery
         [
           :browser_title, :draft, :link_url, :menu_title, :meta_description,
           :parent_id, :skip_to_first_child, :show_in_menu, :title, :view_template,
-          :layout_template, :custom_slug, parts_attributes: [:id, :title, :slug, :body, :position]
+          :layout_template, :custom_slug, :expand_in_admin_tree,
+           parts_attributes: [:id, :title, :slug, :body, :position]
         ]
       end
 

--- a/pages/app/controllers/refinery/pages/admin/preview_controller.rb
+++ b/pages/app/controllers/refinery/pages/admin/preview_controller.rb
@@ -41,7 +41,8 @@ module Refinery
           [
             :browser_title, :draft, :link_url, :menu_title, :meta_description,
             :parent_id, :skip_to_first_child, :show_in_menu, :title, :view_template,
-            :layout_template, :custom_slug, parts_attributes: [:id, :title, :slug, :body, :position]
+            :layout_template, :custom_slug, :expand_in_admin_tree,
+             parts_attributes: [:id, :title, :slug, :body, :position]
           ]
         end
       end

--- a/pages/app/views/refinery/admin/pages/_form_advanced_options.html.erb
+++ b/pages/app/views/refinery/admin/pages/_form_advanced_options.html.erb
@@ -79,6 +79,18 @@
                   :class => "stripped" %>
     </div>
 
+    <% if Refinery::Pages.auto_expand_admin_tree %>
+      <div class='field'>
+        <span class='label_with_help'>
+          <%= f.label :expand_in_admin_tree, t('.expand_in_admin_tree') %>
+          <%= refinery_help_tag t('.expand_in_admin_tree_help') %>
+        </span>
+        <%= f.check_box :expand_in_admin_tree %>
+        <%= f.label :expand_in_admin_tree, t('.expand_in_admin_tree_label'),
+                    :class => "stripped" %>
+      </div>
+    <% end %>
+
     <%= render 'form_extra_fields_for_more_options', :f => f %>
   </div>
 

--- a/pages/app/views/refinery/admin/pages/_page.html.erb
+++ b/pages/app/views/refinery/admin/pages/_page.html.erb
@@ -11,7 +11,7 @@
   <li class='clearfix record items' id="<%= dom_id(page) -%>">
   <div class='clearfix'>
     <% if page.children.present? %>
-      <span class="item icon toggle <%= 'expanded' if Refinery::Pages.auto_expand_admin_tree %>"
+      <span class="item icon toggle <%= 'expanded' if Refinery::Pages.auto_expand_admin_tree && page.expand_in_admin_tree %>"
         title="<%= t('expand_collapse', scope: 'refinery.admin.pages')%>">
       </span>
     <% else %>
@@ -47,6 +47,6 @@
     </span>
   </div>
   <ul class='nested' data-ajax-content="<%= refinery.admin_children_pages_path(page.nested_url) %>">
-    <%= render(partial: 'page', collection: page.children) if Refinery::Pages.auto_expand_admin_tree %>
+    <%= render(partial: 'page', collection: page.children) if Refinery::Pages.auto_expand_admin_tree && page.expand_in_admin_tree %>
   </ul>
 </li>

--- a/pages/config/locales/en.yml
+++ b/pages/config/locales/en.yml
@@ -73,6 +73,9 @@ en:
           layout_template_help: You can choose a different layout template for this page
           view_template: View template
           view_template_help: You can choose a different view template for this page
+          expand_in_admin_tree: Expand in admin tree
+          expand_in_admin_tree_label: Display this page expanded in admin pages tree
+          expand_in_admin_tree_help: Uncheck this box if you don't want to expand this page from your admin pages tree.
         actions:
           create_new_page: Add new page
           reorder_pages: Reorder pages

--- a/pages/db/migrate/20160817121737_add_expand_in_admin_tree_to_refinery_pages.rb
+++ b/pages/db/migrate/20160817121737_add_expand_in_admin_tree_to_refinery_pages.rb
@@ -1,0 +1,5 @@
+class AddExpandInAdminTreeToRefineryPages < ActiveRecord::Migration
+  def change
+    add_column :refinery_pages, :expand_in_admin_tree, :boolean, default: true
+  end
+end

--- a/pages/spec/features/refinery/admin/pages_spec.rb
+++ b/pages/spec/features/refinery/admin/pages_spec.rb
@@ -108,21 +108,11 @@ module Refinery
               expect(page).not_to have_content(locations.title)
             end
 
-            context "expands children" do
-              it "by clicking on the toggle button", js: true do
-                find("#page_#{company.id} .title.toggle").click
+            it "expands children", js: true do
+              find("#page_#{company.id} .title.toggle").click
 
-                expect(page).to have_content(team.title)
-                expect(page).to have_content(locations.title)
-              end
-
-              it "when expand_in_admin_tree is set true", js: true do
-                company.toggle!(:expand_in_admin_tree)
-                visit refinery.admin_pages_path
-
-                expect(page).to have_content(team.title)
-                expect(page).to have_content(locations.title)
-              end
+              expect(page).to have_content(team.title)
+              expect(page).to have_content(locations.title)
             end
 
             it "expands children when nested multiple levels deep", js: true do
@@ -140,9 +130,17 @@ module Refinery
               visit refinery.admin_pages_path
             end
 
-            it "shows children when expand_in_admin_tree is set false" do
+            it "shows children" do
               expect(page).to have_content(team.title)
               expect(page).to have_content(locations.title)
+            end
+
+            it "doesn't shows children when expand_in_admin_tree is false" do
+              company.toggle!(:expand_in_admin_tree)
+              visit refinery.admin_pages_path
+
+              expect(page).not_to have_content(team.title)
+              expect(page).not_to have_content(locations.title)
             end
           end
         end

--- a/pages/spec/features/refinery/admin/pages_spec.rb
+++ b/pages/spec/features/refinery/admin/pages_spec.rb
@@ -108,11 +108,21 @@ module Refinery
               expect(page).not_to have_content(locations.title)
             end
 
-            it "expands children", js: true do
-              find("#page_#{company.id} .title.toggle").click
+            context "expands children" do
+              it "by clicking on the toggle button", js: true do
+                find("#page_#{company.id} .title.toggle").click
 
-              expect(page).to have_content(team.title)
-              expect(page).to have_content(locations.title)
+                expect(page).to have_content(team.title)
+                expect(page).to have_content(locations.title)
+              end
+
+              it "when expand_in_admin_tree is set true", js: true do
+                company.toggle!(:expand_in_admin_tree)
+                visit refinery.admin_pages_path
+
+                expect(page).to have_content(team.title)
+                expect(page).to have_content(locations.title)
+              end
             end
 
             it "expands children when nested multiple levels deep", js: true do
@@ -130,7 +140,7 @@ module Refinery
               visit refinery.admin_pages_path
             end
 
-            it "shows children" do
+            it "shows children when expand_in_admin_tree is set false" do
               expect(page).to have_content(team.title)
               expect(page).to have_content(locations.title)
             end


### PR DESCRIPTION
Before this feature you could only enable expanding pages with children in the admin tree by setting the `config.auto_expand_admin_tree` to true. But you couldn't disable expanding for pages where expanding isn't necessary when `config.auto_expand_admin_tree` is set to true.

I added a boolean attribute `expand_in_admin_tree` (which default is true) to the pages entity so you can disable expanding for a page in the admin pages tree.
