### PR TITLE
BUGFIX #3315: Now require globalize on top of the engine

### DIFF
--- a/pages/lib/refinery/pages.rb
+++ b/pages/lib/refinery/pages.rb
@@ -1,4 +1,5 @@
 require 'refinerycms-core'
+require 'globalize'
 
 module Refinery
   autoload :PagesGenerator, 'generators/refinery/pages/pages_generator'
@@ -46,7 +47,6 @@ end
 
 ActiveSupport.on_load(:active_record) do
   require 'awesome_nested_set'
-  require 'globalize'
 end
 require 'friendly_id'
 require 'seo_meta'


### PR DESCRIPTION
This fixes page create seeds on refinerycms installation