### PR TITLE
change capybara and rails-controller-testing dependencies to minimal versions and fix factory bot deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ group :test do
   gem 'launchy'
   gem 'coveralls', require: false
   gem 'rspec-retry'
+  gem 'puma'
 end
 
 # Load local gems according to Refinery developer preference.

--- a/images/spec/factories/image.rb
+++ b/images/spec/factories/image.rb
@@ -1,13 +1,13 @@
 FactoryBot.define do
   factory :image, :class => ::Refinery::Image do
-    image Refinery.roots('refinery/images').join("spec/fixtures/beach.jpeg")
+    image { Refinery.roots('refinery/images').join("spec/fixtures/beach.jpeg") }
   end
 
   factory :alternate_image, :class => ::Refinery::Image do
-    image Refinery.roots('refinery/images').join("spec/fixtures/beach-alternate.jpeg")
+    image { Refinery.roots('refinery/images').join("spec/fixtures/beach-alternate.jpeg") }
   end
 
   factory :another_image, :class => ::Refinery::Image do
-    image Refinery.roots('refinery/images').join("spec/fixtures/fathead.png")
+    image { Refinery.roots('refinery/images').join("spec/fixtures/fathead.png") }
   end
 end

--- a/pages/spec/factories/page_parts.rb
+++ b/pages/spec/factories/page_parts.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :page_part, class: Refinery::PagePart do
-    title 'Body'
-    slug 'side_body'
+    title { 'Body' }
+    slug { 'side_body' }
   end
 end

--- a/resources/spec/factories/resource.rb
+++ b/resources/spec/factories/resource.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :resource, class: Refinery::Resource do
-    file Refinery.roots('refinery/resources').join('spec/fixtures/cape-town-tide-table.pdf')
+    file { Refinery.roots('refinery/resources').join('spec/fixtures/cape-town-tide-table.pdf') }
   end
 end

--- a/testing/refinerycms-testing.gemspec
+++ b/testing/refinerycms-testing.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'database_cleaner',        '~> 1.6'
   s.add_dependency 'factory_bot_rails',       '~> 4.8'
   s.add_dependency 'rspec-rails',             '~> 3.5'
-  s.add_dependency 'capybara',                '~> 2.18'
-  s.add_dependency 'rails-controller-testing', '~> 0.1.1'
+  s.add_dependency 'capybara',                '>= 2.18'
+  s.add_dependency 'rails-controller-testing', '>= 0.1.1'
 
   s.required_ruby_version = Refinery::Version.required_ruby_version
 


### PR DESCRIPTION
Hi there, 
we are using refinerycms in our project and tried to use refinerycms-testing. We got some problems with the development dependencies of the testing gem and our dev dependencies. So we tried to use new versions of the gems mentioned above and it just worked. So is ti possible to update the dev dependencies for refinerycms-testing?
Thanks,
Steve