### PR TITLE
Switch from Globalize to Mobility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ end
 if !ENV['TRAVIS'] || ENV['DB'] == 'mysql'
   group :mysql do
     gem 'activerecord-jdbcmysql-adapter', '>= 1.3.0.rc1', platform: :jruby
-    gem 'mysql2', '~> 0.3.18', :platform => :ruby
+    gem 'mysql2', '~> 0.4.10', :platform => :ruby
   end
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ end
 
 # TODO: Remove this before merging this PR
 gem 'refinerycms-i18n', git: 'https://github.com/refinery/refinerycms-i18n', branch: 'feature/mobility'
+gem 'mobility', git: 'https://github.com/shioyama/mobility', branch: 'table_finder_extension'
 
 gem 'spring'
 gem 'spring-commands-rspec'

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,9 @@ path "./" do
   gem "refinerycms-resources"
 end
 
+# TODO: Remove this before merging this PR
+gem 'refinerycms-i18n', git: 'https://github.com/refinery/refinerycms-i18n', branch: 'feature/mobility'
+
 gem 'spring'
 gem 'spring-commands-rspec'
 gem 'poltergeist', '>= 1.8.1'

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 
 # TODO: Remove this before merging this PR
 gem 'refinerycms-i18n', git: 'https://github.com/refinery/refinerycms-i18n', branch: 'feature/mobility'
-gem 'mobility', git: 'https://github.com/shioyama/mobility', branch: 'table_finder_extension'
+gem 'mobility', git: 'https://github.com/shioyama/mobility', branch: 'master'
 
 gem 'spring'
 gem 'spring-commands-rspec'

--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,8 @@ path "./" do
   gem "refinerycms-resources"
 end
 
-# TODO: Remove this before merging this PR
-gem 'refinerycms-i18n', git: 'https://github.com/refinery/refinerycms-i18n', branch: 'feature/mobility'
+# TODO: Switch to the released gem
+gem 'refinerycms-i18n', git: 'https://github.com/refinery/refinerycms-i18n', branch: 'master'
 
 gem 'spring'
 gem 'spring-commands-rspec'

--- a/Gemfile
+++ b/Gemfile
@@ -9,9 +9,6 @@ path "./" do
   gem "refinerycms-resources"
 end
 
-# TODO: Switch to the released gem
-gem 'refinerycms-i18n', git: 'https://github.com/refinery/refinerycms-i18n', branch: 'master'
-
 gem 'spring'
 gem 'spring-commands-rspec'
 gem 'poltergeist', '>= 1.8.1'

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ end
 
 # TODO: Remove this before merging this PR
 gem 'refinerycms-i18n', git: 'https://github.com/refinery/refinerycms-i18n', branch: 'feature/mobility'
-gem 'mobility', git: 'https://github.com/shioyama/mobility', branch: 'master'
 
 gem 'spring'
 gem 'spring-commands-rspec'

--- a/core/lib/generators/refinery/engine/templates/Gemfile
+++ b/core/lib/generators/refinery/engine/templates/Gemfile
@@ -20,7 +20,7 @@ end
 
 platforms :ruby do
   gem 'sqlite3'
-  gem 'mysql2'
+  gem 'mysql2', '~> 0.4.10'
   gem 'pg'
 end
 

--- a/core/lib/generators/refinery/engine/templates/app/models/refinery/namespace/singular_name.rb.erb
+++ b/core/lib/generators/refinery/engine/templates/app/models/refinery/namespace/singular_name.rb.erb
@@ -6,6 +6,7 @@ module Refinery
 <% end %>
 <% if localized? -%>
 
+      extend Mobility
       translates <%= localized_attributes.map { |a| ":#{a.name}" }.join(', ') %>
 <% end -%>
 <% if string_attributes.any? -%>

--- a/core/lib/generators/refinery/engine/templates/app/views/refinery/namespace/admin/plural_name/_form.html.erb
+++ b/core/lib/generators/refinery/engine/templates/app/views/refinery/namespace/admin/plural_name/_form.html.erb
@@ -9,7 +9,7 @@
 
 <% if localized? -%>
   <%%= render '/refinery/admin/locale_picker',
-              :current_locale => Globalize.locale %>
+              :current_locale => Mobility.locale %>
 <% end -%>
 <% attributes.each_with_index do |attribute, index| -%>
 <% if attribute.refinery_type == :image -%>

--- a/core/lib/generators/refinery/engine/templates/db/migrate/1_create_namespace_plural_name.rb.erb
+++ b/core/lib/generators/refinery/engine/templates/db/migrate/1_create_namespace_plural_name.rb.erb
@@ -2,18 +2,29 @@ class Create<%= namespacing %><%= class_name.pluralize %> < ActiveRecord::Migrat
 
   def up
     create_table :refinery_<%= "#{namespacing.underscore}_" if table_name != namespacing.underscore.pluralize -%><%= table_name %> do |t|
-<% attributes.each do |attribute| -%>
+<% (attributes - localized_attributes).each do |attribute| -%>
       t.<%= attribute.type %> :<%= attribute.column_name %>
 <% end -%>
       t.integer :position
 
       t.timestamps
     end
+
 <% if localized? %>
-    # FIXME: remove create_translation_table!` method
-    Refinery::<%= namespacing %>::<%= class_name %>.create_translation_table! <%= attributes_for_translation_table %>
+    create_table :<%= localized_table_name %> do |t|
+<% localized_attributes.each do |attribute| -%>
+      t.<%= attribute.type %> :<%= attribute.column_name %>
+<% end -%>
+      t.string  :locale, null: false
+      t.integer :refinery_<%= singular_table_name %>_id, null: false
+      t.timestamps
+    end
+
+    add_index :<%= localized_table_name %>, :locale, name: :index_<%= localized_table_name %>_on_locale
+    add_index :<%= localized_table_name %>, [:refinery_<%= singular_table_name %>_id, :locale], name: :index_<%= Digest::SHA1.hexdigest(localized_table_name) %>, unique: true
 <% end %>
   end
+
 
   def down
     if defined?(::Refinery::UserPlugin)
@@ -26,8 +37,7 @@ class Create<%= namespacing %><%= class_name.pluralize %> < ActiveRecord::Migrat
 <% end %>
     drop_table :refinery_<%= "#{namespacing.underscore}_" if table_name != namespacing.underscore.pluralize -%><%= table_name %>
 <% if localized? %>
-    Refinery::<%= namespacing %>::<%= class_name %>.drop_translation_table!
+    drop_table :<%= localized_table_name %>
 <% end %>
   end
-
 end

--- a/core/lib/generators/refinery/engine/templates/db/migrate/1_create_namespace_plural_name.rb.erb
+++ b/core/lib/generators/refinery/engine/templates/db/migrate/1_create_namespace_plural_name.rb.erb
@@ -10,6 +10,7 @@ class Create<%= namespacing %><%= class_name.pluralize %> < ActiveRecord::Migrat
       t.timestamps
     end
 <% if localized? %>
+    # FIXME: remove create_translation_table!` method
     Refinery::<%= namespacing %>::<%= class_name %>.create_translation_table! <%= attributes_for_translation_table %>
 <% end %>
   end

--- a/core/lib/refinery/core/engine.rb
+++ b/core/lib/refinery/core/engine.rb
@@ -44,6 +44,15 @@ module Refinery
         WillPaginate.per_page = 20
       end
 
