### PR TITLE
Bugfix #2915: assign cancel_url path in engine generator _form partial

### DIFF
--- a/core/lib/generators/refinery/engine/templates/app/views/refinery/namespace/admin/plural_name/_form.html.erb
+++ b/core/lib/generators/refinery/engine/templates/app/views/refinery/namespace/admin/plural_name/_form.html.erb
@@ -48,10 +48,11 @@
 
 <% end -%>
 <% end -%>
-  <%%= render '/refinery/admin/form_actions', :f => f,
-             :continue_editing => false,
-             :delete_title => t('delete', :scope => 'refinery.<%= plural_name %>.admin.<%= plural_name %>.<%= singular_name %>'),
-             :delete_confirmation => t('message', :scope => 'refinery.admin.delete'<% if (title = attributes.detect { |a| a.type.to_s == "string" }).present? %>, :title => @<%= singular_name %>.<%= title.name %><% end %>) -%>
+  <%%= render '/refinery/admin/form_actions', f: f,
+             continue_editing: false,
+             delete_title: t('delete', scope: 'refinery.<%= plural_name %>.admin.<%= plural_name %>.<%= singular_name %>'),
+             delete_confirmation: t('message', scope: 'refinery.admin.delete'<% if (title = attributes.detect { |a| a.type.to_s == "string" }).present? %>, title: @<%= singular_name %>.<%= title.name %><% end %>),
+             cancel_url: refinery.<%= plural_name %>_admin_<%= plural_name %>_path -%>
 <%% end -%>
 <% if text_areas.any? -%>
 


### PR DESCRIPTION
This will fix Cancel button who did not work on non-posts after switching languages