### PR TITLE
Refinery won't work with Rails 6.1 until 'routing-filter' is updated.…

### DIFF
--- a/core/refinerycms-core.gemspec
+++ b/core/refinerycms-core.gemspec
@@ -3,7 +3,7 @@
 require File.expand_path('../core/lib/refinery/version', __dir__)
 
 version = Refinery::Version.to_s
-rails_version = ['>= 6.0.0', '< 7']
+rails_version = ['>= 6.0.0', '<6.1.0']
 
 Gem::Specification.new do |s|
   s.platform          = Gem::Platform::RUBY


### PR DESCRIPTION
… Change comes from  PR https://github.com/rails/rails/pull/39534, which converts the route params array into an object.