### PR TITLE
Replace obsolete method URI.decode

### DIFF
--- a/pages/app/presenters/refinery/pages/menu_presenter.rb
+++ b/pages/app/presenters/refinery/pages/menu_presenter.rb
@@ -89,7 +89,7 @@ module Refinery
         url = find_url_for(item)
 
         # Now use all possible vectors to try to find a valid match
-        [path, URI.decode(path)].include?(url) || path == "/#{item.original_id}"
+        [path, CGI.unescape(path)].include?(url) || path == "/#{item.original_id}"
       end
 
       def menu_item_css(menu_item, index)


### PR DESCRIPTION
`URI.decode` calls `URI.unescape`, which has been removed in Ruby 2.7. 

This commit replaces `URI.decode` with `CGI.unescape`.