### PR TITLE
Fix `render file:` deprecation warning

### DIFF
--- a/core/lib/refinery/application_controller.rb
+++ b/core/lib/refinery/application_controller.rb
@@ -31,8 +31,7 @@ module Refinery
       # fallback to the default 404.html page.
       file = Rails.root.join 'public', '404.html'
       file = Refinery.roots('refinery/core').join('public', '404.html') unless file.exist?
-      render file: file.cleanpath.to_s.gsub(%r{#{file.extname}$}, ''),
-             layout: false, status: 404, format: :html
+      render file: file, format: :html, layout: false, status: 404
       return false
     end
 


### PR DESCRIPTION
DEPRECATION WARNING: render file: should be given the absolute path to a file

We were giving it an absolute path, but removing the `.html` so it was causing
a deprecation warning to be shown while running this code.