### PR TITLE
Bugfix/draft page view

### DIFF
--- a/pages/app/controllers/refinery/pages_controller.rb
+++ b/pages/app/controllers/refinery/pages_controller.rb
@@ -3,7 +3,7 @@ module Refinery
     include Pages::RenderOptions
 
     before_action :find_page, :set_canonical
-    before_action :error_404, :unless => :current_user_can_view_page?
+    before_action :error_404, unless: :current_user_can_view_page?
 
     # Save whole Page after delivery
     after_action :write_cache?
@@ -60,9 +60,13 @@ module Refinery
     end
 
     def current_user_can_view_page?
-      page.live? || authorisation_manager.allow?(:plugin, "refinery_pages")
+      page.live? || current_refinery_user_can_access?("refinery_pages")
     end
 
+    def current_refinery_user_can_access?(plugin)
+      admin? && authorisation_manager.allow?(:plugin, plugin)
+    end
+    
     def first_live_child
       page.children.order('lft ASC').live.first
     end

--- a/pages/spec/features/refinery/pages_spec.rb
+++ b/pages/spec/features/refinery/pages_spec.rb
@@ -336,6 +336,30 @@ module Refinery
         end
       end
     end
+
+    describe 'when draft is set to true' do
+      before { allow_any_instance_of(PagesController).to receive(:find_page).and_return(:draft_page) }
+
+      describe 'for vistor' do
+        it 'redirect to the 404 error page' do
+          allow_any_instance_of(PagesController).to receive(:current_refinery_user_can_access?).and_return(false)
+          
+          visit refinery.page_path(draft_page)
+
+          expect(page).to have_http_status(404)
+        end
+      end
+
+      describe 'for admin' do
+        it 'displays draft page message not live' do
+          allow_any_instance_of(PagesController).to receive(:current_refinery_user_can_access?).and_return(true)
+
+          visit refinery.page_path(draft_page)
+
+          expect(page).to have_content(::I18n.t('refinery.draft_page_message.not_live'))
+        end
+      end
+    end
   end
 
   context "with multiple locales" do


### PR DESCRIPTION
Since 3.0.0, draft pages are not hidden for visitors. This PR fix this bug.

It does not fixed the problem for extensions who use this code: 

```
        def find_page
          @page = Refinery::Page.find_by(:link_url => Refinery::Blog.page_url)
        end
```
https://github.com/refinery/refinerycms-blog/blob/master/app/controllers/refinery/blog/blog_controller.rb#L12-L14

If the blog page is set to draft, the page is still reachable by a visitor.