### PR TITLE
Fix #3218 regression on sitemap: don't duplicate locale in url

### DIFF
--- a/core/app/views/refinery/sitemap/index.xml.builder
+++ b/core/app/views/refinery/sitemap/index.xml.builder
@@ -1,33 +1,39 @@
 xml.instruct!
 
 xml.urlset "xmlns" => "http://www.sitemaps.org/schemas/sitemap/0.9" do
-
   @locales.each do |locale|
     ::I18n.locale = locale
-    ::Refinery::Page.live.in_menu.includes(:parts).each do |page|
-     # exclude sites that are external to our own domain.
-     page_url = if page.url.is_a?(Hash)
-       # This is how most pages work without being overriden by link_url
-       page.url.merge({:only_path => false, locale: locale})
-     elsif page.url.to_s !~ /^http/
-       # handle relative link_url addresses.
-       raw_url = [request.protocol, request.host_with_port, page.url].join
-       if (@locales.size > 1) && defined?(RoutingFilter::RefineryLocales)
-         filter = RoutingFilter::RefineryLocales.new
-         filter.around_generate({}) do
-           raw_url
-         end
-       else
-         raw_url
-       end
-     end
 
-     # Add XML entry only if there is a valid page_url found above.
-     xml.url do
-       xml.loc refinery.url_for(page_url)
-       xml.lastmod page.updated_at.to_date
-     end if page_url.present? and page.show_in_menu?
+    ::Refinery::Page.live.in_menu.each do |page|
+      
+      # exclude sites that are external to our own domain.
+      if page.url.is_a?(Hash)
+        
+        # This is how most pages work without being overriden by link_url
+        page_url = page.url.merge({:only_path => false, locale: locale})
+      
+      elsif page.url.to_s !~ /^http/
+        
+        # handle relative link_url addresses.
+        raw_url = [request.protocol, request.host_with_port, page.url].join
+        
+        if (@locales.size > 1) && !page.url.start_with?("/#{locale}/") && defined?(RoutingFilter::RefineryLocales)
+          filter = RoutingFilter::RefineryLocales.new
+          filter.around_generate({}) do
+            raw_url
+          end
+        else
+          raw_url
+        end
+
+        page_url = raw_url
+      end
+
+      # Add XML entry only if there is a valid page_url found above.
+      xml.url do
+        xml.loc refinery.url_for(page_url)
+        xml.lastmod page.updated_at.to_date
+      end if page_url.present?
     end
   end
-
 end


### PR DESCRIPTION
Fix #3218 regression: don't duplicate locale in url and refactor the builder to be more readable

Since this PR, i have problems on sitemap:
```xml
[...]
<url>
<loc>
http://localhost:3000/en/en/rate_requests/new
</loc>
<lastmod>2016-09-01</lastmod>
</url>
<url>
<loc>http://localhost:3000/en/forms</loc>
<lastmod>2016-09-01</lastmod>
</url>
<url>
<loc>http://localhost:3000/en/about-us</loc>
<lastmod>2016-09-01</lastmod>
</url>
<url>
<loc>http://localhost:3000/en/en/jobs</loc>
<lastmod>2016-09-01</lastmod>
</url>
<url>
<loc>http://localhost:3000/en/en</loc>
<lastmod>2016-07-20</lastmod>
</url>
[...]
```

After the fix: 

```xml
[...]
<url>
<loc>http://localhost:3000/en/rate_requests/new</loc>
<lastmod>2016-09-01</lastmod>
</url>
<url>
<loc>http://localhost:3000/en/forms</loc>
<lastmod>2016-09-01</lastmod>
</url>
<url>
<loc>http://localhost:3000/en/about-us</loc>
<lastmod>2016-09-01</lastmod>
</url>
<url>
<loc>http://localhost:3000/en/jobs</loc>
<lastmod>2016-09-01</lastmod>
</url>
<url>
<loc>http://localhost:3000/en</loc>
<lastmod>2016-07-20</lastmod>
</url>
[...]
```