### PR TITLE
Update `Refinery::Pages::Type.parts` to match the format introduced in 3535b906fa

### DIFF
--- a/doc/guides/2 - Refinery Basics/1 - Changing Page Parts.md
+++ b/doc/guides/2 - Refinery Basics/1 - Changing Page Parts.md
@@ -15,7 +15,7 @@ Within `config/initializers/refinery/pages.rb` you will see various default sett
 
 ```ruby
 # Configure global page default parts
-# config.default_parts = ["Body", "Side Body"]
+# config.default_parts = [{ title: "Body", slug: "body" }, { title: "Side Body", slug: "side_body" }]
 ```
 
 Edit this code to have the names of the default page parts you want, click *Save* and you're done. You'll need to add a new page to see the page part. Existing pages have the default_parts they were created with.
@@ -24,7 +24,7 @@ Here's a sample of a site that would have three content areas on most of its pag
 
 ```ruby
 # Configure global page default parts
-config.default_parts = ["Left Body", "Middle Body", "Right Body"]
+config.default_parts = [{ title: "Left Body", slug: "left" }, { title: "Middle Body", slug: "middle" }, { title: "Right Body", slug: "right" }]
 ```
 
 ## Changing Page Parts for a single page

--- a/pages/lib/generators/refinery/pages/templates/config/initializers/refinery/pages.rb.erb
+++ b/pages/lib/generators/refinery/pages/templates/config/initializers/refinery/pages.rb.erb
@@ -2,7 +2,7 @@
 Refinery::Pages.configure do |config|
   # Configure specific page templates
   # config.types.register :home do |home|
-  #   home.parts = %w[intro body]
+  #   home.parts = [{slug: "intro", title: "Intro"}, {slug: "body", title: "Body}]
   # end
 
   # Configure global page default parts

--- a/pages/lib/refinery/pages.rb
+++ b/pages/lib/refinery/pages.rb
@@ -35,7 +35,7 @@ module Refinery
       def default_parts_for(page)
         return default_parts unless page.view_template.present?
 
-        types.find_by_name(page.view_template).parts.map(&:titleize)
+        types.find_by_name(page.view_template).parts
       end
     end
 

--- a/pages/lib/refinery/pages/type.rb
+++ b/pages/lib/refinery/pages/type.rb
@@ -4,6 +4,21 @@ module Refinery
 
       attr_accessor :name, :parts, :template
 
+      def parts=(new_parts)
+        @parts = if new_parts.all? { |v| v.is_a?(String) }
+          new_syntax = new_parts.map do |part|
+            { title: part, slug: part.downcase.gsub(" ", "_") }
+          end
+          Refinery.deprecate(
+            "Change Refinery::Pages.default_parts= from #{@parts} to #{new_syntax}",
+            when: "4.1.0"
+          )
+          new_syntax
+        else
+          new_parts
+        end
+      end
+
       def parts
         @parts ||= []
       end

--- a/pages/lib/refinery/pages/type.rb
+++ b/pages/lib/refinery/pages/type.rb
@@ -10,7 +10,7 @@ module Refinery
             { title: part, slug: part.downcase.gsub(" ", "_") }
           end
           Refinery.deprecate(
-            "Change Refinery::Pages.default_parts= from #{@parts} to #{new_syntax}",
+            "Change specific page template page parts from #{new_parts} to #{new_syntax}",
             when: "4.1.0"
           )
           new_syntax

--- a/pages/spec/controllers/refinery/admin/pages_controller_spec.rb
+++ b/pages/spec/controllers/refinery/admin/pages_controller_spec.rb
@@ -4,6 +4,12 @@ module Refinery
   module Admin
     describe PagesController, type: :controller do
 
+      describe "with view template" do 
+        before { Refinery::Pages::Types.register("show") { |type| type.parts = ["Body"] } }
+        after { Refinery::Pages::Types.registered.delete(Refinery::Pages::Types.registered.find_by_name("show")) }
+        it { expect(get(:new, params: { view_template: "show" })).to be_ok }
+      end
+
       describe "valid templates" do
         before do
           File.write(Rails.root.join('tmp', 'abc.html.erb'), '')

--- a/pages/spec/controllers/refinery/admin/pages_controller_spec.rb
+++ b/pages/spec/controllers/refinery/admin/pages_controller_spec.rb
@@ -5,7 +5,7 @@ module Refinery
     describe PagesController, type: :controller do
 
       describe "with view template" do 
-        before { Refinery::Pages::Types.register("show") { |type| type.parts = ["Body"] } }
+        before { Refinery::Pages::Types.register("show") { |type| type.parts = Refinery::Pages.default_parts } }
         after { Refinery::Pages::Types.registered.delete(Refinery::Pages::Types.registered.find_by_name("show")) }
         it { expect(get(:new, params: { view_template: "show" })).to be_ok }
       end

--- a/pages/spec/lib/pages_spec.rb
+++ b/pages/spec/lib/pages_spec.rb
@@ -22,5 +22,13 @@ module Refinery
         end
       end
     end
+
+    describe ".default_parts_for" do
+      context "with no view template" do
+        it "returns the default page parts" do
+          expect(subject.default_parts_for(Page.new)).to eq subject.default_parts_for
+        end
+      end
+    end
   end
 end

--- a/pages/spec/lib/pages_spec.rb
+++ b/pages/spec/lib/pages_spec.rb
@@ -32,26 +32,13 @@ module Refinery
 
       context "with registered type" do
         let(:type_name) { "custom_type" }
