### PR TITLE
Fix 'Pages' list on admin

### DIFF
--- a/pages/app/views/refinery/admin/pages/_page.html.erb
+++ b/pages/app/views/refinery/admin/pages/_page.html.erb
@@ -25,7 +25,7 @@
 
     <% if Refinery::I18n.frontend_locales.many? %>
       <span class='locales'>
-        <% page.translations.sort_by{ |t| Refinery::I18n.frontend_locales.index(t.locale)}.each do |translation| %>
+        <% page.translations.sort_by{ |t| Refinery::I18n.frontend_locales.index(t.locale).to_i }.each do |translation| %>
           <% if translation.title.present? %>
             <%= link_to refinery.admin_edit_page_path(page.nested_url, switch_locale: translation.locale),
                         class: 'locale', title: translation.locale.upcase do %>


### PR DESCRIPTION
Issue:
'Pages' list doesn't work in the admin area.

Error description:
ActionView::Template::Error (comparison of Fixnum with nil failed):
25:
26: <% if Refinery::I18n.frontend_locales.many? %>
27:   <span class='locales'>
28:     <% page.translations.sort_by{ |t| Refinery::I18n.frontend_locales.index(t.locale)}.each do |translation| %>
29:       <% if translation.title.present? %>
30:         <%= link_to refinery.admin_edit_page_path(page.nested_url, switch_locale: translation.locale),
31:                     class: 'locale', title: translation.locale.upcase do %>
app/views/refinery/admin/pages/_page.html.erb:28

How to reproduce:
1. Add 'a' and 'b' locales to frontend_locales.
config.frontend_locales = [:a, :b]
2. Create 'b' translation for a page.
3. Remove 'b' locale from frontend_locales.
config.frontend_locales = [:a]
4. Load 'Pages' listing page in admin.

Cause:
Refinery tries to sort page translations based on their locale's position in frontend_locales array.
Once locale is removed, sort tries to compare nil as position index with a Fixnum.