### PR TITLE
change warn to use rails logger

### DIFF
--- a/pages/app/presenters/refinery/pages/section_presenter.rb
+++ b/pages/app/presenters/refinery/pages/section_presenter.rb
@@ -77,7 +77,7 @@ module Refinery
           warning << "Refinery::Pages::SectionPresenter#wrap_content_in_tag\n"
           warning << "HTML attributes and/or elements content has been sanitized\n"
           warning << "#{::Diffy::Diff.new(input, output).to_s(:color)}\n"
-          warn warning
+          Rails.logger.warn warning
         end
 
         return output

--- a/pages/spec/presenters/refinery/pages/section_presenter_spec.rb
+++ b/pages/spec/presenters/refinery/pages/section_presenter_spec.rb
@@ -114,13 +114,10 @@ module Refinery
 
         describe "#sanitize_content" do
           it "shows a sanitized content warning" do
+            expect(Rails.logger).to receive(:warn).with(%Q{\n-- SANITIZED CONTENT WARNING --\nRefinery::Pages::SectionPresenter#wrap_content_in_tag\nHTML attributes and/or elements content has been sanitized\n\e[31m-<dummy></dummy>\e[0m\n\\ No newline at end of file\n\n})
             section = SectionPresenter.new
             section.override_html = %Q{<dummy></dummy>}
             section.wrapped_html(true)
-            @errors.rewind
-            expect(@errors.read).to eq(
-              %Q{\n-- SANITIZED CONTENT WARNING --\nRefinery::Pages::SectionPresenter#wrap_content_in_tag\nHTML attributes and/or elements content has been sanitized\n\e[31m-<dummy></dummy>\e[0m\n\\ No newline at end of file\n\n}
-            )
           end
         end
 


### PR DESCRIPTION
This allows backtrace_silencers to be able to ignore this error. It also behaves nicely on what is set as log level in the environment file.

Prior to this, having `config.log_level = :fatal` will still output this warning as it uses the kernel warn rather than the rails logging facility.

Given that refinery is designed to run in rails, this will be the case in all cases.