### PR TITLE
Fix the configuration for Dragonfly so you can use the before_s…

### DIFF
--- a/dragonfly/lib/refinery/dragonfly/dragonfly.rb
+++ b/dragonfly/lib/refinery/dragonfly/dragonfly.rb
@@ -32,7 +32,7 @@ module Refinery
 
           #  These options require a name and block
           define_url extension.dragonfly_define_url if extension.dragonfly_define_url.present?
-          before_serve extension.dragonfly_before_serve if extension.dragonfly_before_serve.present?
+          before_serve(&extension.dragonfly_before_serve) if extension.dragonfly_before_serve.present?
 
 
           # There can be more than one instance of each of these options.

--- a/dragonfly/refinerycms-dragonfly.gemspec
+++ b/dragonfly/refinerycms-dragonfly.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |s|
   s.platform          = Gem::Platform::RUBY
   s.name              = %q{refinerycms-dragonfly}
-  s.version           = '1.0.1'
+  s.version           = '1.0.2'
   s.summary           = %q{Dragonfly interface for Refinery CMS}
   s.description       = %q{Allows Refinery to use dragonfly for file storage and processing}
   s.email             = %q{anita@joli.com.au}

--- a/dragonfly/refinerycms-dragonfly.gemspec
+++ b/dragonfly/refinerycms-dragonfly.gemspec
@@ -1,10 +1,9 @@
 # Encoding: UTF-8
 
-
 Gem::Specification.new do |s|
   s.platform          = Gem::Platform::RUBY
   s.name              = %q{refinerycms-dragonfly}
-  s.version           = '1.0.0'
+  s.version           = '1.0.1'
   s.summary           = %q{Dragonfly interface for Refinery CMS}
   s.description       = %q{Allows Refinery to use dragonfly for file storage and processing}
   s.email             = %q{anita@joli.com.au}

--- a/resources/spec/lib/refinery/resources/engine_spec.rb
+++ b/resources/spec/lib/refinery/resources/engine_spec.rb
@@ -4,5 +4,17 @@ module Refinery
   describe Resources do
     it_has_behaviour 'Creates a dragonfly App:'
     it_has_behaviour 'adds the dragonfly app to the middleware stack'
+
+    it 'calls dragonfly#before_serve to set configuration' do
+      dummy_proc = -> (_job, _env) {}
+      expect_any_instance_of(::Dragonfly::Server).to(
+        receive(:before_serve) { |&block| expect(block).to be(dummy_proc) }
+      )
+      ::Refinery::Resources.configure do |config|
+        config.dragonfly_before_serve = dummy_proc
+      end
+
+      ::Refinery::Dragonfly.configure!(::Refinery::Resources)
+    end
   end
 end


### PR DESCRIPTION
This fixes an issue with setting the `Dragonfly` configuration for `before_serve`. It looked like before it was a simple attr_accessor, but since `before_serve` is more like a DSL it was expecting to be called with a block. This PR corrects that, and I'm able to confirm it works on my project.

The good news is this also solves another use case, serving private content. If you look at this Google Groups post from a few years ago, it appears my client isn't alone in wanting this feature. https://groups.google.com/forum/#!searchin/refinery-cms/dragonfly$20before_serve%7Csort:date/refinery-cms/lRBOsddSzHM/1tXNjzaHcBUJ