### PR TITLE
Closes GH-3381

### DIFF
--- a/core/app/assets/javascripts/refinery/refinery.js.erb
+++ b/core/app/assets/javascripts/refinery/refinery.js.erb
@@ -1,9 +1,9 @@
 /*
  *= require jquery
  *= require jquery_ujs
- *= require jquery-ui/dialog
- *= require jquery-ui/sortable
- *= require jquery-ui/tabs
+ *= require jquery-ui/widgets/dialog
+ *= require jquery-ui/widgets/sortable
+ *= require jquery-ui/widgets/tabs
  *= require modernizr-min
  *= require jquery/jquery.html5-placeholder-shim
  *= require jquery/jquery.timers

--- a/core/refinerycms-core.gemspec
+++ b/core/refinerycms-core.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'font-awesome-sass',           '>= 4.3.0', '< 5.0'
   s.add_dependency 'coffee-rails',                ['~> 4.0', '>= 4.0.0']
   s.add_dependency 'jquery-rails',                '~> 4.3', '>= 4.3.1'
-  s.add_dependency 'jquery-ui-rails',             '~> 5.0', '>= 5.0.0'
+  s.add_dependency 'jquery-ui-rails',             '~> 6.0', '>= 6.0.0'
   s.add_dependency 'decorators',                  '~> 2.0', '>= 2.0.0'
   s.add_dependency 'zilch-authorisation',         '~> 0', '>= 0.0.1'
 


### PR DESCRIPTION
Upgraded `'jquery-ui-rails'` dependency from v5 to v6. This is required to be able to integrate Spree with Refinery.