### PR TITLE
Revert: "TEMP be sure we run against rails 6"

### DIFF
--- a/core/refinerycms-core.gemspec
+++ b/core/refinerycms-core.gemspec
@@ -3,7 +3,7 @@
 require File.expand_path('../core/lib/refinery/version', __dir__)
 
 version = Refinery::Version.to_s
-rails_version = ['>= 6.0.0', '< 7']
+rails_version = ['>= 5.2.0', '< 7']
 
 Gem::Specification.new do |s|
   s.platform          = Gem::Platform::RUBY


### PR DESCRIPTION
Reverted 1430e8fe59d3d6bd784d462aa63883ab45b62947 - "TEMP be sure we run against rails 6"
Seems like this shouldn't have been left in the code.
The main readme says `An open source content management system for Rails 5.1+`
So far as I can tell, refinery should support at least rails 5.2 and rails 6.X

If this is not a correct understanding, I would urge the readme to be updated appropriately.