### PR TITLE
Replace redirect_to :back with redirect_back for Rails 5.2

### DIFF
--- a/core/lib/refinery/crud.rb
+++ b/core/lib/refinery/crud.rb
@@ -181,7 +181,7 @@ module Refinery
                 if request.xhr?
                   render :partial => '/refinery/message'
                 else
-                  redirect_to :back
+                  redirect_back(fallback_location: { action: 'edit' })
                 end
               else
                 redirect_back_or_default redirect_url

--- a/images/app/controllers/refinery/admin/images_controller.rb
+++ b/images/app/controllers/refinery/admin/images_controller.rb
@@ -93,7 +93,7 @@ module Refinery
               if request.xhr?
                 render partial: '/refinery/message'
               else
-                redirect_to :back
+                redirect_back(fallback_location: { action: 'edit' })
               end
             else
               redirect_back_or_default refinery.admin_images_path

--- a/pages/app/controllers/refinery/admin/pages_controller.rb
+++ b/pages/app/controllers/refinery/admin/pages_controller.rb
@@ -35,7 +35,7 @@ module Refinery
                 render partial: 'save_and_continue_callback',
                        locals: save_and_continue_locals(@page)
               else
-                redirect_to :back
+                redirect_back(fallback_location: { action: 'edit' })
               end
             else
               redirect_back_or_default(refinery.admin_pages_path)


### PR DESCRIPTION
In Rails 5.0 redirect_to :back is deprecated in favour of redirect_back [Add `redirect_back` and deprecate `redirect_to :back`](https://github.com/rails/rails/pull/22506)