### PR TITLE
Updated: rspec-rails from ~>4.0.0.beta2 to ~>6.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,8 +54,7 @@ group :test do
   gem 'falcon'
   gem 'falcon-capybara'
 
-  # TODO: Use beta source for Rails 6 support
-  gem 'rspec-rails', '~> 4.0.0.beta3'
+  gem 'rspec-rails', '~> 6.0.0'
 end
 
 # Load local gems according to Refinery developer preference.

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'concurrent-ruby', '= 1.3.4'
+
 path "./" do
   gem "refinerycms-core"
   gem "refinerycms-images"

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../spec/dummy/config/environment',  __FILE__)
+require ::File.expand_path("../spec/dummy/config/environment",  __FILE__)
 run Dummy::Application

--- a/core/app/views/refinery/admin/_error_messages.html.erb
+++ b/core/app/views/refinery/admin/_error_messages.html.erb
@@ -7,8 +7,8 @@
       <li><%= value %></li>
     <% end %>
   <% else %>
-    <% object.errors.each do |key, value| %>
-      <li><%= value %></li>
+    <% object.errors.each do |error| %>
+      <li><%= error.message %></li>
     <% end %>
   <% end %>
   </ul>

--- a/core/lib/generators/refinery/cms/cms_generator.rb
+++ b/core/lib/generators/refinery/cms/cms_generator.rb
@@ -19,13 +19,13 @@ module Refinery
                            :desc => "Skip over installing or running migrations."
 
     def generate
-      start_pretending?
+      saved_pretend = start_pretending?
 
       manage_roadblocks! unless self.options[:update]
 
       ensure_environments_are_sane!
 
-      stop_pretending?
+      stop_pretending? saved_pretend
 
       append_gemfile!
 
@@ -333,15 +333,16 @@ end
         new_options = self.options.dup
         new_options[:pretend] = true
         self.options = new_options
+        old_pretend
       end
     end
 
-    def stop_pretending?
+    def stop_pretending?(saved_pretend)
       # Stop pretending
       if destination_path == Refinery.root
         say_status :'-- finished pretending --', nil, :yellow
         new_options = self.options.dup
-        new_options[:pretend] = old_pretend
+        new_options[:pretend] = saved_pretend
         self.options = new_options
       end
     end

--- a/images/lib/refinery/images/validators/image_size_validator.rb
+++ b/images/lib/refinery/images/validators/image_size_validator.rb
@@ -7,9 +7,9 @@ module Refinery
           image = record.image
 
           if image.respond_to?(:length) && image.length > Images.max_image_size
-            record.errors[:image] << ::I18n.t('too_big',
-                                             :scope => 'activerecord.errors.models.refinery/image',
-                                             :size => Images.max_image_size)
+            record.errors.add :too_big, ::I18n.t('too_big',
+                                       scope: 'activerecord.errors.models.refinery/image',
+                                       size: Images.max_image_size)
           end
         end
 

--- a/images/spec/models/refinery/image_spec.rb
+++ b/images/spec/models/refinery/image_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'uri'
 
 module Refinery
-  describe Image, :type => :model do
+  describe Image, type: :model do
 
     let(:image)         { FactoryBot.build(:image) }
     let(:created_image) { FactoryBot.create(:image) }
@@ -37,7 +37,7 @@ module Refinery
         it "should contain an error message" do
           @image.valid?
           expect(@image.errors).not_to be_empty
-          expect(@image.errors[:image]).to eq(["Image should be smaller than #{Images.max_image_size} bytes in size"])
+          expect(@image.errors[:too_big]).to eq(["Image should be smaller than #{Images.max_image_size} bytes in size"])
         end
       end
 

--- a/images/spec/support/shared_examples/image_deleter.rb
+++ b/images/spec/support/shared_examples/image_deleter.rb
@@ -5,10 +5,8 @@ shared_examples_for 'deletes an image' do
   end
 
   let(:image_count) {[Refinery::Image.count, Refinery::Images.pages_per_admin_index].min}
