### PR TITLE
Update 3.0.6 release date in changelog.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,11 +2,6 @@
 
 * Remove deprecated methods for versions < 4.0.0. [124e560](https://github.com/refinery/refinerycms/commit/124e560086eb9b10bb5665aff7923f6881374398). [Brice Sanchez](https://github.com/bricesanchez)
 * Now supporting Rails 5.1. [#3122](https://github.com/refinery/refinerycms/pull/3122). [Brice Sanchez](https://github.com/bricesanchez) & [Philip Arndt](https://github.com/parndt) & [Remco Meinen](https://github.com/sjoulbak) & [Don Pinkster](https://github.com/donpinkster) & [Johan Bruning](https://github.com/johanb) & [Michael de Silva](https://github.com/bsodmike) & [Kiril Mitov](https://github.com/thebravoman) and everyone else who helped out!
-
-* [See full list](https://github.com/refinery/refinerycms/compare/3-0-stable...4.0.0)
-
-## 3.0.6 [unreleased]
-
 * Fix search placeholder. [#3291](https://github.com/refinery/refinerycms/pull/3291). [Roman Krylov](https://github.com/xtsidx)
 * Upgrade dragonfly to version 1.1. [#3303](https://github.com/refinery/refinerycms/pull/3303). [Anita Graham](https://github.com/anitagraham)
 * Bugfix: canonical url now use current_frontend_locale instead of default_frontend_locale. [#3299](https://github.com/refinery/refinerycms/pull/3299). [Brice Sanchez](https://github.com/bricesanchez)
@@ -20,7 +15,7 @@
 * Fix #3218 regression: don't duplicate locale in url. [#3271](https://github.com/refinery/refinerycms/pull/3271). [Brice Sanchez](https://github.com/bricesanchez)
 * Change data attribute to match Turbolinks 5 syntax. [#3269](https://github.com/refinery/refinerycms/pull/3269). [Maarten Bezemer](https://github.com/veger)
 
-* [See full list](https://github.com/refinery/refinerycms/compare/3.0.5...3.0.6)
+* [See full list](https://github.com/refinery/refinerycms/compare/3.0.5...4.0.0)
 
 
 ## 3.0.5 [23 November 2016]

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 * Remove deprecated methods for versions < 4.0.0. [124e560](https://github.com/refinery/refinerycms/commit/124e560086eb9b10bb5665aff7923f6881374398). [Brice Sanchez](https://github.com/bricesanchez)
 * Now supporting Rails 5.1. [#3122](https://github.com/refinery/refinerycms/pull/3122). [Brice Sanchez](https://github.com/bricesanchez) & [Philip Arndt](https://github.com/parndt) & [Remco Meinen](https://github.com/sjoulbak) & [Don Pinkster](https://github.com/donpinkster) & [Johan Bruning](https://github.com/johanb) & [Michael de Silva](https://github.com/bsodmike) & [Kiril Mitov](https://github.com/thebravoman) and everyone else who helped out!
+
+* [See full list](https://github.com/refinery/refinerycms/compare/3-0-stable...4.0.0)
+
+## 3.0.6 [2 October 2017]
+
 * Fix search placeholder. [#3291](https://github.com/refinery/refinerycms/pull/3291). [Roman Krylov](https://github.com/xtsidx)
 * Upgrade dragonfly to version 1.1. [#3303](https://github.com/refinery/refinerycms/pull/3303). [Anita Graham](https://github.com/anitagraham)
 * Bugfix: canonical url now use current_frontend_locale instead of default_frontend_locale. [#3299](https://github.com/refinery/refinerycms/pull/3299). [Brice Sanchez](https://github.com/bricesanchez)
@@ -15,7 +20,7 @@
 * Fix #3218 regression: don't duplicate locale in url. [#3271](https://github.com/refinery/refinerycms/pull/3271). [Brice Sanchez](https://github.com/bricesanchez)
 * Change data attribute to match Turbolinks 5 syntax. [#3269](https://github.com/refinery/refinerycms/pull/3269). [Maarten Bezemer](https://github.com/veger)
 
-* [See full list](https://github.com/refinery/refinerycms/compare/3.0.5...4.0.0)
+* [See full list](https://github.com/refinery/refinerycms/compare/3.0.5...3.0.6)
 
 
 ## 3.0.5 [23 November 2016]


### PR DESCRIPTION
Alternative approach can be releasing of 3.0.6 without latest 4.0 changes.