### PR TITLE
Fix Zeitwerk conventions for `Refinery::Pages::Finder`

### DIFF
--- a/pages/lib/refinery/pages/finder.rb
+++ b/pages/lib/refinery/pages/finder.rb
@@ -57,123 +57,122 @@ module Refinery
         translations_conditions
       end
 
-    end
-
-    class FinderByTitle < Finder
-      def initialize(title)
-        @title = title
-        @conditions = default_conditions
-      end
-
-      def default_conditions
-        { :title => title }
-      end
-
-      private
-      attr_accessor :title
-    end
-
-    class FinderBySlug < Finder
-      def initialize(slug, conditions)
-        @slug = slug
-        @conditions = default_conditions.merge(conditions)
-      end
-
-      def default_conditions
-        {
-          :locale => Refinery::I18n.frontend_locales.map(&:to_s),
-          :slug => slug
-        }
-      end
-
-      private
-      attr_accessor :slug
-    end
-
-    class FinderByPath
-      def initialize(path)
-        @path = path
-      end
-
-      def find
-        if slugs_scoped_by_parent?
-          FinderByScopedPath.new(path).find
-        else
-          FinderByUnscopedPath.new(path).find
+      class FinderByTitle < Finder
+        def initialize(title)
+          @title = title
+          @conditions = default_conditions
         end
-      end
 
-      private
-      attr_accessor :path
-
-      def slugs_scoped_by_parent?
-        ::Refinery::Pages.scope_slug_by_parent
-      end
-
-      def by_slug(slug_path, conditions = {})
-        Finder.by_slug(slug_path, conditions)
-      end
-    end
-
-    class FinderByScopedPath < FinderByPath
-      def find
-        # With slugs scoped to the parent page we need to find a page by its full path.
-        # For example with about/example we would need to find 'about' and then its child
-        # called 'example' otherwise it may clash with another page called /example.
-        page = parent_page
-        while page && path_segments.any? do
-          page = next_page(page)
+        def default_conditions
+          { :title => title }
         end
-        page
+
+        private
+        attr_accessor :title
       end
 
-      private
-
-      def path_segments
-        @path_segments ||= path.split('/').select(&:present?)
-      end
-
-      def parent_page
-        parent_page_segment = path_segments.shift
-        if parent_page_segment.friendly_id?
-          by_slug(parent_page_segment, :parent_id => nil).first
-        else
-          Page.find(parent_page_segment)
+      class FinderBySlug < Finder
+        def initialize(slug, conditions)
+          @slug = slug
+          @conditions = default_conditions.merge(conditions)
         end
+
+        def default_conditions
+          {
+            :locale => Refinery::I18n.frontend_locales.map(&:to_s),
+            :slug => slug
+          }
+        end
+
+        private
+        attr_accessor :slug
       end
 
-      def next_page(page)
-        slug_or_id = path_segments.shift
-        page.children.by_slug(slug_or_id).first || page.children.find(slug_or_id)
-      end
-    end
+      class FinderByPath
+        def initialize(path)
+          @path = path
+        end
 
-    class FinderByUnscopedPath < FinderByPath
-      def find
-        by_slug(path).first
-      end
-    end
-
-    class FinderByPathOrId
-      def initialize(path, id)
-        @path = path
-        @id = id
-      end
-
-      def find
-        if path.present?
-          if path.friendly_id?
-            FinderByPath.new(path).find
+        def find
+          if slugs_scoped_by_parent?
+            FinderByScopedPath.new(path).find
           else
-            Page.friendly.find(path)
+            FinderByUnscopedPath.new(path).find
           end
-        elsif id.present?
-          Page.friendly.find(id)
+        end
+
+        private
+        attr_accessor :path
+
+        def slugs_scoped_by_parent?
+          ::Refinery::Pages.scope_slug_by_parent
+        end
+
+        def by_slug(slug_path, conditions = {})
+          Finder.by_slug(slug_path, conditions)
         end
       end
 
-      private
-      attr_accessor :id, :path
+      class FinderByScopedPath < FinderByPath
+        def find
+          # With slugs scoped to the parent page we need to find a page by its full path.
+          # For example with about/example we would need to find 'about' and then its child
+          # called 'example' otherwise it may clash with another page called /example.
+          page = parent_page
+          while page && path_segments.any? do
+            page = next_page(page)
+          end
+          page
+        end
+
+        private
+
+        def path_segments
+          @path_segments ||= path.split('/').select(&:present?)
+        end
+
+        def parent_page
+          parent_page_segment = path_segments.shift
+          if parent_page_segment.friendly_id?
+            by_slug(parent_page_segment, :parent_id => nil).first
+          else
+            Page.find(parent_page_segment)
+          end
+        end
+
+        def next_page(page)
+          slug_or_id = path_segments.shift
+          page.children.by_slug(slug_or_id).first || page.children.find(slug_or_id)
+        end
+      end
+
+      class FinderByUnscopedPath < FinderByPath
+        def find
+          by_slug(path).first
+        end
+      end
+
+      class FinderByPathOrId
+        def initialize(path, id)
+          @path = path
+          @id = id
+        end
+
+        def find
+          if path.present?
+            if path.friendly_id?
+              FinderByPath.new(path).find
+            else
+              Page.friendly.find(path)
+            end
+          elsif id.present?
+            Page.friendly.find(id)
+          end
+        end
+
+        private
+        attr_accessor :id, :path
+      end
     end
   end
 end


### PR DESCRIPTION
Regarding #3523

The issue stems from the definition of `Refinery::Pages::Finder` and its sibling classes (`Refinery::Pages::FinderByTitle` and so on). These are all defined beside each other in [`pages/lib/refinery/pages/finder.rb`](https://github.com/refinery/refinerycms/blob/aee49a603860bf7d5fdb1532b9add5f4e7f839f4/pages/lib/refinery/pages/finder.rb) which gets required in [`pages/app/models/refinery/page.rb`](https://github.com/refinery/refinerycms/blob/aee49a603860bf7d5fdb1532b9add5f4e7f839f4/pages/app/models/refinery/page.rb#L6).

When reloading, zeitwerk reloads the model, which in turn loads the finder again. But because the file is named `finder.rb`, only `Refinery::Pages::Finder` gets unloaded and reloaded again. All other classes stay loaded and would be patched by the reload. But because `Refinery::Pages::Finder` has been reloaded and initialized again, it got a new `object_id`, thus triggering the **`superclass mismatch`** error.

The solution, that fixed the error, was to move all sibling-classes of `Refinery::Pages::Finder` into it, making them children of `Refinery::Pages::Finder`. Because they are only called inside `Refinery::Pages::Finder` itself, this *should* not make problems.

I am not sure, if this is the best or most elegant solution, if it introduces side effects or if there are other parts of refinery, that suffer the same issues.