### PR TITLE
Feature/admin page index cache

### DIFF
--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -55,7 +55,7 @@ module Refinery
 
     # Docs for acts_as_nested_set https://github.com/collectiveidea/awesome_nested_set
     # rather than :delete_all we want :destroy
-    acts_as_nested_set :dependent => :destroy
+    acts_as_nested_set counter_cache: :children_count, dependent: :destroy
 
     friendly_id :custom_slug_or_title, FriendlyIdOptions.options
 

--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -55,7 +55,7 @@ module Refinery
 
     # Docs for acts_as_nested_set https://github.com/collectiveidea/awesome_nested_set
     # rather than :delete_all we want :destroy
-    acts_as_nested_set counter_cache: :children_count, dependent: :destroy
+    acts_as_nested_set counter_cache: :children_count, dependent: :destroy, touch: true
 
     friendly_id :custom_slug_or_title, FriendlyIdOptions.options
 

--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -389,7 +389,7 @@ module Refinery
     end
 
     def update_all_descendants
-      self.descendants.update_all(updated_at: DateTime.now)
+      self.descendants.map(&:touch)
     end
   end
 end

--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -73,8 +73,8 @@ module Refinery
     before_destroy :deletable?
     after_save :reposition_parts!
 
-    after_save { update_all_descendants if descendants.any? }
-    after_move { update_all_descendants if descendants.any? }
+    after_save :update_all_descendants
+    after_move :update_all_descendants
 
     class << self
       # Live pages are 'allowed' to be shown in the frontend of your website.

--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -73,6 +73,9 @@ module Refinery
     before_destroy :deletable?
     after_save :reposition_parts!
 
+    after_save { update_all_descendants if descendants.any? }
+    after_move { update_all_descendants if descendants.any? }
+
     class << self
       # Live pages are 'allowed' to be shown in the frontend of your website.
       # By default, this is all pages that are not set as 'draft'.
@@ -383,6 +386,10 @@ module Refinery
       else
         translations.first.locale
       end
+    end
+
+    def update_all_descendants
+      self.descendants.update_all(updated_at: DateTime.now)
     end
   end
 end

--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -381,7 +381,7 @@ module Refinery
     def slug_locale
       return Globalize.locale if translation_for(Globalize.locale, false).try(:slug).present?
 
-      if translations.empty? || translation_for(Refinery::I18n.default_frontend_locale, false).present?
+      if translations.empty? || translation_for(Refinery::I18n.default_frontend_locale, false).try(:slug).present?
         Refinery::I18n.default_frontend_locale
       else
         translations.first.locale

--- a/pages/app/views/refinery/admin/pages/_page.html.erb
+++ b/pages/app/views/refinery/admin/pages/_page.html.erb
@@ -46,7 +46,8 @@
       <%= action_icon(:delete,  delete_url, t('delete', scope: 'refinery.admin.pages' ), delete_options ) if page.deletable? %>
     </span>
   </div>
-  <ul class='nested' data-ajax-content="<%= refinery.admin_children_pages_path(page.nested_url) %>">
-    <%= render(partial: 'page', collection: page.children) if Refinery::Pages.auto_expand_admin_tree %>
-  </ul>
+
+  <%= content_tag :ul, class: 'nested', data: { 'ajax-content': refinery.admin_children_pages_path(page.nested_url) } do %>
+    <%= render(partial: 'page', collection: page.children, cached: true) if Refinery::Pages.auto_expand_admin_tree %>
+  <% end %>
 </li>

--- a/pages/app/views/refinery/admin/pages/_sortable_list.html.erb
+++ b/pages/app/views/refinery/admin/pages/_sortable_list.html.erb
@@ -1,4 +1,5 @@
-<ul id='sortable_list'>
-  <%= render :partial => 'page', :collection => @pages.roots  %>
-</ul>
-<%= render '/refinery/admin/sortable_list', :continue_reordering => !!local_assigns[:continue_reordering] %>
+<%= content_tag :ul, id: 'sortable_list' do %>
+  <%= render partial: 'page', collection: @pages.roots, cached: true %>
+<% end %>
+
+<%= render '/refinery/admin/sortable_list', continue_reordering: !!local_assigns[:continue_reordering] %>

--- a/pages/app/views/refinery/admin/pages/children.html.erb
+++ b/pages/app/views/refinery/admin/pages/children.html.erb
@@ -1,1 +1,1 @@
-<%= render :partial => 'page', :collection => @page.children %>
+<%= render partial: 'page', collection: @page.children, cached: true %>

--- a/pages/db/migrate/20180316032602_add_children_count_to_refinery_pages.rb
+++ b/pages/db/migrate/20180316032602_add_children_count_to_refinery_pages.rb
@@ -1,0 +1,5 @@
+class AddChildrenCountToRefineryPages < ActiveRecord::Migration[5.1]
+  def change
+    add_column :refinery_pages, :children_count, :integer, null: false, default: 0
+  end
+end


### PR DESCRIPTION
Displaying the page tree in the admin could be slow when there are a lot of pages in the Tree.

Using the fragment cache will help us to save time in rendering, it should fix this issue #2950 and this PR #3094