### PR TITLE
no need call valid?

### DIFF
--- a/core/lib/refinery/crud.rb
+++ b/core/lib/refinery/crud.rb
@@ -67,7 +67,8 @@ module Refinery
           end
 
           def create
-            if (@#{singular_name} = #{class_name}.create(#{singular_name}_params)).valid?
+            @#{singular_name} = #{class_name}.new(#{singular_name}_params)
+            if @#{singular_name}.save
               flash.notice = t(
                 'refinery.crudify.created',
                 :what => "'\#{@#{singular_name}.#{options[:title_attribute]}}'"


### PR DESCRIPTION
When we use `refinerycms-pages`, `friendly_id`, `globalize`, if we add validation which make it invalid to page, the `valid?` method will trigger `set_slug` of `friendly_id` one more time, and the `set_slug` method will use `globalize`.

This will be something like this:
```
globalize (5.1.0.beta2) lib/globalize/active_record/class_methods.rb:96:in `block in define_translated_attr_writer'
globalize (5.1.0.beta2) lib/globalize/active_record/adapter_dirty.rb:44:in `_reset_attribute'
globalize (5.1.0.beta2) lib/globalize/active_record/adapter_dirty.rb:16:in `write'
globalize (5.1.0.beta2) lib/globalize/active_record/instance_methods.rb:31:in `write_attribute'
globalize (5.1.0.beta2) lib/globalize/active_record/class_methods.rb:96:in `block in define_translated_attr_writer'
globalize (5.1.0.beta2) lib/globalize/active_record/adapter_dirty.rb:44:in `_reset_attribute'
globalize (5.1.0.beta2) lib/globalize/active_record/adapter_dirty.rb:16:in `write'
globalize (5.1.0.beta2) lib/globalize/active_record/instance_methods.rb:31:in `write_attribute'
globalize (5.1.0.beta2) lib/globalize/active_record/class_methods.rb:96:in `block in define_translated_attr_writer'
friendly_id (5.2.3) lib/friendly_id/slugged.rb:359:in `set_slug'
```
Finally, it will be `SystemStackError (stack level too deep):`