### PR TITLE
Remove call to URI.Encode for dragonfly.cache_store_root.

### DIFF
--- a/dragonfly/lib/refinery/dragonfly/dragonfly.rb
+++ b/dragonfly/lib/refinery/dragonfly/dragonfly.rb
@@ -81,8 +81,8 @@ module Refinery
           unless app.config.action_controller.perform_caching && app.config.action_dispatch.rack_cache
             app.config.middleware.insert 0, ::Rack::Cache, {
               verbose: extension.dragonfly_cache_log_level =='verbose',
-              metastore: URI.encode("file:#{extension.dragonfly_cache_store_root}/meta"), # URI encoded in case of spaces
-              entitystore: URI.encode("file:#{extension.dragonfly_cache_store_root}/body")
+              metastore: "file:#{extension.dragonfly_cache_store_root}/meta",
+              entitystore: "file:#{extension.dragonfly_cache_store_root}/body"
             }
           end
           app.config.middleware.insert_after ::Rack::Cache, ::Dragonfly::Middleware, extension.dragonfly_name


### PR DESCRIPTION
URI.Encode is deprecated.
The line is commented 
```
URI.encode("file:#{extension.dragonfly_cache_store_root}/meta"), # URI encoded in case of spaces
```

This variable being encoded is used as a file path and it  is not clear that encoding spaces is useful in this case.

