### PR TITLE
Fix generation of second/subsequent resources in an extension

### DIFF
--- a/core/lib/generators/refinery/engine/engine_generator.rb
+++ b/core/lib/generators/refinery/engine/engine_generator.rb
@@ -43,5 +43,6 @@ module Refinery
     def in_frontend_directory?(file)
       file.to_s.include?('app') && file.to_s.scan(/admin|models|mailers/).empty?
     end
+
   end
 end

--- a/core/lib/generators/refinery/engine/templates/app/controllers/refinery/namespace/plural_name_controller.rb.erb
+++ b/core/lib/generators/refinery/engine/templates/app/controllers/refinery/namespace/plural_name_controller.rb.erb
@@ -26,7 +26,7 @@ module Refinery
       end
 
       def find_page
-        @page = ::Refinery::Page.where(:link_url => "/<%= plural_name %>").first
+        @page = ::Refinery::Page.where(link_url: "<%= index_route %>").first
       end
 
     end

--- a/core/lib/refinery/extension_generation.rb
+++ b/core/lib/refinery/extension_generation.rb
@@ -333,6 +333,14 @@ module Refinery
                              gsub('namespace', namespacing.underscore)
     end
 
+    def index_route
+      if namespacing.underscore == plural_name
+        '/' + plural_name
+      else
+        '/' + namespacing.underscore + '/' + plural_name
+      end
+    end
+
     def viable_templates
       @viable_templates ||= begin
         all_templates.reject(&method(:reject_template?)).inject({}) do |hash, path|
@@ -393,8 +401,10 @@ module Refinery
         end
       end
 
+      # merge_rb is only used for merging routes.rb
+      # Put destination lines first, so that extension namespaced routes precede the default extension route
       def merge_rb
-        (source_lines[0..-2] + destination_lines[1..-2] + [source_lines.last]).join "\n"
+        (destination_lines[0..-2] + source_lines[1..-2] + [destination_lines.last]).join "\n"
       end
 
       def merge_yaml


### PR DESCRIPTION
This PR changes the order of frontend routes generated when adding a second or subsequent route to an extension. See gitter discussion with jussihirvi on May 10.

The current routes generated by
```
generate refinery:engine place name:string
generate refinery:engine person  name:string --extension places --namespace places
```

are (with intervening lines removed)
```
  # Frontend routes
  namespace :places do
    resources :places, :path => '', :only => [:index, :show]
  end
  # Frontend routes
  namespace :places do
    resources :people, :only => [:index, :show]
  end
```

Trying to access  `/places/people` results in "Couldn't find Refinery::Places::Place with 'id'=people",  as routes are matched in the order defined.

With the changes the routes (with even more lines removed) become:

```
  namespace :places do
    resources :people, :only => [:index, :show]
    resources :places, :path => '', :only => [:index, :show]
  end
```




