### PR TITLE
Update upload validation errors

### DIFF
--- a/images/app/controllers/refinery/admin/images_controller.rb
+++ b/images/app/controllers/refinery/admin/images_controller.rb
@@ -149,7 +149,7 @@ module Refinery
       protected
 
       def set_original_filename
-        i = ::Refinery::Image.find_by_id(params[:image_id])
+        i = ::Refinery::Image.find_by_id(params[:id])
         @original_filename = i
       rescue 
         # noop

--- a/images/app/controllers/refinery/admin/images_controller.rb
+++ b/images/app/controllers/refinery/admin/images_controller.rb
@@ -149,8 +149,7 @@ module Refinery
       protected
 
       def set_original_filename
-        i = ::Refinery::Image.find_by_id(params[:id])
-        @original_filename = i
+        @original_file = ::Refinery::Image.find_by_id(params[:id]).image_name
       rescue 
         # noop
       end

--- a/images/app/controllers/refinery/admin/images_controller.rb
+++ b/images/app/controllers/refinery/admin/images_controller.rb
@@ -80,6 +80,7 @@ module Refinery
       end
 
       def update
+        @original_filename = @image.image_name
         @image.attributes = image_params
         if @image.valid? && @image.save
           flash.notice = t('refinery.crudify.updated', what: "'#{@image.title}'")

--- a/images/app/controllers/refinery/admin/images_controller.rb
+++ b/images/app/controllers/refinery/admin/images_controller.rb
@@ -9,6 +9,7 @@ module Refinery
               conditions: 'parent_id IS NULL'
 
       before_action :change_list_mode_if_specified, :init_dialog
+      before_action :set_original_filename, only: [:edit, :update]
 
       def new
         @image = ::Refinery::Image.new if @image.nil?
@@ -80,7 +81,6 @@ module Refinery
       end
 
       def update
-        @original_filename = @image.image_name
         @image.attributes = image_params
         if @image.valid? && @image.save
           flash.notice = t('refinery.crudify.updated', what: "'#{@image.title}'")
@@ -147,6 +147,13 @@ module Refinery
       end
 
       protected
+
+      def set_original_filename
+        i = ::Refinery::Image.find_by_id(params[:image_id])
+        @original_filename = i
+      rescue 
+        # noop
+      end
 
       def init_dialog
         @app_dialog = params[:app_dialog].present?

--- a/images/app/views/refinery/admin/images/_form.html.erb
+++ b/images/app/views/refinery/admin/images/_form.html.erb
@@ -15,6 +15,9 @@
       </p>
       <p>
         <%= f.file_field :image %>
+        <% if @original_file || @image.image_name %>
+          <em><%= t('.expected_filename') %>: <%=@original_file || @image.image_name %></em>
+        <% end %>
       </p>
     <% else %>
       <% # we must only hint at multiple when it's a new record otherwise update fails. %>

--- a/images/app/views/refinery/admin/images/_form.html.erb
+++ b/images/app/views/refinery/admin/images/_form.html.erb
@@ -15,10 +15,12 @@
       </p>
       <p>
         <%= f.file_field :image %>
-        <% if @original_file || @image.image_name %>
-          <em><%= t('.expected_filename') %>: <%=@original_file || @image.image_name %></em>
-        <% end %>
       </p>
+      <% if @original_file %>
+        <p>
+          <em><%= t('.expected_filename') %>: <%=@original_file %></em>
+        </p>
+      <% end %>
     <% else %>
       <% # we must only hint at multiple when it's a new record otherwise update fails. %>
       <%= f.file_field :image, multiple: true %>

--- a/images/app/views/refinery/admin/images/_form.html.erb
+++ b/images/app/views/refinery/admin/images/_form.html.erb
@@ -63,6 +63,7 @@
 <% if action_name =~ /(edit)|(update)/ %>
   <div id="existing_image">
     <label><%= t('.current_image') %></label>
