### PR TITLE
Make dragonfly-s3_data_store gem dependency optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,12 @@ script:
   - bin/rspec $EXTENSION/spec
 env:
   - DB=postgresql EXTENSION=core
+  - DB=postgresql EXTENSION=dragonfly
   - DB=postgresql EXTENSION=pages
   - DB=postgresql EXTENSION=images
   - DB=postgresql EXTENSION=resources
   - DB=mysql EXTENSION=core
+  - DB=mysql EXTENSION=dragonfly
   - DB=mysql EXTENSION=pages
   - DB=mysql EXTENSION=images
   - DB=mysql EXTENSION=resources

--- a/dragonfly/lib/refinery/dragonfly/configuration.rb
+++ b/dragonfly/lib/refinery/dragonfly/configuration.rb
@@ -57,7 +57,7 @@ module Refinery
     self.verify_urls = true
 
     # s3 Data Store Config
-
+    # When using s3 as data store, make sure to add the dragonfly-s3_data_store gem to your project
     self.s3_datastore = false
     self.s3_bucket_name = ENV['S3_BUCKET']
     self.s3_access_key_id = ENV['S3_KEY']
@@ -84,4 +84,3 @@ module Refinery
   end
 
 end
-

--- a/dragonfly/refinerycms-dragonfly.gemspec
+++ b/dragonfly/refinerycms-dragonfly.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
   s.add_dependency 'dragonfly', '~> 1.1'
-  s.add_dependency 'dragonfly-s3_data_store'
+  s.add_development_dependency 'dragonfly-s3_data_store'
   s.add_dependency 'refinerycms-core', ['~> 4.0', '>= 4.0.2']
 
   s.cert_chain  = [File.expand_path("../../certs/parndt.pem", __FILE__)]


### PR DESCRIPTION
Remove forced dependencies for AWS S3 support (which (probably) makes no sense in a lot of projects)

See #3411