### PR TITLE
Fix CI error due to pg 1.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ end
 if !ENV['TRAVIS'] || ENV['DB'] == 'postgresql'
   group :postgres, :postgresql do
     gem 'activerecord-jdbcpostgresql-adapter', '>= 1.3.0.rc1', platform: :jruby
-    gem 'pg', platform: :ruby
+    gem 'pg', '~> 0.21', platform: :ruby
   end
 end
 


### PR DESCRIPTION
pg 1.0.0 causes activerecord to error as it explicitly depends on ~>
0.18
https://github.com/rails/rails/blob/f30f20ccec9edbffc2b80b2d7e839a4fa9ac
1eac/activerecord/lib/active_record/connection_adapters/postgresql_adapt
er.rb#L4