### PR TITLE
Update the updated_at field of the page itself when a page_part got updated

### DIFF
--- a/pages/app/models/refinery/page_part.rb
+++ b/pages/app/models/refinery/page_part.rb
@@ -1,7 +1,7 @@
 module Refinery
   class PagePart < Refinery::Core::BaseModel
 
-    belongs_to :page, :foreign_key => :refinery_page_id
+    belongs_to :page, :foreign_key => :refinery_page_id, :touch => true
 
     before_validation :set_default_slug
 

--- a/pages/spec/models/refinery/page_part_spec.rb
+++ b/pages/spec/models/refinery/page_part_spec.rb
@@ -31,6 +31,16 @@ module Refinery
       expect(part_two.errors[:slug]).to be_empty
     end
 
+    it 'updates the page updated_at field when changed' do
+      page.save
+      original_updated_at = page.updated_at
+
+      page.parts.first.content = 'Modified'
+      page.parts.first.save
+
+      expect(original_updated_at).to be < page.updated_at
+    end
+
     context 'when using content_for?' do
 
       it 'return true when page part has content' do


### PR DESCRIPTION
This fixes an issue with the sitemap: `updated_at` field does not get updated when the page (content) is updated.