### PR TITLE
Adding Multiple Images to your Model guide improvement

### DIFF
--- a/doc/guides/4 - Refinery Extensions/9 - Adding an image collection to an extension using PageImages.textile
+++ b/doc/guides/4 - Refinery Extensions/9 - Adding an image collection to an extension using PageImages.textile
@@ -43,7 +43,7 @@ Add +has_many_page_images+ line to the model in +vendor/extensions/shows/app/mod
 
 h3. Define Tabs
 
-Create the tabs file in +vendor/extensions/shows/lib/refinery/shows/tabs.rb+:
+Create the tab class in +vendor/extensions/shows/lib/refinery/shows/tabs.rb+:
 
 <ruby>
 module Refinery
@@ -109,7 +109,7 @@ h3. Modify the admin view
 
 TIP: You may add custom fields like +blurb+ and add the support inside the +form_part+ partial.
 
-Add a new field to the form +vendor/extensions/shows/app/views/refinery/admin/_form.html.erb+:
+Add a new field to the form in +vendor/extensions/shows/app/views/refinery/admin/_form.html.erb+:
 
 <erb>
 <div class='field'>
@@ -170,7 +170,7 @@ h4. Tell the Controller to Permit the new parameters it must handle
 
 TIP: It doesn't change the controller itself, but makes it easier to extend the initial list of permitted fields. Later versions of Refinery may generate this automatically.
 
-Edit the controller +vendor/extensions/shows/app/controllers/refinery/shows/admin/shows_controller.rb+:
+Edit the controller in +vendor/extensions/shows/app/controllers/refinery/shows/admin/shows_controller.rb+:
 
 <ruby>
 module Refinery
@@ -196,3 +196,28 @@ module Refinery
   end
 end
 </ruby>
+
+h3. Add captions
+
+Create the model decorator and define images collection with captions in +vendor/extensions/shows/app/decorators/models/refinery/show_decorator.rb+
+
+<ruby>
+require 'ostruct'
+
+Refinery::Shows::Show.class_eval do
+  attr_accessor :images_with_captions
+
+  def images_with_captions
+    @images_with_captions = image_pages.map do |ref|
+      OpenStruct.new(
+        {
+          image: Refinery::Image.find(ref.image_id),
+          caption: ref.caption || ''
+        }
+      )
+    end
+  end
+end
+</ruby>
+
+TIP: See further usage "here":https://github.com/refinery/refinerycms-page-images#usage.

--- a/doc/guides/4 - Refinery Extensions/9 - Adding an image collection to an extension using PageImages.textile
+++ b/doc/guides/4 - Refinery Extensions/9 - Adding an image collection to an extension using PageImages.textile
@@ -1,8 +1,8 @@
 h1. Adding Multiple Images to your Model
 
-Refinery offers a generator which allows an engine/model to have fields which are single images. It doesn't supply anything out-of-the-box to allow a model to have a collection of images. 
+Refinery offers a generator which allows an engine/model to have fields which are single images. It doesn't supply anything out-of-the-box to allow a model to have a collection of images.
 
-However Refinery has a plugin "Refinerycms-page-images" which implements an image collection for the Refinery::Page model.
+However Refinery has a plugin "Refinerycms-page-images" which implements an image collection for the +Refinery::Page+ model.
 
 It is relatively straight-forward to use this plugin to add an image collection to your model.
 
@@ -10,9 +10,9 @@ It is relatively straight-forward to use this plugin to add an image collection 
 
 h2. What you get
 
-When you have completed these steps your model/engine you will be able to add and remove images from an instance of your model using the same tabbed interface used by Refinery::Pages.
+When you have completed these steps your model/engine you will be able to add and remove images from an instance of your model using the same tabbed interface used by +Refinery::Pages+.
 
-In a view you will have access to a collection of images ("@model.images").
+In a view you will have access to a collection of images +@model.images+.
 
 h3. Pre-requisites
 
@@ -20,40 +20,33 @@ h3. Pre-requisites
 * Refinerycms-page-images
 * an engine or extension to work with (the examples will use Shows)
 
+h3. Configure Refinerycms-page-images
 
