### PR TITLE
Fix Reserved Word Documentation Typo

### DIFF
--- a/doc/guides/2 - Refinery Basics/2 - Page Titles and URLs.md
+++ b/doc/guides/2 - Refinery Basics/2 - Page Titles and URLs.md
@@ -27,6 +27,6 @@ To use custom slugs, open `config/initializers/refinery/pages.rb`, uncomment `co
 
 ## Reserved Words
 
-By default, Refinery will scan your routes.rb file and add your routes as reserved words. This prevents Refinery Pages from interfering with your app. If you want to have a Refinery Page that has the same slug as a Rails route, you can add `:allow_slug => true` : `match '/cart', :to => 'cart#index, :allow_slug => true'`
+By default, Refinery will scan your routes.rb file and add your routes as reserved words. This prevents Refinery Pages from interfering with your app. If you want to have a Refinery Page that has the same slug as a Rails route, you can add `:allow_slug => true` : `match '/cart', :to => 'cart#index', :allow_slug => true`
 
 This will allow a page with slug 'cart', whereas the default behaviour would result in a page with slug 'cart-page'


### PR DESCRIPTION
The `:allow_slug` example was placed inside the quotes for the route's `to` action, instead of as a separate hash element. This minor text update fixes the example so that it matches what needs to be in the routes file.