### PR TITLE
Allow 'group_by_date' to group by 'created_at' or 'updated_at'

### DIFF
--- a/core/lib/refinery/admin/base_controller.rb
+++ b/core/lib/refinery/admin/base_controller.rb
@@ -40,11 +40,11 @@ module Refinery
         authorisation_manager.authenticate!
       end
 
-      def group_by_date(records)
+      def group_by_date(records, date_field = :created_at)
         new_records = []
 
         records.each do |record|
-          key = record.created_at.strftime("%Y-%m-%d")
+          key = record.send(date_field).strftime("%Y-%m-%d")
           record_group = new_records.map{ |r| r.last if r.first == key }.flatten.compact << record
           (new_records.delete_if { |i| i.first == key}) << [key, record_group]
         end

--- a/images/app/views/refinery/admin/images/_list_view.html.erb
+++ b/images/app/views/refinery/admin/images/_list_view.html.erb
@@ -1,6 +1,6 @@
 <div id= 'image_list' class="<%= ['clearfix', 'pagination_frame', pagination_css_class].compact.join(' ') %>">
-  <% group_by_date(@images).each do |container| %>
-    <% date_time = (image_group = container.last).first.created_at %>
+  <% group_by_date(@images, :updated_at).each do |container| %>
+    <% date_time = (image_group = container.last).first.updated_at %>
     <% date = Date.parse(date_time.to_s) %>
     <h3><%= l(date, format: :long ) %></h3>
     <ul class='images_list'>

--- a/resources/app/views/refinery/admin/resources/_resources.html.erb
+++ b/resources/app/views/refinery/admin/resources/_resources.html.erb
@@ -1,7 +1,7 @@
 <%= will_paginate @resources if Refinery::Admin::ResourcesController.pageable? %>
 <div class="<%= ['clearfix', 'pagination_frame', pagination_css_class].compact.join(' ') %>">
-  <% group_by_date(@resources).each do |container|
-       date = Date.parse((resource_group = container.last).first.created_at.to_s) %>
+  <% group_by_date(@resources, :updated_at).each do |container|
+       date = Date.parse((resource_group = container.last).first.updated_at.to_s) %>
     <h3><%= l(date, :format => :long ) %></h3>
     <ul>
       <%= render :partial => 'resource', :collection => resource_group %>


### PR DESCRIPTION
Refinery-images and Refinery-resources both use `order: "updated_at DESC",` in their admin controller.
However when presenting the resources/images they call `group_by_date` which uses `created_at` for its grouping and labelling.

The results _are_ grouped by date, but the dates are in no particular order

This PR adds an optional parameter to `group_by_date`, leaving the current default of `created_at` as the default.
<img width="300" alt="order_by_date before" src="https://user-images.githubusercontent.com/397118/116182780-6abda300-a74f-11eb-95fe-d4291df9d2f4.png">
<img width="300" alt="order_by_date after" src="https://user-images.githubusercontent.com/397118/116182784-6d1ffd00-a74f-11eb-9e87-862490b06cd2.png">

