### PR TITLE
Bugfix factory page_with_page_part since Rails 5.1

### DIFF
--- a/pages/spec/factories/pages.rb
+++ b/pages/spec/factories/pages.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
 
     factory :page_with_page_part do
       after(:create) do |page|
-        page.parts << FactoryBot.create(:page_part)
+        page.parts << FactoryBot.build(:page_part)
       end
     end
   end


### PR DESCRIPTION
Now use build instead of create because `belongs_to` association is now required by default since Rails 5.1.