### PR TITLE
Generator specs clean up after themselves.

### DIFF
--- a/core/spec/lib/generators/refinery/engine/engine_generator_multiple_resources_spec.rb
+++ b/core/spec/lib/generators/refinery/engine/engine_generator_multiple_resources_spec.rb
@@ -1,16 +1,20 @@
 require 'spec_helper'
+require 'fileutils'
 require 'generator_spec/test_case'
 require 'generators/refinery/engine/engine_generator'
-require 'tmpdir'
 
 module Refinery
   describe EngineGenerator do
     include GeneratorSpec::TestCase
-    destination Dir.mktmpdir
+    destination File.expand_path("../../../../../../tmp", __FILE__)
 
     before do
       prepare_destination
       run_generator %w{ rspec_product_test title:string description:text image:image brochure:resource }
+    end
+
+    after do
+      FileUtils.rm_r destination_root
     end
 
     context "when generating a resource without passing a namespace" do

--- a/core/spec/lib/generators/refinery/engine/engine_generator_spec.rb
+++ b/core/spec/lib/generators/refinery/engine/engine_generator_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'fileutils'
 require 'generator_spec/test_case'
 require 'generators/refinery/engine/engine_generator'
 
@@ -10,6 +11,10 @@ module Refinery
     before do
       prepare_destination
       run_generator %w{ rspec_product_test title:string description:text image:image brochure:resource }
+    end
+
+    after do
+      FileUtils.rm_r destination_root
     end
 
     it "uses reference columns for image and resource attributes" do

--- a/core/spec/lib/generators/refinery/engine/engine_generator_with_author_spec.rb
+++ b/core/spec/lib/generators/refinery/engine/engine_generator_with_author_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'fileutils'
 require 'generator_spec/test_case'
 require 'generators/refinery/engine/engine_generator'
 
@@ -10,6 +11,10 @@ module Refinery
     before do
       prepare_destination
       run_generator %w{ rspec_product_test title:string description:text image:image brochure:resource --authors Author1 Author2 }
+    end
+
+    after do
+      FileUtils.rm_r destination_root
     end
 
     it "uses reference columns for image and resource attributes" do

--- a/core/spec/lib/generators/refinery/engine/engine_generator_with_i18n_spec.rb
+++ b/core/spec/lib/generators/refinery/engine/engine_generator_with_i18n_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'fileutils'
 require 'generator_spec/test_case'
 require 'generators/refinery/engine/engine_generator'
 
@@ -10,6 +11,10 @@ module Refinery
     before do
       prepare_destination
       run_generator %w{ rspec_product_test title:string description:text image:image brochure:resource --i18n title description }
+    end
+
+    after do
+      FileUtils.rm_r destination_root
     end
 
     specify do

--- a/core/spec/lib/generators/refinery/engine/engine_generator_without_frontend_spec.rb
+++ b/core/spec/lib/generators/refinery/engine/engine_generator_without_frontend_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'fileutils'
 require 'generator_spec/test_case'
 require 'generators/refinery/engine/engine_generator'
 
@@ -10,6 +11,10 @@ module Refinery
     before do
       prepare_destination
       run_generator %w{ rspec_product_test title:string description:text image:image brochure:resource --skip-frontend }
+    end
+
+    after do
+      FileUtils.rm_r destination_root
     end
 
     specify do


### PR DESCRIPTION
I was having issues running the generator specs because I got permission
denied errors for the tmpdir that was being used in the spec for
engine_generator_multiple_resources.

I then noticed that the other specs use a relative path inside the core/
directory for the temporary directory.

I've switched the spec to do this and also added an after which cleans
up after the test ensuring no extra files or folders are left lying
around on the file system.