-  let(:deleting_an_image) {
-    -> {
-      first("#records li").click_link(::I18n.t('delete', scope: 'refinery.admin.images'))
-    }
+  let(:deleting_an_image)  {
+    first("#records li").click_link(::I18n.t('delete', scope: 'refinery.admin.images'))
   }
 
   it 'has a delete image link for each image' do
@@ -16,7 +14,7 @@ shared_examples_for 'deletes an image' do
   end
 
   it "removes an image" do
-    expect(deleting_an_image).to change(Refinery::Image, :count).by(-1)
+    expect{ deleting_an_image }.to change(Refinery::Image, :count).by(-1)
   end
 
   it 'says the image has been removed' do

--- a/images/spec/support/shared_examples/image_uploader.rb
+++ b/images/spec/support/shared_examples/image_uploader.rb
@@ -6,7 +6,6 @@ shared_examples 'uploads images' do
   end
 
   let(:uploading_an_image) {
-  ->{
     open_upload_dialog
     page.within_frame(dialog_frame_id) do
       select_upload
@@ -15,20 +14,19 @@ shared_examples 'uploads images' do
       fill_in  'image_image_alt', with: "Alt description for image"
       click_button ::I18n.t('save', scope: 'refinery.admin.form_actions')
     end
-    }
   }
 
   context 'when the image type is acceptable' do
     let(:image_path) {Refinery.roots('refinery/images').join("spec/fixtures/image-with-dashes.jpg")}
     it 'the image is uploaded', :js => true do
-      expect(uploading_an_image).to change(Refinery::Image, :count).by(1)
+      expect { uploading_an_image }.to change(Refinery::Image, :count).by(1)
     end
   end
 
   context 'when the image type is not acceptable' do
     let(:image_path) {Refinery.roots('refinery/images').join("spec/fixtures/cape-town-tide-table.pdf")}
     it 'the image is rejected', :js => true do
-      expect(uploading_an_image).to_not change(Refinery::Image, :count)
+      expect { uploading_an_image }.to_not change(Refinery::Image, :count)
       page.within_frame(dialog_frame_id) do
         expect(page).to have_content(::I18n.t('incorrect_format',
                                               :scope => 'activerecord.errors.models.refinery/image',

--- a/images/spec/support/spec_helper.rb
+++ b/images/spec/support/spec_helper.rb
@@ -13,7 +13,3 @@ end
 def ensure_on(path)
   visit(path) unless current_path == path
 end
-
-RSpec.configure do |c|
-  c.alias_it_should_behave_like_to :it_has_behaviour, 'has behaviour:'
-end

--- a/resources/lib/refinery/resources/validators/file_size_validator.rb
+++ b/resources/lib/refinery/resources/validators/file_size_validator.rb
@@ -7,9 +7,9 @@ module Refinery
           file = record.file
 
           if file.respond_to?(:length) && file.length > Resources.max_file_size
-            record.errors[:file] << ::I18n.t('too_big',
-                                             :scope => 'activerecord.errors.models.refinery/resource',
-                                             :size => Resources.max_file_size)
+            record.errors.add  :too_big, ::I18n.t('too_big',
+                                        scope: 'activerecord.errors.models.refinery/resource',
+                                        size: Resources.max_file_size)
           end
         end
 

--- a/resources/spec/models/refinery/resource_spec.rb
+++ b/resources/spec/models/refinery/resource_spec.rb
@@ -157,10 +157,10 @@ module Refinery
         it 'should contain an error message' do
           @resource.valid?
           expect(@resource.errors).not_to be_empty
-          expect(@resource.errors[:file]).to eq(Array(::I18n.t(
+          expect(@resource.errors[:too_big]).to eq([::I18n.t(
                                                         'too_big', scope: 'activerecord.errors.models.refinery/resource',
                                                                    size: Resources.max_file_size
-                                                      )))
+                                                      )])
         end
       end
 

--- a/resources/spec/system/refinery/admin/resources_spec.rb
+++ b/resources/spec/system/refinery/admin/resources_spec.rb
@@ -22,16 +22,14 @@ module Refinery
 
       context 'new/create' do
         let(:uploading_a_file) do
-          lambda do
-            visit refinery.admin_resources_path
-            find('a', text: 'Upload new file').click
+          visit refinery.admin_resources_path
+          find('a', text: 'Upload new file').click
 
-            expect(page).to have_selector 'iframe#dialog_iframe'
+          expect(page).to have_selector 'iframe#dialog_iframe'
 
-            page.within_frame('dialog_iframe') do
-              attach_file 'resource_file', file_path
-              click_button ::I18n.t('save', scope: 'refinery.admin.form_actions')
-            end
+          page.within_frame('dialog_iframe') do
+            attach_file 'resource_file', file_path
+            click_button ::I18n.t('save', scope: 'refinery.admin.form_actions')
           end
         end
 
@@ -39,7 +37,7 @@ module Refinery
           let(:file_path) { Refinery.roots('refinery/resources').join('spec/fixtures/cape-town-tide-table.pdf') }
 
           it 'the file is uploaded', js: true do
-            expect(uploading_a_file).to change(Refinery::Resource, :count).by(1)
+            expect { uploading_a_file }.to change(Refinery::Resource, :count).by(1)
           end
         end
 
@@ -47,7 +45,7 @@ module Refinery
           let(:file_path) { Refinery.roots('refinery/resources').join('spec/fixtures/refinery_is_secure.html') }
 
           it 'the file is rejected', js: true do
-            expect(uploading_a_file).to_not change(Refinery::Resource, :count)
+            expect { uploading_a_file }.to_not change(Refinery::Resource, :count)
 
             page.within_frame('dialog_iframe') do
               expect(page).to have_content(::I18n.t('incorrect_format', scope: 'activerecord.errors.models.refinery/resource'))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -74,6 +74,12 @@ RSpec.configure do |config|
 
   # Store last errors so we can run rspec with --only-failures
   config.example_status_persistence_file_path = ".rspec_failures"
+
+  # it_has_behaviour alias is used in several gems.
+  config.alias_it_should_behave_like_to :it_has_behaviour, 'has behaviour:'
+
+  # for use when chasing deprecations
+  # config.raise_errors_for_deprecations!
 end
 
 # Requires supporting files with custom matchers and macros, etc,

--- a/testing/refinerycms-testing.gemspec
+++ b/testing/refinerycms-testing.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'factory_bot_rails',       '~> 4.8'
   s.add_dependency 'rails-controller-testing', '>= 0.1.1'
   s.add_dependency 'refinerycms-core', version
-  s.add_dependency 'rspec-rails', '~> 4.0.0.beta2'
+  s.add_dependency 'rspec-rails', '~> 6.0.0'
   s.add_dependency 'webdrivers', '~> 4.0'
 
   s.required_ruby_version = Refinery::Version.required_ruby_version

--- a/testing/refinerycms-testing.gemspec
+++ b/testing/refinerycms-testing.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails-controller-testing', '>= 0.1.1'
   s.add_dependency 'refinerycms-core', version
   s.add_dependency 'rspec-rails', '~> 6.0.0'
-  s.add_dependency 'webdrivers', '~> 4.0'
+  s.add_dependency 'webdrivers', '~> 5.3'
 
   s.required_ruby_version = Refinery::Version.required_ruby_version
 

--- a/testing/refinerycms-testing.gemspec
+++ b/testing/refinerycms-testing.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails-controller-testing', '>= 0.1.1'
   s.add_dependency 'refinerycms-core', version
   s.add_dependency 'rspec-rails', '~> 6.0'
-  s.add_dependency 'selenium-webdriver', '>= 2.46.0'
+  s.add_dependency 'webdrivers', '~> 4.0'
 
   s.required_ruby_version = Refinery::Version.required_ruby_version
 

--- a/testing/refinerycms-testing.gemspec
+++ b/testing/refinerycms-testing.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'factory_bot_rails',       '~> 4.8'
   s.add_dependency 'rails-controller-testing', '>= 0.1.1'
   s.add_dependency 'refinerycms-core', version
-  s.add_dependency 'rspec-rails', '~> 6.0.0'
-  s.add_dependency 'webdrivers', '~> 5.3'
+  s.add_dependency 'rspec-rails', '~> 6.0'
+  s.add_dependency 'selenium-webdriver', '>= 2.46.0'
 
   s.required_ruby_version = Refinery::Version.required_ruby_version
 


### PR DESCRIPTION
Moved :it_has_behaviour alias to refinery's spec_helper, as it was being called from both images/spec and resources/spec.

Deprecate no more:
Handling errors as objects now - when adding them (for image/resource validation), and when presenting them. 

"The implicit block expectation syntax is deprecated" from refinery/images and refinery/resources. 
Added explicit block {} at expects where required, and de-lambda-ed the blocks being called.