### PR TITLE
Update Ruby versions for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,6 @@ notifications:
   webhooks:
     - https://webhooks.gitter.im/e/b5d48907cdc89864b874
 rvm:
-  - 2.6.1
-  - 2.5.3
-  - 2.4.5
+  - 2.6.5
+  - 2.5.7
+  - 2.4.8


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-4-8-released/
https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-5-7-released/
https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-6-5-released/