### PR TITLE
Updating the SEO in the Pages Engine

### DIFF
--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -10,6 +10,8 @@ module Refinery
 
     translates :title, :menu_title, :custom_slug, :slug, :include => :seo_meta
 
+    after_save { translations.collect(&:save) }
+
     class Translation
       is_seo_meta
 

--- a/pages/spec/models/refinery/page_meta_data_spec.rb
+++ b/pages/spec/models/refinery/page_meta_data_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 module Refinery
   describe Page do
     let(:page_title) { 'RSpec is great for testing too' }
-    let(:page) { subject.class.new(:title => page_title, :deletable => true)}
+    let(:page) { subject.class.create(title: page_title, deletable: true)}
 
     context 'responds to' do
       it 'meta_description' do


### PR DESCRIPTION
Hello all,

I've been experiencing an issue with updating the `browser_title` and the `meta_description` of the `Refinery::Page` model in the `master` branch and in the #3122 PR (feature/rails-5). It's not possible to update only the `browser_title` or the `meta_description` after creating a new page. I think that this is caused by Globalize, but I cannot confirm this yet. 

It is possible to update the `browser_title` or the `meta_description` when there's one (or more) of the [other translated attributes](https://github.com/refinery/refinerycms/blob/master/pages/app/models/refinery/page.rb#L11) of the `Refinery::Page` model also edited.

I've changed the page meta data spec to confirm this issue, because we tried to [create a page at line 34](https://github.com/refinery/refinerycms/blob/master/pages/spec/models/refinery/page_meta_data_spec.rb#L34) and not update it.

Can anyone else also confirm this issue? And does someone have any thoughts why this could happen?