+      initializer "refinery.mobility" do
+        Mobility.configure do |config|
+          config.default_backend = :table
+          config.accessor_method = :translates
+          config.query_method    = :i18n
+          config.default_options[:dirty] = true
+        end
+      end
+
       before_inclusion do
         Refinery::Plugin.register do |plugin|
           plugin.pathname = root

--- a/core/lib/refinery/extension_generation.rb
+++ b/core/lib/refinery/extension_generation.rb
@@ -68,6 +68,13 @@ module Refinery
       @localized_attributes ||= attributes.select{ |a| options[:i18n].include?(a.name)}
     end
 
+    def localized_table_name
+      localized_table_name = [ 'refinery']
+      localized_table_name << namespacing.underscore if table_name != namespacing.underscore.pluralize
+      localized_table_name << [ singular_table_name, 'translations']
+      localized_table_name.join('_')
+    end
+
     def attributes_for_translation_table
       localized_attributes.inject([]) { |memo, attr| memo << ":#{attr.name} => :#{attr.type}"}.join(', ')
     end

--- a/core/refinerycms-core.gemspec
+++ b/core/refinerycms-core.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = Refinery::Version.required_ruby_version
 
   s.add_dependency 'refinerycms-i18n',            ['~> 4.0', '>= 4.0.0']
-  s.add_dependency 'awesome_nested_set',          ['~> 3.0', '>= 3.0.0']
   s.add_dependency 'railties',                    rails_version
   s.add_dependency 'activerecord',                rails_version
   s.add_dependency 'actionpack',                  rails_version

--- a/core/refinerycms-core.gemspec
+++ b/core/refinerycms-core.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = Refinery::Version.required_ruby_version
 
-  s.add_dependency 'refinerycms-i18n',            ['~> 4.0', '>= 4.0.0']
+  s.add_dependency 'refinerycms-i18n',            ['~> 5.0', '>= 5.0.0']
   s.add_dependency 'railties',                    rails_version
   s.add_dependency 'activerecord',                rails_version
   s.add_dependency 'actionpack',                  rails_version

--- a/core/spec/helpers/refinery/translation_helper_spec.rb
+++ b/core/spec/helpers/refinery/translation_helper_spec.rb
@@ -14,12 +14,12 @@ module Refinery
       let(:page) { FactoryBot.build(:page) }
 
       before do
-        Globalize.with_locale(:en) do
+        Mobility.with_locale(:en) do
           page.title = "draft"
           page.save!
         end
 
-        Globalize.with_locale(:lv) do
+        Mobility.with_locale(:lv) do
           page.title = "melnraksts"
           page.save!
         end

--- a/core/spec/helpers/refinery/translation_helper_spec.rb
+++ b/core/spec/helpers/refinery/translation_helper_spec.rb
@@ -33,7 +33,7 @@ module Refinery
 
       context "when title for current locale isn't available" do
         it "returns existing title from translations" do
-          Page.translation_class.where(locale: :en).first.destroy
+          Page::Translation.where(locale: :en).first.destroy
           expect(helper.translated_field(page, :title)).to eq("melnraksts")
         end
       end

--- a/core/spec/presenters/refinery/translated_field_presenter_spec.rb
+++ b/core/spec/presenters/refinery/translated_field_presenter_spec.rb
@@ -25,7 +25,7 @@ module Refinery
 
       context "when title for current locale isn't available" do
         it "returns existing title from translations" do
-          Page.translation_class.where(locale: :en).first.destroy
+          Page::Translation.where(locale: :en).first.destroy
           expect(TranslatedFieldPresenter.new(page).call(:title)).to eq("melnraksts")
         end
       end

--- a/core/spec/presenters/refinery/translated_field_presenter_spec.rb
+++ b/core/spec/presenters/refinery/translated_field_presenter_spec.rb
@@ -5,12 +5,12 @@ module Refinery
     let(:page) { FactoryBot.build(:page) }
 
     before do
-      Globalize.with_locale(:en) do
+      Mobility.with_locale(:en) do
         page.title = "draft"
         page.save!
       end
 
-      Globalize.with_locale(:lv) do
+      Mobility.with_locale(:lv) do
         page.title = "melnraksts"
         page.save!
       end

--- a/images/app/models/refinery/image.rb
+++ b/images/app/models/refinery/image.rb
@@ -2,6 +2,7 @@ require 'dragonfly'
 
 module Refinery
   class Image < Refinery::Core::BaseModel
+    extend Mobility
     translates :image_title, :image_alt
 
     attribute :image_title

--- a/images/app/models/refinery/image.rb
+++ b/images/app/models/refinery/image.rb
@@ -5,9 +5,6 @@ module Refinery
     extend Mobility
     translates :image_title, :image_alt
 
-    attribute :image_title
-    attribute :image_alt
-
     dragonfly_accessor :image, :app => :refinery_images
 
     include Images::Validators

--- a/images/app/views/refinery/admin/images/_form.html.erb
+++ b/images/app/views/refinery/admin/images/_form.html.erb
@@ -5,7 +5,7 @@
              object: @image,
              include_object_name: false %>
 
-  <%= render '/refinery/admin/locale_picker', :current_locale => Globalize.locale if @image.persisted? %>
+  <%= render '/refinery/admin/locale_picker', :current_locale => Mobility.locale if @image.persisted? %>
 
   <div class="field">
     <% if action_name =~ /(edit)|(update)/ %>

--- a/images/db/migrate/20150430171341_translate_refinery_images.rb
+++ b/images/db/migrate/20150430171341_translate_refinery_images.rb
@@ -1,22 +1,20 @@
 class TranslateRefineryImages < ActiveRecord::Migration[4.2]
-  def self.up
-    begin
-      ::Refinery::Image.create_translation_table!({
-        image_alt: :string,
-        image_title: :string
-      }, {
-        :migrate_data => true
-      })
-    rescue NameError
-      warn "Refinery::Image was not defined!"
-    end
-  end
+  def change
+    create_table :refinery_image_translations do |t|
 
-  def self.down
-    begin
-      Refinery::Image.drop_translation_table! migrate_data: true
-    rescue NameError
-      warn "Refinery::Image was not defined!"
+      # Translated attribute(s)
+      t.string :image_alt
+      t.string :image_title
+
+      t.string  :locale, null: false
+      t.integer :refinery_image_id, null: false
+
+      t.timestamps null: false
     end
+
+    add_index :refinery_image_translations, :refinery_image_id, name: :index_refinery_image_translations_on_refinery_image_id
+    add_index :refinery_image_translations, :locale, name: :index_refinery_image_translations_on_locale
+    add_index :refinery_image_translations, [:refinery_image_id, :locale], name: :index_2f245f0c60154d35c851e1df2ffc4c86571726f0, unique: true
+
   end
 end

--- a/images/db/migrate/20150430171341_translate_refinery_images.rb
+++ b/images/db/migrate/20150430171341_translate_refinery_images.rb
@@ -12,9 +12,7 @@ class TranslateRefineryImages < ActiveRecord::Migration[4.2]
       t.timestamps null: false
     end
 
-    add_index :refinery_image_translations, :refinery_image_id, name: :index_refinery_image_translations_on_refinery_image_id
     add_index :refinery_image_translations, :locale, name: :index_refinery_image_translations_on_locale
     add_index :refinery_image_translations, [:refinery_image_id, :locale], name: :index_2f245f0c60154d35c851e1df2ffc4c86571726f0, unique: true
