### PR TITLE
require refinery core nil_user class (needed for prod env)

### DIFF
--- a/core/lib/refinery/core/authorisation_adapter.rb
+++ b/core/lib/refinery/core/authorisation_adapter.rb
@@ -1,3 +1,5 @@
+require 'refinery/core/nil_user'
+
 module Refinery
   module Core
     class AuthorisationAdapter < Zilch::Authorisation::Adapters::Default


### PR DESCRIPTION
I was trying to fix https://github.com/parndt/refinerycms-wymeditor/issues/47 

And in order to be able to start the dummy app on `RAILS_ENV=production`. i had to require refinery core nil_user class in the `authorisation_adapter`

Could you check this PR fix the problem?