### PR TITLE
Add Rails version to generated migration

### DIFF
--- a/core/lib/generators/refinery/engine/templates/db/migrate/1_create_namespace_plural_name.rb.erb
+++ b/core/lib/generators/refinery/engine/templates/db/migrate/1_create_namespace_plural_name.rb.erb
@@ -1,4 +1,4 @@
-class Create<%= namespacing %><%= class_name.pluralize %> < ActiveRecord::Migration
+class Create<%= namespacing %><%= class_name.pluralize %> < ActiveRecord::Migration[4.2]
 
   def up
     create_table :refinery_<%= "#{namespacing.underscore}_" if table_name != namespacing.underscore.pluralize -%><%= table_name %> do |t|


### PR DESCRIPTION
Rails no longer allows migrations without a Rails version specified. I chose 4.2 as that's the minimum rails version Refinery supports.

Fixes #3312