-
   end
 end

--- a/images/lib/refinery/images.rb
+++ b/images/lib/refinery/images.rb
@@ -24,5 +24,5 @@ module Refinery
 end
 
 ActiveSupport.on_load(:active_record) do
-  require 'globalize'
+  require 'mobility'
 end

--- a/images/refinerycms-images.gemspec
+++ b/images/refinerycms-images.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
   s.add_dependency 'refinerycms-dragonfly',   '~> 1.0'
-  s.add_dependency 'mobility',               '~> 0.5'
   s.add_dependency 'activemodel-serializers-xml', '~> 1.0', '>= 1.0.1'
   s.add_dependency 'refinerycms-core',        version
 

--- a/images/refinerycms-images.gemspec
+++ b/images/refinerycms-images.gemspec
@@ -19,9 +19,8 @@ Gem::Specification.new do |s|
   s.files             = `git ls-files`.split("\n")
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
-  s.add_dependency 'refinerycms-dragonfly',   '~> 1.0'
-  s.add_dependency 'activemodel-serializers-xml', '~> 1.0', '>= 1.0.1'
-  s.add_dependency 'refinerycms-core',        version
+  s.add_dependency 'refinerycms-core', version
+  s.add_dependency 'refinerycms-dragonfly', '~> 1.0'
 
   s.required_ruby_version = Refinery::Version.required_ruby_version
 

--- a/images/refinerycms-images.gemspec
+++ b/images/refinerycms-images.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
   s.add_dependency 'refinerycms-dragonfly',   '~> 1.0'
-  s.add_dependency 'globalize',               ['>= 5.1.0.beta1', '< 5.2']
+  s.add_dependency 'mobility',               '~> 0.5'
   s.add_dependency 'activemodel-serializers-xml', '~> 1.0', '>= 1.0.1'
   s.add_dependency 'refinerycms-core',        version
 

--- a/images/spec/support/shared_examples/image_translator.rb
+++ b/images/spec/support/shared_examples/image_translator.rb
@@ -25,7 +25,7 @@ shared_examples 'translates an image' do
       click_button "Save"
 
       expect(page).to have_content("'Titre de la première image' was successfully updated.")
-      expect(Refinery::Image.translation_class.count).to eq(1)
+      expect(Refinery::Image::Translation.count).to eq(1)
     end
   end
 end

--- a/pages/app/controllers/refinery/admin/page_parts_controller.rb
+++ b/pages/app/controllers/refinery/admin/page_parts_controller.rb
@@ -28,7 +28,7 @@ module Refinery
 
       private
         def permitted_new_page_part_params
-          [:title, :slug, :body, :locale]
+          [:title, :slug, :body]
         end
     end
   end

--- a/pages/app/controllers/refinery/admin/pages_controller.rb
+++ b/pages/app/controllers/refinery/admin/pages_controller.rb
@@ -72,9 +72,9 @@ module Refinery
 
         # Always display the tree of pages from the default frontend locale.
         if Refinery::I18n.built_in_locales.keys.map(&:to_s).include?(params[:switch_locale])
-          Globalize.locale = params[:switch_locale].try(:to_sym)
+          Mobility.locale = params[:switch_locale].try(:to_sym)
         else
-          Globalize.locale = Refinery::I18n.default_frontend_locale
+          Mobility.locale = Refinery::I18n.default_frontend_locale
         end
       end
 

--- a/pages/app/controllers/refinery/admin/pages_controller.rb
+++ b/pages/app/controllers/refinery/admin/pages_controller.rb
@@ -67,7 +67,7 @@ module Refinery
 
       # We can safely assume ::Refinery::I18n is defined because this method only gets
       # Invoked when the before_action from the plugin is run.
-      def globalize!
+      def mobility!
         return super unless action_name.to_s == 'index'
 
         # Always display the tree of pages from the default frontend locale.

--- a/pages/app/controllers/refinery/admin/pages_dialogs_controller.rb
+++ b/pages/app/controllers/refinery/admin/pages_dialogs_controller.rb
@@ -6,9 +6,9 @@ module Refinery
 
       def link_to
         # Get the switch_local variable to determine the locale we're currently editing
-        # Set up Globalize with our current locale
-        Globalize.locale = if params[:switch_locale].present? && Refinery::I18n.built_in_locales.keys.map(&:to_s).include?(params[:switch_locale])
-          Globalize.locale = params[:switch_locale]
+        # Set up Mobility with our current locale
+        Mobility.locale = if params[:switch_locale].present? && Refinery::I18n.built_in_locales.keys.map(&:to_s).include?(params[:switch_locale])
+          Mobility.locale = params[:switch_locale]
         else
           Refinery::I18n.default_locale
         end

--- a/pages/app/controllers/refinery/admin/pages_dialogs_controller.rb
+++ b/pages/app/controllers/refinery/admin/pages_dialogs_controller.rb
@@ -15,7 +15,7 @@ module Refinery
 
         @pages = ::Refinery::Page.roots.paginate(:page => params[:page], :per_page => ::Refinery::Page.per_page(true))
 
-        @pages = @pages.with_globalize
+        @pages = @pages.with_mobility
 
         if ::Refinery::Plugins.registered.names.include?('refinery_files')
           @resources = Resource.paginate(:page => params[:resource_page], :per_page => Resource.per_page(true)).

--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -10,7 +10,7 @@ module Refinery
     extend Mobility
     translates :title, :menu_title, :custom_slug, :slug, :browser_title, :meta_description
 
-    after_save { translations.in(Mobility.locale).seo_meta.save! }
+    after_save { translations.in_locale(Mobility.locale).seo_meta.save! }
 
     class Translation
       is_seo_meta

--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -11,6 +11,8 @@ module Refinery
     extend Mobility
     translates :title, :menu_title, :custom_slug, :slug, :browser_title, :meta_description
 
+    default_scope { i18n }
+
     class Translation
       is_seo_meta
     end
@@ -19,14 +21,14 @@ module Refinery
       def self.options
         # Docs for friendly_id https://github.com/norman/friendly_id
         friendly_id_options = {
-          use: [:reserved],
+          use: [:mobility, :reserved],
           reserved_words: Refinery::Pages.friendly_id_reserved_words
         }
         if ::Refinery::Pages.scope_slug_by_parent
           friendly_id_options[:use] << :scoped
           friendly_id_options.merge!(scope: :parent)
         end
-        friendly_id_options[:use] << :mobility
+        # friendly_id_options[:use] << :mobility
         friendly_id_options
       end
     end

--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -47,7 +47,7 @@ module Refinery
 
     has_many :parts, -> {
       scope = order('position ASC')
-      scope = scope.includes(:translations) if ::Refinery::PagePart.respond_to?(:translation_class)
+      scope = scope.includes(:translations) if ::Refinery::PagePart.respond_to?(:mobility)
       scope
     },       :foreign_key => :refinery_page_id,
              :class_name => '::Refinery::PagePart',

--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -10,6 +10,8 @@ module Refinery
     extend Mobility
     translates :title, :menu_title, :custom_slug, :slug, :browser_title, :meta_description
 
+    after_save { translations.in(Mobility.locale).seo_meta.save! }
+
     class Translation
       is_seo_meta
     end

