### PR TITLE
Fixed deprecated error handling

### DIFF
--- a/core/app/views/refinery/admin/_error_messages.html.erb
+++ b/core/app/views/refinery/admin/_error_messages.html.erb
@@ -7,8 +7,8 @@
       <li><%= value %></li>
     <% end %>
   <% else %>
-    <% object.errors.each do |key, value| %>
-      <li><%= value %></li>
+    <% object.errors.each do |error| %>
+      <li><%= error.message %></li>
     <% end %>
   <% end %>
   </ul>

--- a/images/lib/refinery/images/validators/image_size_validator.rb
+++ b/images/lib/refinery/images/validators/image_size_validator.rb
@@ -7,9 +7,9 @@ module Refinery
           image = record.image
 
           if image.respond_to?(:length) && image.length > Images.max_image_size
-            record.errors[:image] << ::I18n.t('too_big',
-                                             :scope => 'activerecord.errors.models.refinery/image',
-                                             :size => Images.max_image_size)
+            record.errors.add(:image,  message: ::I18n.t('too_big',
+                                                  scope: 'activerecord.errors.models.refinery/image',
+                                                  size: Images.max_image_size))
           end
         end
 


### PR DESCRIPTION
 Enumerating ActiveModel::Errors as a hash has been deprecated
Calling errors.add to add errors to a record