### PR TITLE
Use collection caching for generation of page links (pages_dialogs) 

### DIFF
--- a/pages/app/views/refinery/admin/pages_dialogs/link_to.html.erb
+++ b/pages/app/views/refinery/admin/pages_dialogs/link_to.html.erb
@@ -27,7 +27,7 @@
       <div id="your_page_content" class="clearfix">
         <div id="pages_list" class="pages_list">
           <ul class="link_list">
-            <%= render :partial => 'page_link', :collection => @pages, :cached => 'true',
+            <%= render :partial => 'page_link', :collection => @pages, :cached => true,
                        :locals => {
                          :child => 0,
                          :link_to_arguments => {}

--- a/pages/app/views/refinery/admin/pages_dialogs/link_to.html.erb
+++ b/pages/app/views/refinery/admin/pages_dialogs/link_to.html.erb
@@ -27,7 +27,7 @@
       <div id="your_page_content" class="clearfix">
         <div id="pages_list" class="pages_list">
           <ul class="link_list">
-            <%= render :partial => 'page_link', :collection => @pages,
+            <%= render :partial => 'page_link', :collection => @pages, :cached => 'true',
                        :locals => {
                          :child => 0,
                          :link_to_arguments => {}


### PR DESCRIPTION
Using the link button in wymeditor scales poorly when you get many pages. It was okay in the beginning, but now my app has approx 700 pages (most of them in two languages), and loading the page_links partial takes 15 seconds or more in my application. (This is especially annoying since most of our links are external and thus the page_links aren't even necessary most of the time.) Since the partial seems to generate the page link list from scratch every time and uses the standard page model as collection to create the links, it's a prime candidate for collection caching (since invalidation is taken care of by the model). 

I've done some simple testing. Load time went from approx. 15 seconds to approx 1 second. I've created a new page and I've reordered pages. No stale content. Link list is significantly faster even when there are new entries. (After reordering it's quite slow on first load, but still faster than uncached.)

I've filed this PR to the 4-0-stable branch since that's the branch I use (because I use page-images, which is still on Globalize, so I can't go to master (also, I have a lot of Globalize-specific code in my app)). Please consider merging anyway, or if you want to merge this to master, please backport/cherry-pick this to the 4-0-stable branch as well if it's not too much trouble. Thanks!