+    <% if @image.url %>
     <div id="original-image">
       <%= image_tag @image.url, id: 'crop',
                   data: { mime_type: @image.mime_type,
@@ -104,6 +105,7 @@
           <p id="no-crops-yet"><strong><%=t('.no_crops_yet')%></strong></p>
       <% end %>
     </section>
+    <% end %>
   </div>
 
   <% content_for :after_javascript_libraries do %>

--- a/images/config/locales/en.yml
+++ b/images/config/locales/en.yml
@@ -13,6 +13,7 @@ en:
         form:
           image: Image
           use_current_image: Use current image
+          expected_filename: File must be named 
           or: or
           replace_image: " replace it with this one..."
           current_image: Current Image

--- a/images/spec/support/shared_examples/image_editor.rb
+++ b/images/spec/support/shared_examples/image_editor.rb
@@ -1,3 +1,45 @@
 shared_examples 'edits an image' do
-  pending
+  before do
+    raise "please set let(:initial_path)" if initial_path.blank?
+    ensure_on(initial_path)
+  end
+
+  let(:uploading_a_good_image) {
+    ->{
+      first("#records li a.edit_icon").click
+      attach_file 'image_image', valid_image_path
+      fill_in  'image_image_title', with: 'Image With Dashes'
+      fill_in  'image_image_alt', with: "Alt description for image"
+      click_button ::I18n.t('save', scope: 'refinery.admin.form_actions')
+    }
+  }
+  let(:uploading_a_bad_image) {
+    ->{
+      first("#records li a.edit_icon").click
+      attach_file 'image_image', invalid_image_path
+      fill_in  'image_image_title', with: 'Image With Dashes'
+      fill_in  'image_image_alt', with: "Alt description for image"
+      click_button ::I18n.t('save', scope: 'refinery.admin.form_actions')
+    }
+  }
+
+  let(:valid_image_path) {Refinery.roots('refinery/images').join("spec/fixtures/beach.jpeg")}
+  let(:invalid_image_path) {Refinery.roots('refinery/images').join("spec/fixtures/beach-alternate.jpeg")}
+    
+  it 'allows replacing an image with another of the same name', :js => true do
+    expect(uploading_a_good_image).to_not change(Refinery::Image, :count)
+    expect(page).to have_content(::I18n.t('updated',
+      :scope => 'refinery.crudify',
+      :what => "'Image With Dashes'"
+    ))
+  end
+  it 'gracefully rejects replacing an image with another of a different name', :js => true do 
+    expect(uploading_a_bad_image).to_not change(Refinery::Image, :count)
+    expect(page).to have_content(::I18n.t('expected_filename',
+      :scope => 'refinery.admin.images.form'
+    ))
+    expect(page).to have_content(::I18n.t('different_file_name',
+      :scope => 'activerecord.errors.models.refinery/image'
+    ))
+  end
 end

--- a/images/spec/system/refinery/admin/images_spec.rb
+++ b/images/spec/system/refinery/admin/images_spec.rb
@@ -22,8 +22,8 @@ module Refinery
       it_has_behaviour 'indexes images'
       it_has_behaviour 'shows list and grid views'
       it_has_behaviour 'shows an image preview'
-      it_has_behaviour 'deletes an image'
       it_has_behaviour 'edits an image'
+      it_has_behaviour 'deletes an image'
       it_has_behaviour 'uploads images'
       it_has_behaviour 'translates an image'
     end
@@ -37,7 +37,6 @@ module Refinery
       it_has_behaviour 'shows an image preview'
       it_has_behaviour 'deletes an image'
       it_has_behaviour 'uploads images'
-      it_has_behaviour 'edits an image'
     end
   end
 


### PR DESCRIPTION
Refinery has existing validation criteria on editing an uploaded image to prevent the filename from changing, but there's an unhandled exception on the edit page preventing that validation error from being visible to the user. This change both advertises the expected filename to the user as well as prevents the exception from arising. 2 new tests to support.