### PR TITLE
Duplicate

### DIFF
--- a/core/app/assets/stylesheets/refinery/components/_icons.scss
+++ b/core/app/assets/stylesheets/refinery/components/_icons.scss
@@ -10,6 +10,7 @@
 .delete_section_icon  {@include icon('minus-circle', $icon_delete_colour);}
 
 .download_icon        {@include icon('download');}
+.duplicate_icon       {@include icon('copy');}
 .edit_email_icon      {@include icon('envelope-o');}
 .edit_icon            {@include icon('edit', $icon_edit_colour);}
 .email_icon           {@include icon('envelope-o');}

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -17,6 +17,8 @@ en:
       updated: '%{what} was successfully updated.'
       destroyed: '%{what} was successfully removed.'
       not_destroyed: '%{what} was not removed.'
+      duplicated: '%{what} was duplicated.'
+      duplicate_suffix: ' Copy'
     site_bar:
       log_out: Log out
       switch_to_your_website: Switch to your website

--- a/core/lib/refinery/crud.rb
+++ b/core/lib/refinery/crud.rb
@@ -59,7 +59,7 @@ module Refinery
           end
 
           prepend_before_action :find_#{singular_name},
-                                :only => [:update, :destroy, :edit, :show]
+                                :only => [:update, :destroy, :edit, :show, :duplicate]
           prepend_before_action :merge_position_into_params!, :only => :create
 
           def new
@@ -82,6 +82,17 @@ module Refinery
 
           def edit
             # object gets found by find_#{singular_name} function
+          end
+          
+          def duplicate
+            original = @#{singular_name}
+            @#{singular_name} = original.dup
+            @#{singular_name}.title << duplicate_suffix
+            render 'edit'
+          end
+
+          def duplicate_suffix
+            t('refinery.crudify.duplicate_suffix')
           end
 
           def update


### PR DESCRIPTION
This is a very short PR.

It puts in place the basic features needed to implement a **duplicate** action.

The default duplicate action is very naive - it copies the item and opens the copy to be edited.
There is no attempt to copy any associations apart from `:belongs_to`, which is held on the model.

_A full implementation of a duplicate action will need a more sophisticated duplicate method - it will depend on the model and the implementor. Although the example below,  using refinerycms-pages,  adds some more steps, a true duplicator for refinerycms-pages needs attention paid to translations and other associations added by refinery extensions. I don't think it is ready to be submitted as a PR yet. 

Each model will have different considerations - starting with whether it is appropriate to duplicate at all.
_

For an extension to implement the duplicate action it will need to 
* add a route to the action
* change index/model view to add a link for the action
* perhaps override the default `duplicate` method to extend the duplication to copy associations.

### To implement 'duplicate' in an extension
This is still a simple duplication. 
### Adding a route
```
# refinerycms/pages/config/routes/rb
...
namespace :admin, path: Refinery::Core.backend_route do
  get 'pages/*path/edit', to: 'pages#edit', as: 'edit_page'
  get 'pages/*path/duplicate', to: 'pages#duplicate', as: 'duplicate_page'
...
```

### Override the default duplicate action so page-parts are duplicated
```
# refinerycms/pages/app/controllers/refinery/admin/pages_controller.rb
module Refinery
  module Admin
    class PagesController < Refinery::AdminController
...
def duplicate
  original_page = @page
  @page = original_page.dup
  @page.title += ' copy'
  original_page.parts.each |page_part| do
      @page.parts << page_part.dup
   end
   @page.save
  render :edit
end
```

### add a link to the duplicate action in the admin/index
```
# refinerycms/pages/app/views/refinery/admin/pages/_page.html.erb
...
<%= action_icon(:duplicate, refinery.admin_duplicate_page_path(page.nested_url),  t('duplicate',   scope: 'refinery.admin.pages' ) ) %>
```
#### Note
The example duplicate action saves the page before sending it to be edited. Seems to work.

**Finally**, I tried to write a routing test but didn't manage to get it working. Help appreciated.