--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -11,8 +11,6 @@ module Refinery
     extend Mobility
     translates :title, :menu_title, :custom_slug, :slug, :browser_title, :meta_description
 
-    default_scope { i18n }
-
     class Translation
       is_seo_meta
     end
@@ -48,8 +46,8 @@ module Refinery
     friendly_id :custom_slug_or_title, FriendlyIdOptions.options
 
     has_many :parts, -> {
-      scope = order('position ASC')
-      scope = scope.includes(:translations) if ::Refinery::PagePart.respond_to?(:mobility)
+      scope = ::Refinery::PagePart.respond_to?(:mobility) ? i18n.includes(:translations) : all
+      scope = scope.order('position ASC')
       scope
     },       :foreign_key => :refinery_page_id,
              :class_name => '::Refinery::PagePart',

--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -40,7 +40,7 @@ module Refinery
           friendly_id_options[:use] << :scoped
           friendly_id_options.merge!(scope: :parent)
         end
-        # friendly_id_options[:use] << :mobility
+
         friendly_id_options
       end
     end

--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -9,7 +9,7 @@ module Refinery
     extend FriendlyId
 
     extend Mobility
-    translates :title, :menu_title, :custom_slug, :slug, :include => :seo_meta
+    translates :title, :menu_title, :custom_slug, :slug, :browser_title, :meta_description
 
     attribute :title
     attribute :menu_title
@@ -20,10 +20,6 @@ module Refinery
     
     class Translation
       is_seo_meta
-
-      def self.seo_fields
-        ::SeoMeta.attributes.keys.map{ |a| [a, :"#{a}="]}.flatten
-      end
     end
 
     class FriendlyIdOptions
@@ -47,12 +43,8 @@ module Refinery
       changes.keys.include?("title") || changes.keys.include?("custom_slug")
     end
 
-    # Delegate SEO Attributes to globalize translation
-    delegate(*(Translation.seo_fields << {:to => :translation}))
-
-    validates :title, :presence => true
-
-    validates :custom_slug, :uniqueness => true, :allow_blank => true
+    validates :title, presence: true
+    validates :custom_slug, uniqueness: true, allow_blank: true
 
     # Docs for acts_as_nested_set https://github.com/collectiveidea/awesome_nested_set
     # rather than :delete_all we want :destroy

--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -11,8 +11,6 @@ module Refinery
     extend Mobility
     translates :title, :menu_title, :custom_slug, :slug, :browser_title, :meta_description
 
-    after_save { translations.collect(&:save) }
-
     class Translation
       is_seo_meta
     end

--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -8,6 +8,7 @@ module Refinery
   class Page < Core::BaseModel
     extend FriendlyId
 
+    extend Mobility
     translates :title, :menu_title, :custom_slug, :slug, :include => :seo_meta
 
     attribute :title
@@ -16,7 +17,7 @@ module Refinery
     attribute :slug
 
     after_save { translations.collect(&:save) }
-
+    
     class Translation
       is_seo_meta
 
@@ -36,7 +37,7 @@ module Refinery
           friendly_id_options[:use] << :scoped
           friendly_id_options.merge!(scope: :parent)
         end
-        friendly_id_options[:use] << :globalize
+        friendly_id_options[:use] << :mobility
         friendly_id_options
       end
     end
@@ -174,13 +175,13 @@ module Refinery
     # Consists of:
     #   * The current locale's translated slug
     def canonical
-      Globalize.with_locale(::Refinery::I18n.current_frontend_locale) { url }
+      Mobility.with_locale(::Refinery::I18n.current_frontend_locale) { url }
     end
 
     # The canonical slug for this particular page.
     # This is the slug for the current frontend locale.
     def canonical_slug
-      Globalize.with_locale(::Refinery::I18n.current_frontend_locale) { slug }
+      Mobility.with_locale(::Refinery::I18n.current_frontend_locale) { slug }
     end
 
     # Returns in cascading order: custom_slug or menu_title or title depending on
@@ -237,7 +238,7 @@ module Refinery
     end
 
     def nested_url
-      Globalize.with_locale(slug_locale) do
+      Mobility.with_locale(slug_locale) do
         if ::Refinery::Pages.scope_slug_by_parent && !root?
           self_and_ancestors.includes(:translations).map(&:to_param)
         else
@@ -379,7 +380,7 @@ module Refinery
     end
 
     def slug_locale
-      return Globalize.locale if translation_for(Globalize.locale, false).try(:slug).present?
+      return Mobility.locale if translation_for(Mobility.locale, false).try(:slug).present?
 
       if translations.empty? || translation_for(Refinery::I18n.default_frontend_locale, false).try(:slug).present?
         Refinery::I18n.default_frontend_locale

--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -11,11 +11,6 @@ module Refinery
     extend Mobility
     translates :title, :menu_title, :custom_slug, :slug, :browser_title, :meta_description
 
-    attribute :title
-    attribute :menu_title
-    attribute :custom_slug
-    attribute :slug
-
     after_save { translations.collect(&:save) }
 
     class Translation

--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -153,7 +153,7 @@ module Refinery
     end
 
     def translated_to_default_locale?
-      persisted? && translations.any?{ |t| t.locale == Refinery::I18n.default_frontend_locale}
+      persisted? && translations.any?{ |t| t.locale.to_sym == Refinery::I18n.default_frontend_locale}
     end
 
     # The canonical page for this particular page.

--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -17,7 +17,7 @@ module Refinery
     attribute :slug
 
     after_save { translations.collect(&:save) }
-    
+
     class Translation
       is_seo_meta
     end
@@ -372,9 +372,9 @@ module Refinery
     end
 
     def slug_locale
-      return Mobility.locale if translation_for(Mobility.locale, false).try(:slug).present?
+      return Mobility.locale if slug_backend.read(Mobility.locale).present?
 
-      if translations.empty? || translation_for(Refinery::I18n.default_frontend_locale, false).try(:slug).present?
+      if translations.empty? || slug_backend.read(Refinery::I18n.default_frontend_locale).try(:slug).present?
         Refinery::I18n.default_frontend_locale
       else
         translations.first.locale

--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -365,9 +365,9 @@ module Refinery
     end
 
     def slug_locale
-      return Mobility.locale if slug_backend.read(Mobility.locale).present?
+      return Mobility.locale if slug
 
-      if translations.empty? || slug_backend.read(Refinery::I18n.default_frontend_locale).try(:slug).present?
+      if translations.empty? || slug(locale: Refinery::I18n.default_frontend_locale)
         Refinery::I18n.default_frontend_locale
       else
         translations.first.locale

--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -89,7 +89,7 @@ module Refinery
       def find_by_path_or_id!(path, id)
         page = find_by_path_or_id(path, id)
 
-        raise ActiveRecord::RecordNotFound unless page
+        raise ::ActiveRecord::RecordNotFound unless page
 
         page
       end

--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -148,7 +148,7 @@ module Refinery
       protected
 
       def nullify_duplicate_slugs_under_the_same_parent!
-        t_slug = translation_class.arel_table[:slug]
+        t_slug = Translation.arel_table[:slug]
         joins(:translations).group(:locale, :parent_id, t_slug).having(t_slug.count.gt(1)).count.
         each do |(locale, parent_id, slug), count|
           by_slug(slug, :locale => locale).where(:parent_id => parent_id).drop(1).each do |page|