-        before { Pages::Types.registered.register(type_name) { |type| type.parts = type_parts } }
+        before { Pages::Types.registered.register(type_name) }
         after { Pages::Types.registered.delete(Pages::Types.registered.find_by_name(type_name)) }
 
-        context "page parts specified as array of hashes (part attributes)" do
-          let(:type_parts) { [{slug: "body", title: "Body"}] }
-          it "returns the parts for the type" do
-            type_parts = Pages::Types.registered.find_by_name(type_name).parts
-            page = Page.new(view_template: type_name)
-            expect(subject.default_parts_for(page)).to eq type_parts
-          end
-        end
-
-        context "page parts specified as array of strings" do
-          let(:type_parts) { %w[Body] }
-          it "returns the parts for the type as a hash" do
-            page = Page.new(view_template: type_name)
-            expect(subject.default_parts_for(page)).to eq [{slug: "body", title: "Body"}]
-          end
-
-          xit "warns that this configuration format is deprecated"
+        it "delegates to the type's parts" do
+          part = Pages::Types.registered.find_by_name(type_name)
+          expect(part).to receive(:parts).and_return []
+          subject.default_parts_for(Page.new(view_template: type_name))
         end
       end
     end

--- a/pages/spec/lib/pages_spec.rb
+++ b/pages/spec/lib/pages_spec.rb
@@ -26,7 +26,32 @@ module Refinery
     describe ".default_parts_for" do
       context "with no view template" do
         it "returns the default page parts" do
-          expect(subject.default_parts_for(Page.new)).to eq subject.default_parts_for
+          expect(subject.default_parts_for(Page.new)).to eq subject.default_parts
+        end
+      end
+
+      context "with registered type" do
+        let(:type_name) { "custom_type" }
+        before { Pages::Types.registered.register(type_name) { |type| type.parts = type_parts } }
+        after { Pages::Types.registered.delete(Pages::Types.registered.find_by_name(type_name)) }
+
+        context "page parts specified as array of hashes (part attributes)" do
+          let(:type_parts) { [{slug: "body", title: "Body"}] }
+          it "returns the parts for the type" do
+            type_parts = Pages::Types.registered.find_by_name(type_name).parts
+            page = Page.new(view_template: type_name)
+            expect(subject.default_parts_for(page)).to eq type_parts
+          end
+        end
+
+        context "page parts specified as array of strings" do
+          let(:type_parts) { %w[Body] }
+          it "returns the parts for the type as a hash" do
+            page = Page.new(view_template: type_name)
+            expect(subject.default_parts_for(page)).to eq [{slug: "body", title: "Body"}]
+          end
+
+          xit "warns that this configuration format is deprecated"
         end
       end
     end

--- a/pages/spec/lib/refinery/pages/type_spec.rb
+++ b/pages/spec/lib/refinery/pages/type_spec.rb
@@ -15,9 +15,10 @@ module Refinery
         it "rewrites an array of strings and warns about this deprecated format" do
           parts = ["Side Bar"]
           rewritten_parts = [{title: "Side Bar", slug: "side_bar"}]
-          expect(Refinery).to receive(:deprecate).with("
-            Change Refinery::Pages.default_parts= from #{parts} to #{rewritten_parts}
-          ".strip, when: "4.1.0")
+          expect(Refinery).to receive(:deprecate).with(
+            "Change specific page template page parts from #{parts} to #{rewritten_parts}", 
+            when: "4.1.0"
+          )
 
           subject.parts = parts
           expect(subject.parts).to eq rewritten_parts

--- a/pages/spec/lib/refinery/pages/type_spec.rb
+++ b/pages/spec/lib/refinery/pages/type_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+module Refinery
+  module Pages
+    describe Type do
+      subject { Type.new }
+
+      describe ".parts=" do
+        it "returns an array of hashes unaltered" do
+          parts = [{title: "Body", slug: "body"}]
+          subject.parts = parts
+          expect(subject.parts).to eq parts
+        end
+
+        it "rewrites an array of strings and warns about this deprecated format" do
+          parts = ["Side Bar"]
+          rewritten_parts = [{title: "Side Bar", slug: "side_bar"}]
+          expect(Refinery).to receive(:deprecate).with("
+            Change Refinery::Pages.default_parts= from #{parts} to #{rewritten_parts}
+          ".strip, when: "4.1.0")
+
+          subject.parts = parts
+          expect(subject.parts).to eq rewritten_parts
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
This pull request resolves an issue I noticed while registering custom types in `config/initializers/refinery/pages.rb`. 

In 3535b906fa, the format of specifying page parts for default parts changed from a string: `["Body"]`, to a hash with `title` and `slug` keys: `[{title: "Body", slug: "body"}]`. This change was made for the default page parts, but not for page parts specified against registered types.

I have included a simple regression test as a controller test. This issue can also be caused by adding a database migration to set a default view template (this is how I originally reproduced the issue).

As an interim fix, I have added the following code to the application I am working on:

``` ruby
module RefineryPagePartDiscovery
  def self.included(base)
    base.module_eval do
      class << self
        def default_parts_for(page)
          return default_parts unless page.view_template.present?
          types.find_by_name(page.view_template).parts
        end
      end
    end
  end
end
Refinery::Pages.send(:include, RefineryPagePartDiscovery)
```

This pull request makes this change (removing `titleize`), but also wraps the `parts` writer in some code that prints a deprecation warning for any applications passing any page parts in as array of strings - not that it would work anyway, but I wanted to be thorough.
Note that I've speculated that this kind of config change would be a minor version change.

I have also made adjustments to the default pages initializer that will be generated, and updated the markdown documentation in relation to `default_parts` to match the format used in the initializer.