-h5. Configure Refinerycms-page-images
+Edit the config file +app/config/initializers/refinery/page_images.rb+:
 
-bc..
-# app/config/initializers/refinery/page_images.rb
+<ruby>
 Refinery::PageImages.configure do |config|
   config.captions = true
+
   config.enable_for = [
     {model: "Refinery::Page", tab: "Refinery::Pages::Tab"},
     {model: "Refinery::Show", tab: "Refinery::Shows::Tab"}
   ]
+
   config.wysiwyg = true
 end
+</ruby>
 
-h5.  Add page-images to your model
+h3. Add page-images to your model
 
-bc..
-#vendor/extensions/shows/app/models/refinery/shows/show.rb
+Add +has_many_page_images+ line to the model in +vendor/extensions/shows/app/models/refinery/shows/show.rb+.
+
+h3. Define Tabs
+
+Create the tabs file in +vendor/extensions/shows/lib/refinery/shows/tabs.rb+:
+
+<ruby>
 module Refinery
-  module Shows
-    class Show < Refinery::Core::BaseModel
-
-      self.table_name = 'refinery_shows'
-      validates :title, :presence => true, :uniqueness => true
-      has_many_page_images
-    end
-  end
-end
-
-h5. Define Tabs
-
-bc..
-# in vendor/extensions/shows/lib/refinery/shows/tabs.rb
- module Refinery
   module Shows
     class Tab
       attr_accessor :name, :partial
@@ -74,13 +67,16 @@ bc..
         end
     end
   end
- end
+end
+</ruby>
 
-h5. Load and Initialize Tabs
-# vendor/extensions/shows/lib/refinery/shows.rb
+h3. Load and Initialize Tabs
+
+Edit the file +vendor/extensions/shows/lib/refinery/shows.rb+:
+
+<ruby>
 require 'refinerycms-core'
 
-bc..
 module Refinery
   autoload :ShowsGenerator, 'generators/refinery/shows_generator'
 
@@ -107,76 +103,76 @@ module Refinery
     end
   end
 end
+</ruby>
 
+h3. Modify the admin view
 
-h5. Modify the admin view
+TIP: You may add custom fields like +blurb+ and add the support inside the +form_part+ partial.
 
-bc..
-#vendor/extensions/shows/app/views/refinery/admin/_form.html.erb
-<%= form_for [refinery, :shows_admin, @show] do |f| -%>
-  <%= render '/refinery/admin/error_messages',
-              :object => @show,
-              :include_object_name => true %>
+Add a new field to the form +vendor/extensions/shows/app/views/refinery/admin/_form.html.erb+:
 
-  <div class='field'>
-    <%= f.label :title -%>
-    <%= f.text_field :title, :class => 'larger widest' -%>
-  </div>
+<erb>
+<div class='field'>
+  <div id='page-tabs' class='clearfix ui-tabs ui-widget ui-widget-content ui-corner-all'>
+    <ul id='page_parts'>
+      <li class='ui-state-default ui-state-active'>
+        <%= link_to t('blurb', :scope => 'activerecord.attributes.refinery/shows/show'), "#page_part_blurb" %>
+      </li>
 
-  <div class='field'>
-    <div id='page-tabs' class='clearfix ui-tabs ui-widget ui-widget-content ui-corner-all'>
-      <ul id='page_parts'>
-        <li class='ui-state-default ui-state-active'>
-          <%= link_to 'Blurb', "#page_part_blurb" %>
+      <% Refinery::Shows.tabs.each_with_index do |tab, tab_index| %>
+        <li class='ui-state-default' id="custom_<%= tab.name %>_tab">
+          <%= link_to tab.name.titleize, "#custom_tab_#{tab_index}" %>
         </li>
-        <% Refinery::Shows.tabs.each_with_index do |tab, tab_index| %>
-          <li class='ui-state-default' id="custom_<%= tab.name %>_tab">
-            <%= link_to tab.name.titleize, "#custom_tab_#{tab_index}" %>
-          </li>
-        <% end %>
-      </ul>
+      <% end %>
+    </ul>
 