--- a/pages/app/models/refinery/page.rb
+++ b/pages/app/models/refinery/page.rb
@@ -115,7 +115,7 @@ module Refinery
       # This works using a query against the translated content first and then
       # using all of the page_ids we further filter against this model's table.
       def in_menu
-        where(:show_in_menu => true).with_globalize
+        where(show_in_menu: true).with_mobility
       end
 
       # An optimised scope containing only live pages ordered for display in a menu.
@@ -124,8 +124,8 @@ module Refinery
       end
 
       # Wrap up the logic of finding the pages based on the translations table.
-      def with_globalize(conditions = {})
-        Pages::Finder.with_globalize(conditions)
+      def with_mobility(conditions = {})
+        Pages::Finder.with_mobility(conditions)
       end
 
       # Returns how many pages per page should there be when paginating pages

--- a/pages/app/models/refinery/page_part.rb
+++ b/pages/app/models/refinery/page_part.rb
@@ -32,8 +32,8 @@ module Refinery
     protected
 
     def normalise_text_fields
-      if read_attribute(:body).present? && read_attribute(:body) !~ %r{^<}
-        write_attribute(:body, "<p>#{read_attribute(:body).gsub("\r\n\r\n", "</p><p>").gsub("\r\n", "<br/>")}</p>")
+      if body? && body !~ %r{^<}
+        self.body = "<p>#{body.gsub("\r\n\r\n", "</p><p>").gsub("\r\n", "<br/>")}</p>"
       end
     end
 

--- a/pages/app/models/refinery/page_part.rb
+++ b/pages/app/models/refinery/page_part.rb
@@ -12,8 +12,6 @@ module Refinery
     extend Mobility
     translates :body
 
-    attribute :body
-
     def to_param
       "page_part_#{slug.downcase.gsub(/\W/, '_')}"
     end

--- a/pages/app/models/refinery/page_part.rb
+++ b/pages/app/models/refinery/page_part.rb
@@ -9,6 +9,7 @@ module Refinery
     validates :slug, :presence => true, :uniqueness => {:scope => :refinery_page_id}
     alias_attribute :content, :body
 
+    extend Mobility
     translates :body
 
     attribute :body

--- a/pages/app/models/refinery/page_part.rb
+++ b/pages/app/models/refinery/page_part.rb
@@ -17,7 +17,7 @@ module Refinery
     end
 
     def body=(value)
-      write_attribute(:body, value)
+      super
 
       normalise_text_fields
     end

--- a/pages/app/views/refinery/admin/pages/_form.html.erb
+++ b/pages/app/views/refinery/admin/pages/_form.html.erb
@@ -3,7 +3,7 @@
 
   <%= render '/refinery/admin/error_messages', :object => @page, :include_object_name => true %>
 
-  <%= render '/refinery/admin/locale_picker', :current_locale => Globalize.locale %>
+  <%= render '/refinery/admin/locale_picker', :current_locale => Mobility.locale %>
 
   <div class="field">
     <%= f.label :title %>

--- a/pages/app/views/refinery/admin/pages_dialogs/_page_link.html.erb
+++ b/pages/app/views/refinery/admin/pages_dialogs/_page_link.html.erb
@@ -1,6 +1,6 @@
 <%
   link_args = defined?(link_to_arguments) ? link_to_arguments : {}
-  page_link_url = Globalize.with_locale(params[:switch_locale]) { refinery.url_for(page_link.url) }
+  page_link_url = Mobility.with_locale(params[:switch_locale]) { refinery.url_for(page_link.url) }
   # current_link is relative so check against the relative url portion before conditionally making it absolute
   linked = params[:current_link].present? && page_link_url == params[:current_link]
   page_link_url = "#{[request.protocol, request.host_with_port].join}#{page_link_url}" if Refinery::Pages.absolute_page_links

--- a/pages/db/migrate/20100913234708_create_refinerycms_pages_schema.rb
+++ b/pages/db/migrate/20100913234708_create_refinerycms_pages_schema.rb
@@ -49,7 +49,6 @@ class CreateRefinerycmsPagesSchema < ActiveRecord::Migration[4.2]
       t.timestamps null: false
     end
 
-    add_index :refinery_page_part_translations, :refinery_page_part_id, name: :index_refinery_pp_t10s_on_refinery_pp_id
     add_index :refinery_page_part_translations, :locale, name: :index_refinery_page_part_translations_on_locale
     add_index :refinery_page_part_translations, [:refinery_page_part_id, :locale], name: :index_93b7363baf444ecab114aab0bbdedc79d0ec4f4b, unique: true
 
@@ -67,7 +66,6 @@ class CreateRefinerycmsPagesSchema < ActiveRecord::Migration[4.2]
       t.timestamps null: false
     end
 
-    add_index :refinery_page_translations, :refinery_page_id, name: :index_refinery_page_translations_on_refinery_page_id
     add_index :refinery_page_translations, :locale, name: :index_refinery_page_translations_on_locale
     add_index :refinery_page_translations, [:refinery_page_id, :locale], name: :index_refinery_page_t10s_on_refinery_page_id_and_locale, unique: true
   end

--- a/pages/db/migrate/20100913234708_create_refinerycms_pages_schema.rb
+++ b/pages/db/migrate/20100913234708_create_refinerycms_pages_schema.rb
@@ -1,5 +1,5 @@
 class CreateRefinerycmsPagesSchema < ActiveRecord::Migration[4.2]
-  def up
+  def change
     create_table :refinery_page_parts do |t|
       t.integer  :refinery_page_id
       t.string   :title
@@ -38,38 +38,37 @@ class CreateRefinerycmsPagesSchema < ActiveRecord::Migration[4.2]
     add_index :refinery_pages, :parent_id
     add_index :refinery_pages, :rgt
 
-    begin
-      ::Refinery::PagePart.create_translation_table!({
-        :body => :text
-      })
-    rescue NameError
-      warn "Refinery::PagePart was not defined!"
+    create_table :refinery_page_part_translations do |t|
+
+      # Translated attribute(s)
+      t.text :body
+
+      t.string  :locale, null: false
+      t.integer :refinery_page_part_id, null: false
+
+      t.timestamps null: false
     end
 
-    begin
-      ::Refinery::Page.create_translation_table!({
-        :title => :string,
-        :custom_slug => :string,
-        :menu_title => :string,
-        :slug => :string
-      })
-    rescue NameError
-      warn "Refinery::Page was not defined!"
-    end
-  end
+    add_index :refinery_page_part_translations, :refinery_page_part_id, name: :index_refinery_pp_t10s_on_refinery_pp_id
+    add_index :refinery_page_part_translations, :locale, name: :index_refinery_page_part_translations_on_locale
+    add_index :refinery_page_part_translations, [:refinery_page_part_id, :locale], name: :index_93b7363baf444ecab114aab0bbdedc79d0ec4f4b, unique: true
 
-  def down
-    drop_table :refinery_page_parts
-    drop_table :refinery_pages
-    begin
-      ::Refinery::PagePart.drop_translation_table!
-    rescue NameError
-      warn "Refinery::PagePart was not defined!"
+    create_table :refinery_page_translations do |t|
+
+      # Translated attribute(s)
+      t.string :title
+      t.string :custom_slug
+      t.string :menu_title
+      t.string :slug
+
+      t.string  :locale, null: false
+      t.integer :refinery_page_id, null: false
+
+      t.timestamps null: false
     end
