### PR TITLE
Specify case-sensitive uniqueness for page part slug (fix Rails 6 deprecation warning)

### DIFF
--- a/pages/app/models/refinery/page_part.rb
+++ b/pages/app/models/refinery/page_part.rb
@@ -6,7 +6,7 @@ module Refinery
     before_validation :set_default_slug
 
     validates :title, :presence => true
-    validates :slug, :presence => true, :uniqueness => {:scope => :refinery_page_id}
+    validates :slug, :presence => true, :uniqueness => {:scope => :refinery_page_id, :case_sensitive => true}
     alias_attribute :content, :body
 
     extend Mobility


### PR DESCRIPTION
Hi! We're seeing a deprecation warning for the uniqueness validator as of Rails 6. This pull request adjusts the validation in question to make it case sensitive, which was previously the default behaviour.

Here is the deprecation warning:

```
DEPRECATION WARNING: Uniqueness validator will no longer enforce case sensitive comparison in Rails 6.1. To continue case sensitive comparison on the :slug attribute in Refinery::PagePart model, pass `case_sensitive: true` option explicitly to the uniqueness validator.
```