-      <div id='page_part_editors'>
-        <% part_index = -1 %>
-          <%= render 'form_part', :f => f, :part_index => (part_index += 1) -%>
-        <% Refinery::Shows.tabs.each_with_index do |tab, tab_index| %>
-          <div class='page_part' id='<%= "custom_tab_#{tab_index}" %>'>
-            <%= render tab.partial, :f => f %>
-          </div>
-        <% end %>
-      </div>
+    <div id='page_part_editors'>
+      <% part_index = -1 %>
+      <%= render 'form_part', :f => f, :part_index => (part_index += 1) -%>
+
+      <% Refinery::Shows.tabs.each_with_index do |tab, tab_index| %>
+        <div class='page_part' id='<%= "custom_tab_#{tab_index}" %>'>
+          <%= render tab.partial, :f => f %>
+        </div>
+      <% end %>
     </div>
   </div>
+</div>
+</erb>
 
-  <%= render '/refinery/admin/form_actions', :f => f,
-             :continue_editing => false,
-             :delete_title => t('delete', :scope => 'refinery.shows.admin.shows.show'),
-             :delete_confirmation => t('message', :scope => 'refinery.admin.delete', :title => @show.title) -%>
-<% end -%>
+Create the +form_part+ partial in +vendor/extensions/shows/app/views/refinery/admin/_form_part.html.erb+:
 
-##### Add strong parameters for the new fields
+<erb>
+<div class='page_part' id='page_part_blurb'>
+  <%= f.text_area :blurb, :rows => 20, :class => 'visual_editor widest' -%>
+</div>
+</erb>
 
-Part 1. Write a decorator.
+h3. Add strong parameters for the new fields
 
-bc..
-#vendor/extensions/shows/app/decorators/controllers/refinery/admin/shows_controller_decorator.rb
+h4. Write a decorator
+
+Create the decorator in +vendor/extensions/shows/app/decorators/controllers/refinery/admin/shows_controller_decorator.rb+:
+
+<ruby>
 module RefineryPageImagesShowsControllerDecorator
-    def permitted_show_params
-      # Hand the case where all images have been deleted
-      params[:show][:images_attributes]={} if params[:show][:images_attributes].nil?
-      super <<  [images_attributes: [:id, :caption, :image_page_id]]
-    end
+  def permitted_show_params
+    # handle the case where all images have been deleted
+    params[:show][:images_attributes]={} if params[:show][:images_attributes].nil?
+    super <<  [images_attributes: [:id, :caption, :image_page_id]]
   end
+end
 
 Refinery::Shows::Admin::ShowsController.send :prepend, RefineryPageImagesShowsControllerDecorator
+</ruby>
 
+h4. Tell the Controller to Permit the new parameters it must handle
 
-Part 2. Tell the Controller to Permit the new parameters it must handle
+TIP: It doesn't change the controller itself, but makes it easier to extend the initial list of permitted fields. Later versions of Refinery may generate this automatically.
 
-Some ModelsControllers will require this update. It doesn't change the controller itself, but makes it easier to extend the initial list of permitted fields. Later versions of Refinery may generate this automatically.
+Edit the controller +vendor/extensions/shows/app/controllers/refinery/shows/admin/shows_controller.rb+:
 
-bc..
-#vendor/extensions/shows/app/controllers/refinery/shows/admin/shows_controller.rb
+<ruby>
 module Refinery
   module Shows
     module Admin
@@ -184,11 +180,11 @@ module Refinery
 
         crudify :'refinery/shows/show'
 
+        private
+
         def show_params
           params.require(:show).permit(permitted_show_params)
         end
-
-       # private
 
         # Only allow a trusted parameter "white list" through.
         def permitted_show_params
@@ -199,5 +195,4 @@ module Refinery
     end
   end
 end
-
-
+</ruby>


### PR DESCRIPTION
Pasted additional info and added formatting to [this guide](http://www.refinerycms.com/guides/adding-an-image-collection-to-an-extension-using-pageimages). This issue is related: refinery/refinerycms-page-images#111. Couldn't preview the formatting but I guess it should look fine on [refinerycms.com](http://www.refinerycms.com/) according to other guides.