-    begin
-      ::Refinery::Page.drop_translation_table! if defined?(::Refinery::Page)
-    rescue NameError
-      warn "Refinery::Page was not defined!"
-    end
+
+    add_index :refinery_page_translations, :refinery_page_id, name: :index_refinery_page_translations_on_refinery_page_id
+    add_index :refinery_page_translations, :locale, name: :index_refinery_page_translations_on_locale
+    add_index :refinery_page_translations, [:refinery_page_id, :locale], name: :index_refinery_page_t10s_on_refinery_page_id_and_locale, unique: true
   end
 end

--- a/pages/lib/refinery/pages.rb
+++ b/pages/lib/refinery/pages.rb
@@ -1,5 +1,5 @@
 require 'refinerycms-core'
-require 'globalize'
+require 'mobility'
 
 module Refinery
   autoload :PagesGenerator, 'generators/refinery/pages/pages_generator'

--- a/pages/lib/refinery/pages/finder.rb
+++ b/pages/lib/refinery/pages/finder.rb
@@ -17,7 +17,7 @@ module Refinery
         FinderBySlug.new(slug, conditions).find
       end
 
-      def self.with_globalize(conditions = {})
+      def self.with_mobility(conditions = {})
         Finder.new(conditions).find
       end
 
@@ -26,15 +26,15 @@ module Refinery
       end
 
       def find
-        with_globalize
+        with_mobility
       end
 
-      def with_globalize
-        globalized_conditions = {:locale => ::Mobility.locale.to_s}.merge(conditions)
-        translations_conditions = translations_conditions(globalized_conditions)
+      def with_mobility
+        mobility_conditions = {:locale => ::Mobility.locale.to_s}.merge(conditions)
+        translations_conditions = translations_conditions(mobility_conditions)
 
         # A join implies readonly which we don't really want.
-        Page.where(globalized_conditions).
+        Page.where(mobility_conditions).
              joins(:translations).
              where(translations_conditions).
              readonly(false)

--- a/pages/lib/refinery/pages/finder.rb
+++ b/pages/lib/refinery/pages/finder.rb
@@ -31,12 +31,10 @@ module Refinery
 
       def with_mobility
         mobility_conditions = {:locale => ::Mobility.locale.to_s}.merge(conditions)
-        translations_conditions = translations_conditions(mobility_conditions)
 
         # A join implies readonly which we don't really want.
         Page.i18n.where(mobility_conditions).
              joins(:translations).
-             where(translations_conditions).
              readonly(false)
       end
 
@@ -46,17 +44,6 @@ module Refinery
       def translated_attributes
         Page.translated_attribute_names.map(&:to_s) | %w(locale)
       end
-
-      def translations_conditions(original_conditions)
-        translations_conditions = {}
-        original_conditions.keys.each do |key|
-          if translated_attributes.include? key.to_s
-            translations_conditions["#{Page::Translation.table_name}.#{key}"] = original_conditions.delete(key)
-          end
-        end
-        translations_conditions
-      end
-
     end
 
     class FinderByTitle < Finder

--- a/pages/lib/refinery/pages/finder.rb
+++ b/pages/lib/refinery/pages/finder.rb
@@ -34,7 +34,7 @@ module Refinery
         translations_conditions = translations_conditions(mobility_conditions)
 
         # A join implies readonly which we don't really want.
-        Page.where(mobility_conditions).
+        Page.i18n.where(mobility_conditions).
              joins(:translations).
              where(translations_conditions).
              readonly(false)

--- a/pages/lib/refinery/pages/finder.rb
+++ b/pages/lib/refinery/pages/finder.rb
@@ -30,7 +30,7 @@ module Refinery
       end
 
       def with_globalize
-        globalized_conditions = {:locale => ::Globalize.locale.to_s}.merge(conditions)
+        globalized_conditions = {:locale => ::Mobility.locale.to_s}.merge(conditions)
         translations_conditions = translations_conditions(globalized_conditions)
 
         # A join implies readonly which we don't really want.

--- a/pages/lib/refinery/pages/finder.rb
+++ b/pages/lib/refinery/pages/finder.rb
@@ -31,10 +31,12 @@ module Refinery
 
       def with_mobility
         mobility_conditions = {:locale => ::Mobility.locale.to_s}.merge(conditions)
+        translations_conditions = translations_conditions(mobility_conditions)
 
         # A join implies readonly which we don't really want.
         Page.i18n.where(mobility_conditions).
              joins(:translations).
+             where(translations_conditions).
              readonly(false)
       end
 
@@ -44,6 +46,17 @@ module Refinery
       def translated_attributes
         Page.translated_attribute_names.map(&:to_s) | %w(locale)
       end
+
+      def translations_conditions(original_conditions)
+        translations_conditions = {}
+        original_conditions.keys.each do |key|
+          if translated_attributes.include? key.to_s
+            translations_conditions["#{Page::Translation.table_name}.#{key}"] = original_conditions.delete(key)
+          end
+        end
+        translations_conditions
+      end
+
     end
 
     class FinderByTitle < Finder

--- a/pages/lib/refinery/pages/finder.rb
+++ b/pages/lib/refinery/pages/finder.rb
@@ -51,7 +51,7 @@ module Refinery
         translations_conditions = {}
         original_conditions.keys.each do |key|
           if translated_attributes.include? key.to_s
-            translations_conditions["#{Page.translation_class.table_name}.#{key}"] = original_conditions.delete(key)
+            translations_conditions["#{Page::Translation.table_name}.#{key}"] = original_conditions.delete(key)
           end
         end
         translations_conditions

--- a/pages/refinerycms-pages.gemspec
+++ b/pages/refinerycms-pages.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
   s.add_dependency 'friendly_id',                 ['>= 5.1.0', '< 5.3']
-  s.add_dependency 'mobility',                    '~> 0.5'
   s.add_dependency 'friendly_id-mobility',        '~> 0.5'
   s.add_dependency 'activemodel-serializers-xml', '~> 1.0', '>= 1.0.1'
   s.add_dependency 'awesome_nested_set',          '~> 3.1', '>= 3.1.0'

--- a/pages/refinerycms-pages.gemspec
+++ b/pages/refinerycms-pages.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |s|
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
   s.add_dependency 'friendly_id',                 ['>= 5.1.0', '< 5.3']
-  s.add_dependency 'globalize',                   ['>= 5.1.0.beta1', '< 5.2']
+  s.add_dependency 'mobility',                    '~> 0.5'
+  s.add_dependency 'friendly_id-mobility',        '~> 0.5'
   s.add_dependency 'activemodel-serializers-xml', '~> 1.0', '>= 1.0.1'
   s.add_dependency 'awesome_nested_set',          '~> 3.1', '>= 3.1.0'
   s.add_dependency 'seo_meta',                    '~> 3.0', '>= 3.0.0'

--- a/pages/refinerycms-pages.gemspec
+++ b/pages/refinerycms-pages.gemspec
@@ -19,13 +19,12 @@ Gem::Specification.new do |s|
   s.files             = `git ls-files`.split("\n")
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
+  s.add_dependency 'refinerycms-core',            version
   s.add_dependency 'friendly_id',                 ['>= 5.1.0', '< 5.3']
   s.add_dependency 'friendly_id-mobility',        '~> 0.5'
