### PR TITLE
Remove deprecated heroku gem

### DIFF
--- a/core/lib/generators/refinery/cms/cms_generator.rb
+++ b/core/lib/generators/refinery/cms/cms_generator.rb
@@ -283,7 +283,7 @@ end
       generator_args << '--quiet' if self.options[:quiet]
       generator_args << '--skip-migrations' if self.options[:skip_migrations]
       Refinery::CoreGenerator.start generator_args
-      Refinery::AuthenticationGenerator.start generator_args if defined?(Refinery::AuthenticationGenerator)
+      Refinery::Authentication::DeviseGenerator.start generator_args if defined?(Refinery::Authentication::DeviseGenerator)
       Refinery::ResourcesGenerator.start generator_args if defined?(Refinery::ResourcesGenerator)
       Refinery::PagesGenerator.start generator_args if defined?(Refinery::PagesGenerator)
       Refinery::ImagesGenerator.start generator_args if defined?(Refinery::ImagesGenerator)

--- a/core/lib/generators/refinery/cms/cms_generator.rb
+++ b/core/lib/generators/refinery/cms/cms_generator.rb
@@ -86,9 +86,6 @@ end}  end
 # The Ruby version is specified here so that Heroku uses the right version.
 ruby #{ENV['RUBY_VERSION'].inspect}
 
-# The Heroku gem allows you to interface with Heroku's API
-gem 'heroku'
-
 # Gems that have been added for Heroku support
 group :production do
   {{production_gems}}

--- a/core/lib/generators/refinery/cms/cms_generator.rb
+++ b/core/lib/generators/refinery/cms/cms_generator.rb
@@ -141,6 +141,12 @@ end
 
     def deploy_to_hosting?
       if heroku?
+        if heroku_toolbelt_missing?
+          fail <<-ERROR
+  \033[31m[ABORTING]\033[0m Heroku Toolbelt is not installed. Please re-start the installer after installing at:\nhttps://devcenter.heroku.com/articles/heroku-command-line
+  ERROR
+        end
+
         append_heroku_gems!
 
         # Sanity check the heroku application name and save whatever messages are produced.
@@ -225,6 +231,10 @@ end
 
     def heroku?
       options[:heroku].present?
+    end
+
+    def heroku_toolbelt_missing?
+      !!system("heroku --version")
     end
 
     def manage_roadblocks!

--- a/doc/guides/7 - Hosting and Deployment/1 - Heroku.textile
+++ b/doc/guides/7 - Hosting and Deployment/1 - Heroku.textile
@@ -75,9 +75,7 @@ WARNING. Using differing databases for development and production is not recomme
 h5. Others additions to append in the +Gemfile+
 
 <shell>
-ruby 2.3.0 # or the newest version of Ruby
-
-gem 'heroku'
+ruby 2.3.1 # or the newest version of Ruby
 
 group :production do
   gem 'dragonfly-s3_data_store'


### PR DESCRIPTION
```
Fetching: heroku-3.43.12.gem (100%)
 !    The `heroku` gem has been deprecated and replaced with the Heroku Toolbelt.
 !    Download and install from: https://toolbelt.heroku.com
 !    For API access, see: https://github.com/heroku/heroku.rb
```
