### PR TITLE
jQuery .load() deprecated

### DIFF
--- a/core/app/assets/javascripts/refinery/interface.js.coffee.erb
+++ b/core/app/assets/javascripts/refinery/interface.js.coffee.erb
@@ -16,7 +16,7 @@
     $("html,body").animate scrollTop: $("#other_locales").parent().offset().top, 250
     e.preventDefault()
 
-  $("#existing_image img").load ->
+  $("#existing_image img").on 'load', ->
     margin_top = ($("#existing_image").height() - $("form.edit_image").height() + 8)
     $("form.edit_image .form-actions").css "margin-top": margin_top if margin_top > 0
 


### PR DESCRIPTION
> **Removed deprecated event aliases**
> .load, .unload, and .error, deprecated since jQuery 1.8, are no more. Use .on() to register listeners.
https://blog.jquery.com/2015/07/13/jquery-3-0-and-jquery-compat-3-0-alpha-versions-released/