-  s.add_dependency 'activemodel-serializers-xml', '~> 1.0', '>= 1.0.1'
   s.add_dependency 'awesome_nested_set',          '~> 3.1', '>= 3.1.0'
   s.add_dependency 'seo_meta',                    '~> 3.0', '>= 3.0.0'
-  s.add_dependency 'refinerycms-core',            version
-  s.add_dependency 'babosa',                      '!= 0.3.6'
+  s.add_dependency 'babosa',                      '~> 1.0'
   s.add_dependency 'speakingurl-rails',           '~> 8.0', '>= 8.0.0'
   s.add_dependency 'diffy',                       '~> 3.1', '>= 3.1.0'
 

--- a/pages/spec/features/refinery/admin/pages_spec.rb
+++ b/pages/spec/features/refinery/admin/pages_spec.rb
@@ -451,13 +451,13 @@ module Refinery
           allow(Refinery::I18n).to receive(:frontend_locales).and_return([:en, :ru])
 
           # Create a home page in both locales (needed to test menus)
-          home_page = Globalize.with_locale(:en) do
+          home_page = Mobility.with_locale(:en) do
             Page.create :title => 'Home',
             :link_url => '/',
             :menu_match => "^/$"
           end
 
-          Globalize.with_locale(:ru) do
+          Mobility.with_locale(:ru) do
             home_page.title = 'Домашняя страница'
             home_page.save
           end
@@ -520,10 +520,10 @@ module Refinery
           let!(:news_page) do
             allow(Refinery::I18n).to receive(:frontend_locales).and_return([:en, :ru])
 
