### PR TITLE
Remove rails_12factor from Heroku gems

### DIFF
--- a/core/lib/generators/refinery/cms/cms_generator.rb
+++ b/core/lib/generators/refinery/cms/cms_generator.rb
@@ -77,8 +77,7 @@ end}  end
 
     def append_heroku_gems!
       production_gems = [
-        "gem 'dragonfly-s3_data_store'",
-        "gem 'rails_12factor'"
+        "gem 'dragonfly-s3_data_store'"
       ]
       production_gems << "gem 'puma'" unless destination_gemfile_has_puma?
       production_gems << "gem 'pg'" unless destination_gemfile_has_postgres?


### PR DESCRIPTION
See: https://github.com/heroku/rails_12factor#rails-5

> If you are starting a new application with Rails 5, you do not need this gem.