### PR TITLE
Partial revert ae30517 : Remove layout def, we use render_with_templates? method

### DIFF
--- a/pages/app/controllers/refinery/pages/admin/preview_controller.rb
+++ b/pages/app/controllers/refinery/pages/admin/preview_controller.rb
@@ -10,6 +10,8 @@ module Refinery
 
         skip_before_action :error_404, :set_canonical
 
+        layout :layout
+
         def show
           render_with_templates?
         end
@@ -43,6 +45,10 @@ module Refinery
             :parent_id, :skip_to_first_child, :show_in_menu, :title, :view_template,
             :layout_template, :custom_slug, parts_attributes: [:id, :title, :slug, :body, :position]
           ]
+        end
+
+        def layout
+          'application'
         end
       end
     end


### PR DESCRIPTION
It was a bad idea, it breaks the preview layout.

render_with_templates? will use the default layout 'application' or the @page.layout_template