-            _page = Globalize.with_locale(:en) {
+            _page = Mobility.with_locale(:en) {
               Page.create :title => en_page_title
             }
-            Globalize.with_locale(:ru) do
+            Mobility.with_locale(:ru) do
               _page.title = ru_page_title
               _page.save
             end
@@ -599,7 +599,7 @@ module Refinery
 
         describe "add a page with title only for secondary locale", js:true do
           let(:ru_page) {
-            Globalize.with_locale(:ru) {
+            Mobility.with_locale(:ru) {
               Page.create :title => ru_page_title
             }
           }
@@ -670,7 +670,7 @@ module Refinery
             it 'succeeds' do
               ru_page.destroy!
               parent_page = Page.create(:title => "Parent page")
-              sub_page = Globalize.with_locale(:ru) {
+              sub_page = Mobility.with_locale(:ru) {
                 Page.create :title => ru_page_title, :parent_id => parent_page.id
               }
               expect(sub_page.parent).to eq(parent_page)
@@ -807,7 +807,7 @@ module Refinery
     end
 
     describe "TranslatePages", :type => :feature do
-      before { Globalize.locale = :en }
+      before { Mobility.locale = :en }
       refinery_login
 
       describe "a page with a single locale" do
@@ -833,11 +833,11 @@ module Refinery
           allow(Refinery::I18n).to receive(:frontend_locales).and_return [:en, :ru]
 
           # Create a page in both locales
-          about_page = Globalize.with_locale(:en) do
+          about_page = Mobility.with_locale(:en) do
             Page.create :title => 'About'
           end
 
-          Globalize.with_locale(:ru) do
+          Mobility.with_locale(:ru) do
             about_page.title = 'About Ru'
             about_page.save
           end

--- a/pages/spec/features/refinery/pages_spec.rb
+++ b/pages/spec/features/refinery/pages_spec.rb
@@ -425,7 +425,7 @@ module Refinery
         let(:nested_page_slug) { 'nested_page' }
 
         let!(:nested_page) do
-          Mobility.fallbacks = [:ru]
+          Mobility.new_fallbacks[:ru]
           _page = Mobility.with_locale(:en) {
             news_page.children.create :title => nested_page_title
           }

--- a/pages/spec/features/refinery/pages_spec.rb
+++ b/pages/spec/features/refinery/pages_spec.rb
@@ -8,7 +8,7 @@ module Refinery
     let(:draft_page) { Page.create :title => 'Draft', :draft => true }
     before do
       # Stub the menu pages we're expecting
-      ::I18n.default_locale = Globalize.locale = :en
+      ::I18n.default_locale = Mobility.locale = :en
       allow(Page).to receive(:fast_menu).and_return([home_page, about_page])
     end
 
@@ -370,8 +370,8 @@ module Refinery
       let(:ru_page_title) { 'Новости' }
       let(:ru_page_slug_encoded) { '%D0%BD%D0%BE%D0%B2%D0%BE%D1%81%D1%82%D0%B8' }
       let!(:news_page) do
-        @page = Globalize.with_locale(:en) { Page.create title: en_page_title }
-        Globalize.with_locale(:ru) do
+        @page = Mobility.with_locale(:en) { Page.create title: en_page_title }
+        Mobility.with_locale(:ru) do
           @page.title = ru_page_title
           @page.save
         end
@@ -425,12 +425,12 @@ module Refinery
         let(:nested_page_slug) { 'nested_page' }
 
         let!(:nested_page) do
-          Globalize.fallbacks = [:ru]
-          _page = Globalize.with_locale(:en) {
+          Mobility.fallbacks = [:ru]
+          _page = Mobility.with_locale(:en) {
             news_page.children.create :title => nested_page_title
           }
 
-          Globalize.with_locale(:ru) do
+          Mobility.with_locale(:ru) do
             _page.title = nested_page_title
             _page.save
           end

--- a/pages/spec/features/refinery/pages_spec.rb
+++ b/pages/spec/features/refinery/pages_spec.rb
@@ -425,7 +425,7 @@ module Refinery
         let(:nested_page_slug) { 'nested_page' }
 
         let!(:nested_page) do
-          Mobility.new_fallbacks[:ru]
+          ::I18n.fallbacks[:ru]
           _page = Mobility.with_locale(:en) {
             news_page.children.create :title => nested_page_title
           }

--- a/pages/spec/models/refinery/page_menu_spec.rb
+++ b/pages/spec/models/refinery/page_menu_spec.rb
@@ -42,7 +42,7 @@ module Refinery
 
       context "with #menu_title" do
         before do
-          page[:menu_title] = "Menu Title"
+          page.menu_title = "Menu Title"
         end
 
         it_should_behave_like "Refinery menu item hash"
@@ -54,7 +54,7 @@ module Refinery
 
       context "with #title" do
         before do
-          page[:title] = "Title"
+          page.title = "Title"
         end
 
         it_should_behave_like "Refinery menu item hash"

--- a/pages/spec/models/refinery/page_url_spec.rb
+++ b/pages/spec/models/refinery/page_url_spec.rb
@@ -105,7 +105,7 @@ module Refinery
 
       describe '#canonical' do
         let!(:default_canonical) {
-          Globalize.with_locale(Refinery::I18n.default_frontend_locale) {
+          Mobility.with_locale(Refinery::I18n.default_frontend_locale) {
             page.canonical
           }
         }
@@ -121,7 +121,7 @@ module Refinery
         specify "translated page returns its pages's canonical"  do
           allow(Refinery::I18n).to receive(:current_frontend_locale).and_return(:ru)
 
-          Globalize.with_locale(:ru) do
+          Mobility.with_locale(:ru) do
             page.title = ru_page_title
             page.save
 
@@ -133,7 +133,7 @@ module Refinery
 
       describe '#canonical_slug' do
         let!(:default_canonical_slug) {
-          Globalize.with_locale(Refinery::I18n.default_frontend_locale) {
+          Mobility.with_locale(Refinery::I18n.default_frontend_locale) {
             page.canonical_slug
           }
         }
@@ -148,7 +148,7 @@ module Refinery
         specify "translated page returns its page's canonical slug'" do
           allow(Refinery::I18n).to receive(:current_frontend_locale).and_return(:ru)
 
-          Globalize.with_locale(:ru) do
+          Mobility.with_locale(:ru) do
             page.title = ru_page_title
             page.save
 

--- a/resources/app/models/refinery/resource.rb
+++ b/resources/app/models/refinery/resource.rb
@@ -4,6 +4,7 @@ module Refinery
   class Resource < Refinery::Core::BaseModel
     include Resources::Validators
 
+    extend Mobility
     translates :resource_title
 
     attribute :resource_title

--- a/resources/app/models/refinery/resource.rb
+++ b/resources/app/models/refinery/resource.rb
@@ -7,8 +7,6 @@ module Refinery
     extend Mobility
     translates :resource_title
 
-    attribute :resource_title
-
     dragonfly_accessor :file, :app => :refinery_resources
 
     validates :file, :presence => true

--- a/resources/app/views/refinery/admin/resources/_form.html.erb
+++ b/resources/app/views/refinery/admin/resources/_form.html.erb
@@ -6,7 +6,7 @@
              :object => @resource,
              :include_object_name => false %>
 
-  <%= render '/refinery/admin/locale_picker', :current_locale => Globalize.locale if @resource.persisted? %>
+  <%= render '/refinery/admin/locale_picker', :current_locale => Mobility.locale if @resource.persisted? %>
 
   <div class="field" id="file">
     <span class='label_with_help'>

--- a/resources/db/migrate/20150430180959_add_translated_title_to_refinery_resources.rb
+++ b/resources/db/migrate/20150430180959_add_translated_title_to_refinery_resources.rb
@@ -1,11 +1,19 @@
 class AddTranslatedTitleToRefineryResources < ActiveRecord::Migration[4.2]
-  def self.up
-    Refinery::Resource.create_translation_table!({
-      resource_title: :string
-    })
-  end
+  def change
+    create_table :refinery_resource_translations do |t|
 
-  def self.down
-    Refinery::Resource.drop_translation_table!
+      # Translated attribute(s)
+      t.string :resource_title
+
+      t.string  :locale, null: false
+      t.integer :refinery_resource_id, null: false
+
+      t.timestamps null: false
+    end
+
+    add_index :refinery_resource_translations, :refinery_resource_id, name: :index_refinery_resource_translations_on_refinery_resource_id
+    add_index :refinery_resource_translations, :locale, name: :index_refinery_resource_translations_on_locale
+    add_index :refinery_resource_translations, [:refinery_resource_id, :locale], name: :index_35a57b749803d8437ea64c64da3fb2cb0fbf457a, unique: true
+
   end
 end

--- a/resources/db/migrate/20150430180959_add_translated_title_to_refinery_resources.rb
+++ b/resources/db/migrate/20150430180959_add_translated_title_to_refinery_resources.rb
@@ -11,9 +11,7 @@ class AddTranslatedTitleToRefineryResources < ActiveRecord::Migration[4.2]
       t.timestamps null: false
     end
 
-    add_index :refinery_resource_translations, :refinery_resource_id, name: :index_refinery_resource_translations_on_refinery_resource_id
     add_index :refinery_resource_translations, :locale, name: :index_refinery_resource_translations_on_locale
     add_index :refinery_resource_translations, [:refinery_resource_id, :locale], name: :index_35a57b749803d8437ea64c64da3fb2cb0fbf457a, unique: true
-
   end
 end

--- a/resources/lib/refinery/resources.rb
+++ b/resources/lib/refinery/resources.rb
@@ -24,5 +24,5 @@ module Refinery
 end
 
 ActiveSupport.on_load(:active_record) do
-  require 'globalize'
+  require 'mobility'
 end

--- a/resources/refinerycms-resources.gemspec
+++ b/resources/refinerycms-resources.gemspec
@@ -19,11 +19,8 @@ Gem::Specification.new do |s|
   s.files             = `git ls-files`.split("\n")
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
-  s.add_dependency 'acts_as_indexed',         '~> 0.8.0'
-  s.add_dependency 'dragonfly',               '~> 1.1', '>= 1.1.0'
-  s.add_dependency 'activemodel-serializers-xml', '~> 1.0', '>= 1.0.1'
-  s.add_dependency 'refinerycms-core',        version
-  s.add_dependency 'refinerycms-dragonfly',   '~> 1.0'
+  s.add_dependency 'refinerycms-core', version
+  s.add_dependency 'refinerycms-dragonfly', '~> 1.0'
 
   s.required_ruby_version = Refinery::Version.required_ruby_version
 

--- a/resources/refinerycms-resources.gemspec
+++ b/resources/refinerycms-resources.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'acts_as_indexed',         '~> 0.8.0'
   s.add_dependency 'dragonfly',               '~> 1.1', '>= 1.1.0'
-  s.add_dependency 'mobility',                    '~> 0.5'
   s.add_dependency 'activemodel-serializers-xml', '~> 1.0', '>= 1.0.1'
   s.add_dependency 'refinerycms-core',        version
   s.add_dependency 'refinerycms-dragonfly',   '~> 1.0'

--- a/resources/refinerycms-resources.gemspec
+++ b/resources/refinerycms-resources.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'acts_as_indexed',         '~> 0.8.0'
   s.add_dependency 'dragonfly',               '~> 1.1', '>= 1.1.0'
-  s.add_dependency 'globalize',               ['>= 5.1.0.beta1', '< 5.2']
+  s.add_dependency 'mobility',                    '~> 0.5'
   s.add_dependency 'activemodel-serializers-xml', '~> 1.0', '>= 1.0.1'
   s.add_dependency 'refinerycms-core',        version
   s.add_dependency 'refinerycms-dragonfly',   '~> 1.0'

--- a/resources/spec/features/refinery/admin/resources_spec.rb
+++ b/resources/spec/features/refinery/admin/resources_spec.rb
@@ -113,7 +113,7 @@ module Refinery
             click_button "Save"
 
             expect(page).to have_content("'Premier fichier' was successfully updated.")
-            expect(Resource.translation_class.count).to eq(1)
+            expect(Resource::Translation.count).to eq(1)
           end
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,7 +40,7 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 
   config.before(:each) do
-    ::I18n.default_locale = I18n.locale = Globalize.locale = :en
+    ::I18n.default_locale = I18n.locale = Mobility.locale = :en
   end
 
   unless ENV['FULL_BACKTRACE']


### PR DESCRIPTION
In order to translate our content we have been using a library called
Globalize.  This has worked really well for us up until now, however a
new library has been released called Mobility which seems like it would
work better for our case.

This commit switches us from Globalize to Mobility in conjunction with
the release of refinerycms-i18n version 5.0.0.

This PR is stable, it needs code review but we have a green build: 

Big thanks to @shioyama !

I will merge this PR after : 
* [x] code review
* [x] the release of `mobility` 0.6.0: https://github.com/shioyama/mobility/releases
* [x] decide if `mobility` should be a dependency of `refinerycms-i18n`
* [x] release a new version of `refinerycms-i18n`, we will probably bump to 5.0