### PR TITLE
Only add puma when it's missing

### DIFF
--- a/core/lib/generators/refinery/cms/cms_generator.rb
+++ b/core/lib/generators/refinery/cms/cms_generator.rb
@@ -77,9 +77,9 @@ end}  end
     def append_heroku_gems!
       production_gems = [
         "gem 'dragonfly-s3_data_store'",
-        "gem 'rails_12factor'",
-        "gem 'puma'"
+        "gem 'rails_12factor'"
       ]
+      production_gems << "gem 'puma'" unless destination_gemfile_has_puma?
       production_gems << "gem 'pg'" unless destination_gemfile_has_postgres?
 
       append_file "Gemfile", %Q{
@@ -227,6 +227,11 @@ end
     def destination_gemfile_has_postgres?
       destination_path.join('Gemfile').file? &&
         destination_path.join('Gemfile').read =~ %r{gem ['"]pg['"]}
+    end
+
+    def destination_gemfile_has_puma?
+      destination_path.join('Gemfile').file? &&
+        destination_path.join('Gemfile').read =~ %r{gem ['"]puma['"]}
     end
 
     def heroku?

--- a/core/lib/generators/refinery/cms/cms_generator.rb
+++ b/core/lib/generators/refinery/cms/cms_generator.rb
@@ -225,13 +225,16 @@ end
     end
 
     def destination_gemfile_has_postgres?
-      destination_path.join('Gemfile').file? &&
-        destination_path.join('Gemfile').read =~ %r{gem ['"]pg['"]}
+      destination_gemfile_has_gem?('pg')
     end
 
     def destination_gemfile_has_puma?
+      destination_gemfile_has_gem?('puma')
+    end
+
+    def destination_gemfile_has_gem?(gem_name)
       destination_path.join('Gemfile').file? &&
-        destination_path.join('Gemfile').read =~ %r{gem ['"]puma['"]}
+        destination_path.join('Gemfile').read =~ %r{gem ['"]#{gem_name}['"]}
     end
 
     def heroku?


### PR DESCRIPTION
While looking at #3340 I got the following errors:

```
[!] There was an error parsing `Gemfile`: You cannot specify the same gem twice with different version requirements.
You specified: puma (~> 3.7) and puma (>= 0). Bundler cannot continue.

 #  from myapp/Gemfile:77
 #  -------------------------------------------
 #    gem 'rails_12factor'
 >    gem 'puma'
 #    gem 'pg'
 #  -------------------------------------------
```

Rails now uses puma by default. This should fix the error.