### PR TITLE
Fix `sqlite3` gsub in `Refinery::CmsGenerator`

### DIFF
--- a/core/lib/generators/refinery/cms/cms_generator.rb
+++ b/core/lib/generators/refinery/cms/cms_generator.rb
@@ -62,8 +62,8 @@ module Refinery
     def append_gemfile!
       if destination_path.join('Gemfile').file? &&
          destination_path.join('Gemfile').read !~ %r{group :development, :test do\n.+?gem 'sqlite3'\nend}m
-        gsub_file 'Gemfile', %q{gem 'sqlite3'}, %q{group :development, :test do
-  gem 'sqlite3'
+        gsub_file 'Gemfile', /(gem\ ['|"]sqlite3['|"].*)$/, %q{group :development, :test do
+  \1
 end}  end
     end
 


### PR DESCRIPTION
I noticed when running `rails new -m https://www.refinerycms.com/t/edge`
that it was mangling the `Gemfile` when the `sqlite3` line looked like:

```ruby
  gem 'sqlite3', '~> 1.4'
```

Instead of the expected:

```ruby
  gem 'sqlite3'
```

Our `gsub_file` instruction now captures the entire line and inserts it
inside the `group :development, :test do` block.