### PR TITLE
Fix page tree cache refresh on sub page changes

### DIFF
--- a/pages/app/views/refinery/admin/pages/_page.html.erb
+++ b/pages/app/views/refinery/admin/pages/_page.html.erb
@@ -48,6 +48,6 @@
   </div>
 
   <%= content_tag :ul, class: 'nested', data: { 'ajax-content': refinery.admin_children_pages_path(page.nested_url) } do %>
-    <%= render(partial: 'page', collection: page.children, cached: true) if Refinery::Pages.auto_expand_admin_tree %>
+    <%= render(partial: 'page', collection: page.children, cached: ->(child_page) { child_page.self_and_descendants }) if Refinery::Pages.auto_expand_admin_tree %>
   <% end %>
 </li>

--- a/pages/app/views/refinery/admin/pages/_sortable_list.html.erb
+++ b/pages/app/views/refinery/admin/pages/_sortable_list.html.erb
@@ -1,5 +1,5 @@
 <%= content_tag :ul, id: 'sortable_list' do %>
-  <%= render partial: 'page', collection: @pages.roots, cached: true %>
+  <%= render partial: 'page', collection: @pages.roots, cached: ->(child_page) { child_page.self_and_descendants } %>
 <% end %>
 
 <%= render '/refinery/admin/sortable_list', continue_reordering: !!local_assigns[:continue_reordering] %>

--- a/pages/app/views/refinery/admin/pages/children.html.erb
+++ b/pages/app/views/refinery/admin/pages/children.html.erb
@@ -1,1 +1,1 @@
-<%= render partial: 'page', collection: @page.children, cached: true %>
+<%= render partial: 'page', collection: @page.children, cached: ->(child_page) { child_page.self_and_descendants } %>

--- a/pages/spec/features/refinery/admin/pages_spec.rb
+++ b/pages/spec/features/refinery/admin/pages_spec.rb
@@ -128,6 +128,7 @@ module Refinery
           context "with auto expand option turned on" do
             before do
               allow(Refinery::Pages).to receive(:auto_expand_admin_tree).and_return(true)
+              Rails.cache.clear
 
               visit refinery.admin_pages_path
             end
@@ -135,6 +136,13 @@ module Refinery
             it "shows children" do
               expect(page).to have_content(team.title)
               expect(page).to have_content(locations.title)
+            end
+
+            it "refreshes the cache if sub_children change" do
+              expect(page).to have_content(location.title)
+              location.update(title: 'Las Vegas')
+              visit refinery.admin_pages_path
+              expect(page).to have_content(location.title)
             end
           end
         end


### PR DESCRIPTION
Hi,
it took me some hours to find and fix a problem that came in with admin page index collection caching (see https://github.com/refinery/refinerycms/commit/a1b6e8ac4831aef0747eb60223bf1e94df0ece19).
Problem was, that the page tree showed old pages if we changed a page title on a sub child of one of the children of a page.
The collection caching just checked the children of a page, but not if a child (or child of a child ...) was changed. So we ended with a wrong page tree.
I wrote a test and fixed the problem by including the descendants of a page into the caching decision.
Cheers!