### PR TITLE
Fixed variable name for custom editor options

### DIFF
--- a/core/app/assets/javascripts/admin.js
+++ b/core/app/assets/javascripts/admin.js
@@ -2,6 +2,6 @@
 // Just mirror the options specified in your visual editor's config with the new
 // options here.  This will completely override anything specified in your visual
 // editor's boot process for that key, e.g. skin: 'something_else'
-if (typeof(custom_visual_editor_options) == "undefined") {
-  custom_visual_editor_options = {};
+if (typeof(custom_visual_editor_boot_options) == "undefined") {
+  var custom_visual_editor_boot_options = {};
 }


### PR DESCRIPTION
The variable must be custom_visual_editor_boot_options.
See:
https://github.com/parndt/refinerycms-wymeditor/blob/master/app/assets/javascripts/refinery/boot_wym.js.erb#L5

And the documentation:
https://github.com/parndt/refinerycms-wymeditor#user-content-custom-selectable-styles-in-wymeditor