### PR TITLE
Dragonfly before serve

### DIFF
--- a/dragonfly/lib/refinery/dragonfly/dragonfly.rb
+++ b/dragonfly/lib/refinery/dragonfly/dragonfly.rb
@@ -32,7 +32,8 @@ module Refinery
 
           #  These options require a name and block
           define_url extension.dragonfly_define_url if extension.dragonfly_define_url.present?
-          before_serve extension.dragonfly_before_serve if extension.dragonfly_before_serve.present?
+
+          before_serve &extension.dragonfly_before_serve if extension.dragonfly_define_url.present?
 
 
           # There can be more than one instance of each of these options.


### PR DESCRIPTION
I think this will fix a problem reported in  the [refinery-cms google group.](https://groups.google.com/forum/#!topic/refinery-cms/lRBOsddSzHM).

Usage of dragonfly before_save option, from Refinery:

```Ruby
#config/initializers/refinery/dragonfly.rb

Refinery::Dragonfly.configure do |config|
...
  bar =  -> (job, env) {
    throw :halt, [403, {'Content-Type' => 'text/plain'}, ["You shall not pass"]]
  }
  config.before_serve = bar
...
end
```
